### PR TITLE
refactor: unified DriverProtocol + GUI-driver automation

### DIFF
--- a/src/sim/driver.py
+++ b/src/sim/driver.py
@@ -115,3 +115,35 @@ class DriverProtocol(Protocol):
         protocol stays runtime_checkable for partial migrations.
         """
         ...
+
+    # -- Session lifecycle (optional) ----------------------------------------
+    # Drivers that support persistent sessions (connect/exec/disconnect)
+    # must set supports_session = True and implement launch/run/disconnect.
+
+    @property
+    def supports_session(self) -> bool:
+        """Whether this driver supports persistent sessions."""
+        ...
+
+    def launch(self, **kwargs) -> dict:
+        """Start a persistent solver session.
+
+        Returns dict with at minimum ``{"ok": True, "session_id": "..."}``.
+        Accepts keyword arguments from the connect request; each driver
+        picks what it needs and ignores the rest.
+        """
+        ...
+
+    def run(self, code: str, label: str = "") -> dict:
+        """Execute code in the active session.
+
+        Returns dict with at minimum ``{"ok": bool}``.
+        """
+        ...
+
+    def disconnect(self) -> dict:
+        """Tear down the active session. Must be idempotent.
+
+        Returns ``{"ok": True, "disconnected": True}``.
+        """
+        ...

--- a/src/sim/drivers/ansa/driver.py
+++ b/src/sim/drivers/ansa/driver.py
@@ -133,6 +133,10 @@ class AnsaDriver:
     def name(self) -> str:
         return "ansa"
 
+    @property
+    def supports_session(self) -> bool:
+        return True
+
     # -- DriverProtocol -------------------------------------------------------
 
     def detect(self, script: Path) -> bool:
@@ -463,7 +467,7 @@ class AnsaDriver:
             self._runtime = AnsaRuntime()
         return self._runtime
 
-    def launch(self, port: int | None = None, ui_mode: str = "gui") -> dict:
+    def launch(self, port: int | None = None, ui_mode: str = "gui", **kwargs) -> dict:
         """Start ANSA in listener mode and establish IAP connection.
 
         Args:
@@ -493,10 +497,11 @@ class AnsaDriver:
         record = rt.exec_file(filepath, label=label)
         return record.to_run_result()
 
-    def disconnect(self, keep_listening: bool = False) -> None:
+    def disconnect(self, keep_listening: bool = False) -> dict:
         """Terminate the IAP connection and optionally shut down ANSA."""
         if self._runtime is not None:
             self._runtime.disconnect(keep_listening=keep_listening)
+        return {"ok": True, "disconnected": True}
 
     @property
     def is_connected(self) -> bool:

--- a/src/sim/drivers/comsol/driver.py
+++ b/src/sim/drivers/comsol/driver.py
@@ -255,6 +255,10 @@ class ComsolDriver:
     def name(self) -> str:
         return "comsol"
 
+    @property
+    def supports_session(self) -> bool:
+        return False
+
     def detect(self, script: Path) -> bool:
         """Detect COMSOL/MPh scripts via `import mph`."""
         text = script.read_text(encoding="utf-8")

--- a/src/sim/drivers/flotherm/_win32_backend.py
+++ b/src/sim/drivers/flotherm/_win32_backend.py
@@ -15,123 +15,206 @@ user32 = ctypes.windll.user32
 WM_SETTEXT = 0x000C
 BM_CLICK = 0x00F5
 WM_COMMAND = 0x0111
-WM_KEYDOWN = 0x0100
-WM_KEYUP = 0x0101
-VK_RETURN = 0x0D
+MF_BYPOSITION = 0x0400
+MF_BYCOMMAND = 0x0000
+MIIM_ID = 0x00000002
+MIIM_SUBMENU = 0x00000004
+MIIM_STRING = 0x00000040
 
 
-def find_flotherm_window(timeout: float = 10) -> int:
-    """Find the FloMainWindow handle."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        hwnd = user32.FindWindowW(None, None)
-        while hwnd:
-            buf = ctypes.create_unicode_buffer(256)
-            user32.GetClassNameW(hwnd, buf, 256)
-            if "FloMainWindow" in buf.value:
-                return hwnd
-            hwnd = user32.FindWindowExW(None, hwnd, None, None)
-        # Try by window title containing "Flotherm"
-        hwnd = user32.FindWindowW(None, None)
-        while hwnd:
-            buf = ctypes.create_unicode_buffer(256)
-            user32.GetWindowTextW(hwnd, buf, 256)
-            if "Flotherm" in buf.value or "FloTHERM" in buf.value:
-                if user32.IsWindowVisible(hwnd):
-                    return hwnd
-            hwnd = user32.FindWindowExW(None, hwnd, None, None)
-        time.sleep(0.5)
-    raise RuntimeError("FloMainWindow not found")
+class MENUITEMINFOW(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", ctypes.wintypes.UINT),
+        ("fMask", ctypes.wintypes.UINT),
+        ("fType", ctypes.wintypes.UINT),
+        ("fState", ctypes.wintypes.UINT),
+        ("wID", ctypes.wintypes.UINT),
+        ("hSubMenu", ctypes.wintypes.HMENU),
+        ("hbmpChecked", ctypes.wintypes.HBITMAP),
+        ("hbmpUnchecked", ctypes.wintypes.HBITMAP),
+        ("dwItemData", ctypes.POINTER(ctypes.wintypes.ULONG)),
+        ("dwTypeData", ctypes.wintypes.LPWSTR),
+        ("cch", ctypes.wintypes.UINT),
+        ("hbmpItem", ctypes.wintypes.HBITMAP),
+    ]
 
 
-def _enum_windows_callback_factory(results: list):
-    """Create a callback for EnumWindows."""
+def _enum_windows() -> list[int]:
+    """Enumerate all top-level windows."""
+    results = []
     @ctypes.WINFUNCTYPE(ctypes.wintypes.BOOL, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
     def callback(hwnd, lparam):
         results.append(hwnd)
         return True
-    return callback
+    user32.EnumWindows(callback, 0)
+    return results
+
+
+def _get_window_text(hwnd: int) -> str:
+    buf = ctypes.create_unicode_buffer(512)
+    user32.GetWindowTextW(hwnd, buf, 512)
+    return buf.value
+
+
+def _get_class_name(hwnd: int) -> str:
+    buf = ctypes.create_unicode_buffer(256)
+    user32.GetClassNameW(hwnd, buf, 256)
+    return buf.value
+
+
+def find_flotherm_window(timeout: float = 10) -> int:
+    """Find the Flotherm main window handle."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for hwnd in _enum_windows():
+            if not user32.IsWindowVisible(hwnd):
+                continue
+            title = _get_window_text(hwnd)
+            if "Simcenter Flotherm" in title or "FloTHERM" in title:
+                return hwnd
+        time.sleep(0.5)
+    raise RuntimeError("Flotherm window not found")
 
 
 def find_dialog(title_substring: str, timeout: float = 10) -> int:
     """Find a dialog window by title substring."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        results = []
-        cb = _enum_windows_callback_factory(results)
-        user32.EnumWindows(cb, 0)
-        for hwnd in results:
+        for hwnd in _enum_windows():
             if not user32.IsWindowVisible(hwnd):
                 continue
-            buf = ctypes.create_unicode_buffer(256)
-            user32.GetWindowTextW(hwnd, buf, 256)
-            if title_substring.lower() in buf.value.lower():
+            title = _get_window_text(hwnd)
+            if title_substring.lower() in title.lower():
                 return hwnd
         time.sleep(0.3)
     raise RuntimeError(f"Dialog '{title_substring}' not found within {timeout}s")
 
 
+def _get_menu_item_text(hmenu: int, index: int) -> str:
+    """Get menu item text by position."""
+    buf = ctypes.create_unicode_buffer(256)
+    mii = MENUITEMINFOW()
+    mii.cbSize = ctypes.sizeof(MENUITEMINFOW)
+    mii.fMask = MIIM_STRING
+    mii.dwTypeData = buf
+    mii.cch = 256
+    user32.GetMenuItemInfoW(hmenu, index, True, ctypes.byref(mii))
+    return buf.value
+
+
+def _find_menu_item(hmenu: int, text_substring: str) -> tuple[int, int] | None:
+    """Find menu item by text. Returns (position, command_id) or None."""
+    count = user32.GetMenuItemCount(hmenu)
+    for i in range(count):
+        label = _get_menu_item_text(hmenu, i)
+        if text_substring.lower() in label.lower().replace("&", ""):
+            # Get the command ID
+            mii = MENUITEMINFOW()
+            mii.cbSize = ctypes.sizeof(MENUITEMINFOW)
+            mii.fMask = MIIM_ID | MIIM_SUBMENU
+            user32.GetMenuItemInfoW(hmenu, i, True, ctypes.byref(mii))
+            return (i, mii.wID)
+    return None
+
+
+def _find_submenu(hmenu: int, text_substring: str) -> int | None:
+    """Find a submenu by text. Returns submenu handle or None."""
+    count = user32.GetMenuItemCount(hmenu)
+    for i in range(count):
+        label = _get_menu_item_text(hmenu, i)
+        if text_substring.lower() in label.lower().replace("&", ""):
+            sub = user32.GetSubMenu(hmenu, i)
+            if sub:
+                return sub
+    return None
+
+
+def _dump_menu(hmenu: int, label: str = "menu") -> list[str]:
+    """Debug: dump all menu item labels."""
+    items = []
+    count = user32.GetMenuItemCount(hmenu)
+    for i in range(count):
+        text = _get_menu_item_text(hmenu, i)
+        items.append(text or f"(separator at {i})")
+    return items
+
+
 def play_floscript(script_path: str, timeout: float = 15) -> dict:
     """Trigger Macro > Play FloSCRIPT and feed it the script path.
 
-    Steps:
-    1. Find Flotherm main window
-    2. Send Alt+M (Macro menu) then P (Play FloSCRIPT)
-    3. Wait for file dialog
-    4. Set filename and click Open
+    Uses Win32 menu API (WM_COMMAND) instead of keyboard — works from
+    any process context as long as we're in the same desktop session.
     """
-    import subprocess as sp
-
     # Step 1: Find main window
     hwnd = find_flotherm_window(timeout=10)
-    user32.SetForegroundWindow(hwnd)
-    time.sleep(0.5)
 
-    # Step 2: Use keyboard to open Macro > Play FloSCRIPT
-    # Alt key
-    VK_MENU = 0x12
-    VK_M = 0x4D  # 'M' for Macro
-    VK_P = 0x50  # 'P' for Play
+    # Step 2: Get menu bar and find Macro submenu
+    hmenu = user32.GetMenu(hwnd)
+    if not hmenu:
+        return {"ok": False, "error": "No menu bar found on Flotherm window"}
 
-    # Press Alt
-    user32.keybd_event(VK_MENU, 0, 0, 0)
-    time.sleep(0.1)
-    user32.keybd_event(VK_M, 0, 0, 0)
-    user32.keybd_event(VK_M, 0, 2, 0)  # key up
-    user32.keybd_event(VK_MENU, 0, 2, 0)  # key up
-    time.sleep(0.5)
+    top_items = _dump_menu(hmenu, "menubar")
 
-    # Press P for Play FloSCRIPT
-    user32.keybd_event(VK_P, 0, 0, 0)
-    user32.keybd_event(VK_P, 0, 2, 0)
-    time.sleep(1.0)
+    macro_menu = _find_submenu(hmenu, "macro")
+    if not macro_menu:
+        return {
+            "ok": False,
+            "error": f"Macro menu not found. Menu items: {top_items}",
+        }
 
-    # Step 3: Find the file dialog
+    # Find "Play FloSCRIPT" in Macro submenu
+    macro_items = _dump_menu(macro_menu, "macro")
+    play_item = _find_menu_item(macro_menu, "play")
+    if play_item is None:
+        return {
+            "ok": False,
+            "error": f"Play FloSCRIPT not found in Macro menu. Items: {macro_items}",
+        }
+
+    position, cmd_id = play_item
+
+    # Step 3: Send WM_COMMAND to trigger Play FloSCRIPT
+    user32.PostMessageW(hwnd, WM_COMMAND, cmd_id, 0)
+    time.sleep(1.5)
+
+    # Step 4: Find the file dialog
     try:
         dialog = find_dialog("Play FloSCRIPT", timeout=timeout)
     except RuntimeError:
-        # Try alternate title
-        dialog = find_dialog("Open", timeout=3)
+        try:
+            dialog = find_dialog("Open", timeout=3)
+        except RuntimeError:
+            # List visible windows for debugging
+            visible = []
+            for w in _enum_windows():
+                if user32.IsWindowVisible(w):
+                    t = _get_window_text(w)
+                    if t:
+                        visible.append(t)
+            return {
+                "ok": False,
+                "error": f"File dialog not found. Visible windows: {visible[:10]}",
+            }
 
-    # Step 4: Find the filename edit control (control ID 1148 = standard file dialog)
+    # Step 5: Set filename in the edit control (ID 1148)
     edit = user32.GetDlgItem(dialog, 1148)
     if not edit:
-        # Try combo box edit (control ID 1148 is inside ComboBoxEx32)
-        combo = user32.GetDlgItem(dialog, 1148)
-        if combo:
-            edit = combo
-        else:
-            raise RuntimeError("Cannot find filename edit control in dialog")
+        return {"ok": False, "error": "Cannot find filename edit control (1148)"}
 
-    # Set the filename
     path_buf = ctypes.create_unicode_buffer(script_path)
     user32.SendMessageW(edit, WM_SETTEXT, 0, path_buf)
     time.sleep(0.3)
 
-    # Step 5: Click Open button (control ID 1 = IDOK)
+    # Step 6: Click Open button (ID 1 = IDOK)
     open_btn = user32.GetDlgItem(dialog, 1)
     if not open_btn:
-        raise RuntimeError("Cannot find Open button in dialog")
+        return {"ok": False, "error": "Cannot find Open button"}
+
     user32.SendMessageW(open_btn, BM_CLICK, 0, 0)
 
-    return {"ok": True, "dialog_hwnd": dialog, "main_hwnd": hwnd}
+    return {
+        "ok": True,
+        "menu_items": top_items,
+        "macro_items": macro_items,
+        "cmd_id": cmd_id,
+    }

--- a/src/sim/drivers/flotherm/_win32_backend.py
+++ b/src/sim/drivers/flotherm/_win32_backend.py
@@ -1,220 +1,88 @@
-"""Win32 GUI automation backend for Flotherm.
+"""Win32 GUI automation backend for Flotherm (Qt application).
 
-Automates: Macro > Play FloSCRIPT → file dialog → FloSCRIPT XML path.
+Uses pywinauto with UIA backend to automate:
+  Macro menu > Play FloSCRIPT > file dialog > script path
+
 Runs inside the sim-server process (interactive desktop session required).
+Flotherm uses Qt, so standard Win32 GetMenu() doesn't work — UIA is needed.
 """
 from __future__ import annotations
 
-import ctypes
-import ctypes.wintypes
 import time
-
-user32 = ctypes.windll.user32
-
-# Win32 constants
-WM_SETTEXT = 0x000C
-BM_CLICK = 0x00F5
-WM_COMMAND = 0x0111
-MF_BYPOSITION = 0x0400
-MF_BYCOMMAND = 0x0000
-MIIM_ID = 0x00000002
-MIIM_SUBMENU = 0x00000004
-MIIM_STRING = 0x00000040
-
-
-class MENUITEMINFOW(ctypes.Structure):
-    _fields_ = [
-        ("cbSize", ctypes.wintypes.UINT),
-        ("fMask", ctypes.wintypes.UINT),
-        ("fType", ctypes.wintypes.UINT),
-        ("fState", ctypes.wintypes.UINT),
-        ("wID", ctypes.wintypes.UINT),
-        ("hSubMenu", ctypes.wintypes.HMENU),
-        ("hbmpChecked", ctypes.wintypes.HBITMAP),
-        ("hbmpUnchecked", ctypes.wintypes.HBITMAP),
-        ("dwItemData", ctypes.POINTER(ctypes.wintypes.ULONG)),
-        ("dwTypeData", ctypes.wintypes.LPWSTR),
-        ("cch", ctypes.wintypes.UINT),
-        ("hbmpItem", ctypes.wintypes.HBITMAP),
-    ]
-
-
-def _enum_windows() -> list[int]:
-    """Enumerate all top-level windows."""
-    results = []
-    @ctypes.WINFUNCTYPE(ctypes.wintypes.BOOL, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
-    def callback(hwnd, lparam):
-        results.append(hwnd)
-        return True
-    user32.EnumWindows(callback, 0)
-    return results
-
-
-def _get_window_text(hwnd: int) -> str:
-    buf = ctypes.create_unicode_buffer(512)
-    user32.GetWindowTextW(hwnd, buf, 512)
-    return buf.value
-
-
-def _get_class_name(hwnd: int) -> str:
-    buf = ctypes.create_unicode_buffer(256)
-    user32.GetClassNameW(hwnd, buf, 256)
-    return buf.value
-
-
-def find_flotherm_window(timeout: float = 10) -> int:
-    """Find the Flotherm main window handle."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        for hwnd in _enum_windows():
-            if not user32.IsWindowVisible(hwnd):
-                continue
-            title = _get_window_text(hwnd)
-            if "Simcenter Flotherm" in title or "FloTHERM" in title:
-                return hwnd
-        time.sleep(0.5)
-    raise RuntimeError("Flotherm window not found")
-
-
-def find_dialog(title_substring: str, timeout: float = 10) -> int:
-    """Find a dialog window by title substring."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        for hwnd in _enum_windows():
-            if not user32.IsWindowVisible(hwnd):
-                continue
-            title = _get_window_text(hwnd)
-            if title_substring.lower() in title.lower():
-                return hwnd
-        time.sleep(0.3)
-    raise RuntimeError(f"Dialog '{title_substring}' not found within {timeout}s")
-
-
-def _get_menu_item_text(hmenu: int, index: int) -> str:
-    """Get menu item text by position."""
-    buf = ctypes.create_unicode_buffer(256)
-    mii = MENUITEMINFOW()
-    mii.cbSize = ctypes.sizeof(MENUITEMINFOW)
-    mii.fMask = MIIM_STRING
-    mii.dwTypeData = buf
-    mii.cch = 256
-    user32.GetMenuItemInfoW(hmenu, index, True, ctypes.byref(mii))
-    return buf.value
-
-
-def _find_menu_item(hmenu: int, text_substring: str) -> tuple[int, int] | None:
-    """Find menu item by text. Returns (position, command_id) or None."""
-    count = user32.GetMenuItemCount(hmenu)
-    for i in range(count):
-        label = _get_menu_item_text(hmenu, i)
-        if text_substring.lower() in label.lower().replace("&", ""):
-            # Get the command ID
-            mii = MENUITEMINFOW()
-            mii.cbSize = ctypes.sizeof(MENUITEMINFOW)
-            mii.fMask = MIIM_ID | MIIM_SUBMENU
-            user32.GetMenuItemInfoW(hmenu, i, True, ctypes.byref(mii))
-            return (i, mii.wID)
-    return None
-
-
-def _find_submenu(hmenu: int, text_substring: str) -> int | None:
-    """Find a submenu by text. Returns submenu handle or None."""
-    count = user32.GetMenuItemCount(hmenu)
-    for i in range(count):
-        label = _get_menu_item_text(hmenu, i)
-        if text_substring.lower() in label.lower().replace("&", ""):
-            sub = user32.GetSubMenu(hmenu, i)
-            if sub:
-                return sub
-    return None
-
-
-def _dump_menu(hmenu: int, label: str = "menu") -> list[str]:
-    """Debug: dump all menu item labels."""
-    items = []
-    count = user32.GetMenuItemCount(hmenu)
-    for i in range(count):
-        text = _get_menu_item_text(hmenu, i)
-        items.append(text or f"(separator at {i})")
-    return items
 
 
 def play_floscript(script_path: str, timeout: float = 15) -> dict:
     """Trigger Macro > Play FloSCRIPT and feed it the script path.
 
-    Uses Win32 menu API (WM_COMMAND) instead of keyboard — works from
-    any process context as long as we're in the same desktop session.
+    Uses pywinauto UIA backend for Qt menu automation.
     """
-    # Step 1: Find main window
-    hwnd = find_flotherm_window(timeout=10)
-
-    # Step 2: Get menu bar and find Macro submenu
-    hmenu = user32.GetMenu(hwnd)
-    if not hmenu:
-        return {"ok": False, "error": "No menu bar found on Flotherm window"}
-
-    top_items = _dump_menu(hmenu, "menubar")
-
-    macro_menu = _find_submenu(hmenu, "macro")
-    if not macro_menu:
-        return {
-            "ok": False,
-            "error": f"Macro menu not found. Menu items: {top_items}",
-        }
-
-    # Find "Play FloSCRIPT" in Macro submenu
-    macro_items = _dump_menu(macro_menu, "macro")
-    play_item = _find_menu_item(macro_menu, "play")
-    if play_item is None:
-        return {
-            "ok": False,
-            "error": f"Play FloSCRIPT not found in Macro menu. Items: {macro_items}",
-        }
-
-    position, cmd_id = play_item
-
-    # Step 3: Send WM_COMMAND to trigger Play FloSCRIPT
-    user32.PostMessageW(hwnd, WM_COMMAND, cmd_id, 0)
-    time.sleep(1.5)
-
-    # Step 4: Find the file dialog
     try:
-        dialog = find_dialog("Play FloSCRIPT", timeout=timeout)
-    except RuntimeError:
+        from pywinauto import Desktop
+    except ImportError:
+        return {"ok": False, "error": "pywinauto not installed"}
+
+    # Step 1: Find Flotherm window
+    desktop = Desktop(backend="uia")
+    try:
+        flo_win = desktop.window(title_re=".*Simcenter Flotherm.*")
+        flo_win.wait("visible", timeout=10)
+    except Exception as e:
+        return {"ok": False, "error": f"Flotherm window not found: {e}"}
+
+    # Step 2: Click Macro menu
+    try:
+        menu_bar = flo_win.child_window(control_type="MenuBar", found_index=0)
+        macro_item = menu_bar.child_window(title_re=".*Macro.*", control_type="MenuItem")
+        macro_item.click_input()
+        time.sleep(0.5)
+    except Exception as e:
+        # Try alternate: look for menu item directly
         try:
-            dialog = find_dialog("Open", timeout=3)
-        except RuntimeError:
-            # List visible windows for debugging
-            visible = []
-            for w in _enum_windows():
-                if user32.IsWindowVisible(w):
-                    t = _get_window_text(w)
-                    if t:
-                        visible.append(t)
-            return {
-                "ok": False,
-                "error": f"File dialog not found. Visible windows: {visible[:10]}",
-            }
+            macro_item = flo_win.child_window(title="Macro", control_type="MenuItem")
+            macro_item.click_input()
+            time.sleep(0.5)
+        except Exception as e2:
+            return {"ok": False, "error": f"Cannot find Macro menu: {e}, then {e2}"}
 
-    # Step 5: Set filename in the edit control (ID 1148)
-    edit = user32.GetDlgItem(dialog, 1148)
-    if not edit:
-        return {"ok": False, "error": "Cannot find filename edit control (1148)"}
+    # Step 3: Click "Play FloSCRIPT"
+    try:
+        play_item = desktop.window(control_type="MenuItem", title_re=".*Play FloSCRIPT.*")
+        play_item.click_input()
+        time.sleep(1.0)
+    except Exception:
+        try:
+            play_item = desktop.window(control_type="MenuItem", title_re=".*Play.*")
+            play_item.click_input()
+            time.sleep(1.0)
+        except Exception as e:
+            return {"ok": False, "error": f"Cannot find Play FloSCRIPT menu item: {e}"}
 
-    path_buf = ctypes.create_unicode_buffer(script_path)
-    user32.SendMessageW(edit, WM_SETTEXT, 0, path_buf)
-    time.sleep(0.3)
+    # Step 4: Handle file dialog
+    try:
+        dialog = desktop.window(title_re=".*Play FloSCRIPT.*|.*Open.*")
+        dialog.wait("visible", timeout=timeout)
 
-    # Step 6: Click Open button (ID 1 = IDOK)
-    open_btn = user32.GetDlgItem(dialog, 1)
-    if not open_btn:
-        return {"ok": False, "error": "Cannot find Open button"}
+        # Try setting the filename via the edit/combo control
+        try:
+            edit = dialog.child_window(control_type="Edit", found_index=0)
+            edit.set_text(script_path)
+        except Exception:
+            # Fallback: ComboBox
+            combo = dialog.child_window(control_type="ComboBox", title_re=".*File name.*|.*文件名.*")
+            edit = combo.child_window(control_type="Edit")
+            edit.set_text(script_path)
 
-    user32.SendMessageW(open_btn, BM_CLICK, 0, 0)
+        time.sleep(0.3)
 
-    return {
-        "ok": True,
-        "menu_items": top_items,
-        "macro_items": macro_items,
-        "cmd_id": cmd_id,
-    }
+        # Click Open/OK button
+        try:
+            open_btn = dialog.child_window(title_re="Open|打开|OK", control_type="Button")
+            open_btn.click_input()
+        except Exception:
+            # Press Enter as fallback
+            edit.type_keys("{ENTER}")
+
+    except Exception as e:
+        return {"ok": False, "error": f"File dialog interaction failed: {e}"}
+
+    return {"ok": True, "method": "pywinauto_uia"}

--- a/src/sim/drivers/flotherm/_win32_backend.py
+++ b/src/sim/drivers/flotherm/_win32_backend.py
@@ -1,0 +1,137 @@
+"""Win32 GUI automation backend for Flotherm.
+
+Automates: Macro > Play FloSCRIPT → file dialog → FloSCRIPT XML path.
+Runs inside the sim-server process (interactive desktop session required).
+"""
+from __future__ import annotations
+
+import ctypes
+import ctypes.wintypes
+import time
+
+user32 = ctypes.windll.user32
+
+# Win32 constants
+WM_SETTEXT = 0x000C
+BM_CLICK = 0x00F5
+WM_COMMAND = 0x0111
+WM_KEYDOWN = 0x0100
+WM_KEYUP = 0x0101
+VK_RETURN = 0x0D
+
+
+def find_flotherm_window(timeout: float = 10) -> int:
+    """Find the FloMainWindow handle."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        hwnd = user32.FindWindowW(None, None)
+        while hwnd:
+            buf = ctypes.create_unicode_buffer(256)
+            user32.GetClassNameW(hwnd, buf, 256)
+            if "FloMainWindow" in buf.value:
+                return hwnd
+            hwnd = user32.FindWindowExW(None, hwnd, None, None)
+        # Try by window title containing "Flotherm"
+        hwnd = user32.FindWindowW(None, None)
+        while hwnd:
+            buf = ctypes.create_unicode_buffer(256)
+            user32.GetWindowTextW(hwnd, buf, 256)
+            if "Flotherm" in buf.value or "FloTHERM" in buf.value:
+                if user32.IsWindowVisible(hwnd):
+                    return hwnd
+            hwnd = user32.FindWindowExW(None, hwnd, None, None)
+        time.sleep(0.5)
+    raise RuntimeError("FloMainWindow not found")
+
+
+def _enum_windows_callback_factory(results: list):
+    """Create a callback for EnumWindows."""
+    @ctypes.WINFUNCTYPE(ctypes.wintypes.BOOL, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
+    def callback(hwnd, lparam):
+        results.append(hwnd)
+        return True
+    return callback
+
+
+def find_dialog(title_substring: str, timeout: float = 10) -> int:
+    """Find a dialog window by title substring."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        results = []
+        cb = _enum_windows_callback_factory(results)
+        user32.EnumWindows(cb, 0)
+        for hwnd in results:
+            if not user32.IsWindowVisible(hwnd):
+                continue
+            buf = ctypes.create_unicode_buffer(256)
+            user32.GetWindowTextW(hwnd, buf, 256)
+            if title_substring.lower() in buf.value.lower():
+                return hwnd
+        time.sleep(0.3)
+    raise RuntimeError(f"Dialog '{title_substring}' not found within {timeout}s")
+
+
+def play_floscript(script_path: str, timeout: float = 15) -> dict:
+    """Trigger Macro > Play FloSCRIPT and feed it the script path.
+
+    Steps:
+    1. Find Flotherm main window
+    2. Send Alt+M (Macro menu) then P (Play FloSCRIPT)
+    3. Wait for file dialog
+    4. Set filename and click Open
+    """
+    import subprocess as sp
+
+    # Step 1: Find main window
+    hwnd = find_flotherm_window(timeout=10)
+    user32.SetForegroundWindow(hwnd)
+    time.sleep(0.5)
+
+    # Step 2: Use keyboard to open Macro > Play FloSCRIPT
+    # Alt key
+    VK_MENU = 0x12
+    VK_M = 0x4D  # 'M' for Macro
+    VK_P = 0x50  # 'P' for Play
+
+    # Press Alt
+    user32.keybd_event(VK_MENU, 0, 0, 0)
+    time.sleep(0.1)
+    user32.keybd_event(VK_M, 0, 0, 0)
+    user32.keybd_event(VK_M, 0, 2, 0)  # key up
+    user32.keybd_event(VK_MENU, 0, 2, 0)  # key up
+    time.sleep(0.5)
+
+    # Press P for Play FloSCRIPT
+    user32.keybd_event(VK_P, 0, 0, 0)
+    user32.keybd_event(VK_P, 0, 2, 0)
+    time.sleep(1.0)
+
+    # Step 3: Find the file dialog
+    try:
+        dialog = find_dialog("Play FloSCRIPT", timeout=timeout)
+    except RuntimeError:
+        # Try alternate title
+        dialog = find_dialog("Open", timeout=3)
+
+    # Step 4: Find the filename edit control (control ID 1148 = standard file dialog)
+    edit = user32.GetDlgItem(dialog, 1148)
+    if not edit:
+        # Try combo box edit (control ID 1148 is inside ComboBoxEx32)
+        combo = user32.GetDlgItem(dialog, 1148)
+        if combo:
+            edit = combo
+        else:
+            raise RuntimeError("Cannot find filename edit control in dialog")
+
+    # Set the filename
+    path_buf = ctypes.create_unicode_buffer(script_path)
+    user32.SendMessageW(edit, WM_SETTEXT, 0, path_buf)
+    time.sleep(0.3)
+
+    # Step 5: Click Open button (control ID 1 = IDOK)
+    open_btn = user32.GetDlgItem(dialog, 1)
+    if not open_btn:
+        raise RuntimeError("Cannot find Open button in dialog")
+    user32.SendMessageW(open_btn, BM_CLICK, 0, 0)
+
+    return {"ok": True, "dialog_hwnd": dialog, "main_hwnd": hwnd}

--- a/src/sim/drivers/flotherm/driver.py
+++ b/src/sim/drivers/flotherm/driver.py
@@ -248,27 +248,45 @@ class FlothermDriver:
         """Execute a Flotherm command in the active session.
 
         Supported commands:
-          - A path to a .pack file → load_project()
-          - A path to a .xml FloSCRIPT → submit_job(script=...)
-          - "solve" → submit_job() with auto-generated FloSCRIPT
+          - A path to a .pack file → load_project() + play FloSCRIPT to open in GUI
+          - A path to a .xml FloSCRIPT → play it via GUI automation
+          - "solve" → generate solve FloSCRIPT and play via GUI
           - "status" → query_status()
         """
         text = code.strip()
 
-        # .pack file → load project
+        # .pack file → load project + open in GUI via FloSCRIPT
         if text.lower().endswith(".pack") and os.path.isfile(text):
             result = self.load_project(Path(text))
-            return {"ok": True, "action": "load_project", **result}
+            # Generate a FloSCRIPT to load the project in the GUI
+            from sim.drivers.flotherm._helpers import build_solve_and_save
+            project_name = result["project_name"]
+            # Just unlock + load (no solve)
+            load_script = (
+                '<?xml version="1.0" encoding="UTF-8"?>\n'
+                '<xml_log_file version="1.0">\n'
+                f'    <project_unlock project_name="{project_name}"/>\n'
+                f'    <project_load project_name="{project_name}"/>\n'
+                '</xml_log_file>'
+            )
+            script_path = self._write_script(load_script, "load_project")
+            gui_result = self._play_floscript(script_path)
+            return {"ok": True, "action": "load_project", **result, "gui": gui_result}
 
-        # .xml FloSCRIPT → submit job with script
+        # .xml FloSCRIPT → play via GUI automation
         if text.lower().endswith(".xml") and os.path.isfile(text):
-            result = self.submit_job(label=label or "xml_script", script=Path(text))
-            return {"ok": True, "action": "submit_job", **result}
+            gui_result = self._play_floscript(text)
+            return {"ok": True, "action": "play_floscript", "script": text, "gui": gui_result}
 
-        # "solve" → submit job with auto-generated script
+        # "solve" → generate solve FloSCRIPT and play via GUI
         if text.lower() == "solve":
-            result = self.submit_job(label=label or "solve")
-            return {"ok": True, "action": "submit_job", **result}
+            if self._project is None:
+                return {"ok": False, "error": "No project loaded. Load a .pack first."}
+            from sim.drivers.flotherm._helpers import build_solve_and_save
+            script_content = build_solve_and_save(self._project["project_name"])
+            script_path = self._write_script(script_content, label or "solve")
+            gui_result = self._play_floscript(script_path)
+            return {"ok": True, "action": "solve", "script": script_path, "gui": gui_result}
 
         # "status" → query status
         if text.lower() == "status":
@@ -280,6 +298,16 @@ class FlothermDriver:
             "error": f"Unknown command: {text!r}. "
                      "Use a .pack path, .xml path, 'solve', or 'status'.",
         }
+
+    def _play_floscript(self, script_path: str) -> dict:
+        """Trigger Macro > Play FloSCRIPT via Win32 GUI automation."""
+        try:
+            from sim.drivers.flotherm._win32_backend import play_floscript
+            return play_floscript(script_path)
+        except ImportError:
+            return {"ok": False, "error": "Win32 backend not available (not on Windows)"}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
 
     def load_project(self, pack_or_dir: Path) -> dict:
         """Load a project into the session."""

--- a/src/sim/drivers/flotherm/driver.py
+++ b/src/sim/drivers/flotherm/driver.py
@@ -293,11 +293,50 @@ class FlothermDriver:
             result = self.query_status()
             return {"ok": True, "action": "query_status", **result}
 
+        # "debug windows" → probe Win32 window hierarchy
+        if text.lower() == "debug windows":
+            return self._debug_windows()
+
         return {
             "ok": False,
             "error": f"Unknown command: {text!r}. "
                      "Use a .pack path, .xml path, 'solve', or 'status'.",
         }
+
+    def _debug_windows(self) -> dict:
+        """Probe the Win32 window hierarchy for debugging."""
+        try:
+            import ctypes
+            import ctypes.wintypes
+            user32 = ctypes.windll.user32
+
+            results_list = []
+            @ctypes.WINFUNCTYPE(ctypes.wintypes.BOOL, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
+            def enum_cb(hwnd, lparam):
+                results_list.append(hwnd)
+                return True
+            user32.EnumWindows(enum_cb, 0)
+
+            windows = []
+            for hwnd in results_list:
+                if not user32.IsWindowVisible(hwnd):
+                    continue
+                buf = ctypes.create_unicode_buffer(512)
+                user32.GetWindowTextW(hwnd, buf, 512)
+                cls_buf = ctypes.create_unicode_buffer(256)
+                user32.GetClassNameW(hwnd, cls_buf, 256)
+                hmenu = user32.GetMenu(hwnd)
+                title = buf.value
+                if title:
+                    windows.append({
+                        "hwnd": f"{hwnd:#x}",
+                        "class": cls_buf.value,
+                        "title": title[:80],
+                        "has_menu": hmenu != 0,
+                    })
+            return {"ok": True, "action": "debug_windows", "windows": windows}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
 
     def _play_floscript(self, script_path: str) -> dict:
         """Trigger Macro > Play FloSCRIPT via Win32 GUI automation."""

--- a/src/sim/drivers/flotherm/driver.py
+++ b/src/sim/drivers/flotherm/driver.py
@@ -111,6 +111,10 @@ class FlothermDriver:
     def name(self) -> str:
         return "flotherm"
 
+    @property
+    def supports_session(self) -> bool:
+        return True
+
     def detect(self, script: Path) -> bool:
         """Return True for Flotherm files (.pack, FloSCRIPT .xml)."""
         ext = script.suffix.lower()
@@ -202,7 +206,7 @@ class FlothermDriver:
     # -- Session lifecycle (like COMSOL's launch/run/disconnect) ---------------
 
     def launch(
-        self, *, workspace: str | None = None, ui_mode: str = "gui",
+        self, *, workspace: str | None = None, ui_mode: str = "gui", **kwargs,
     ) -> dict:
         """Start a Flotherm session.
 
@@ -239,6 +243,17 @@ class FlothermDriver:
             "active_project": None,
         }
         return self._session
+
+    def run(self, code: str, label: str = "") -> dict:
+        """Flotherm does not support interactive code execution.
+
+        Use load_project() + submit_job() workflow instead.
+        """
+        return {
+            "ok": False,
+            "error": "Flotherm does not support interactive code execution. "
+                     "Use load_project() + submit_job() workflow.",
+        }
 
     def load_project(self, pack_or_dir: Path) -> dict:
         """Load a project into the session."""
@@ -443,7 +458,7 @@ class FlothermDriver:
 
     _PROCESS_NAMES = ("floserv", "floview", "flotherm")
 
-    def disconnect(self, *, kill_process: bool = True, keep_workspace: bool = True) -> None:
+    def disconnect(self, *, kill_process: bool = True, keep_workspace: bool = True) -> dict:
         """End the session."""
         if kill_process:
             self._kill_flotherm_processes()
@@ -451,6 +466,7 @@ class FlothermDriver:
         if self._session:
             self._session["state"] = "disconnected"
         self._project = None
+        return {"ok": True, "disconnected": True}
 
     # -- Internal helpers -----------------------------------------------------
 

--- a/src/sim/drivers/flotherm/driver.py
+++ b/src/sim/drivers/flotherm/driver.py
@@ -245,14 +245,40 @@ class FlothermDriver:
         return self._session
 
     def run(self, code: str, label: str = "") -> dict:
-        """Flotherm does not support interactive code execution.
+        """Execute a Flotherm command in the active session.
 
-        Use load_project() + submit_job() workflow instead.
+        Supported commands:
+          - A path to a .pack file → load_project()
+          - A path to a .xml FloSCRIPT → submit_job(script=...)
+          - "solve" → submit_job() with auto-generated FloSCRIPT
+          - "status" → query_status()
         """
+        text = code.strip()
+
+        # .pack file → load project
+        if text.lower().endswith(".pack") and os.path.isfile(text):
+            result = self.load_project(Path(text))
+            return {"ok": True, "action": "load_project", **result}
+
+        # .xml FloSCRIPT → submit job with script
+        if text.lower().endswith(".xml") and os.path.isfile(text):
+            result = self.submit_job(label=label or "xml_script", script=Path(text))
+            return {"ok": True, "action": "submit_job", **result}
+
+        # "solve" → submit job with auto-generated script
+        if text.lower() == "solve":
+            result = self.submit_job(label=label or "solve")
+            return {"ok": True, "action": "submit_job", **result}
+
+        # "status" → query status
+        if text.lower() == "status":
+            result = self.query_status()
+            return {"ok": True, "action": "query_status", **result}
+
         return {
             "ok": False,
-            "error": "Flotherm does not support interactive code execution. "
-                     "Use load_project() + submit_job() workflow.",
+            "error": f"Unknown command: {text!r}. "
+                     "Use a .pack path, .xml path, 'solve', or 'status'.",
         }
 
     def load_project(self, pack_or_dir: Path) -> dict:

--- a/src/sim/drivers/fluent/driver.py
+++ b/src/sim/drivers/fluent/driver.py
@@ -158,6 +158,10 @@ class PyFluentDriver:
     def name(self) -> str:
         return "fluent"
 
+    @property
+    def supports_session(self) -> bool:
+        return True
+
     def detect(self, script: Path) -> bool:
         """Return True if the script imports ansys.fluent or pyfluent."""
         text = script.read_text(encoding="utf-8")
@@ -274,6 +278,8 @@ class PyFluentDriver:
         port: int | None = None,
         password: str | None = None,
         ui_mode: str = "gui",
+        processors: int | None = None,
+        **kwargs,
     ) -> dict:
         """
         Launch or connect to a Fluent session. Returns a structured dict.
@@ -323,15 +329,13 @@ class PyFluentDriver:
             if not pyfluent.config.launch_fluent_ip:
                 pyfluent.config.launch_fluent_ip = "127.0.0.1"
 
+            launch_kwargs = {"ui_mode": ui_mode}
             if mode == "meshing":
-                session = pyfluent.launch_fluent(
-                    mode="meshing",
-                    ui_mode=ui_mode,
-                )
-                source = "launch"
-            else:
-                session = pyfluent.launch_fluent(ui_mode=ui_mode)
-                source = "launch"
+                launch_kwargs["mode"] = "meshing"
+            if processors is not None:
+                launch_kwargs["processor_count"] = processors
+            session = pyfluent.launch_fluent(**launch_kwargs)
+            source = "launch"
 
         session_id = str(uuid.uuid4())
         info = self._runtime.register_session(session_id, mode, source, session)
@@ -349,6 +353,17 @@ class PyFluentDriver:
         """
         record = self._runtime.exec_snippet(code=code, label=label)
         return record.to_run_result()
+
+    def disconnect(self) -> dict:
+        """Tear down the active Fluent session."""
+        session_info = self._runtime.get_active_session()
+        if session_info is not None:
+            try:
+                session_info.session.exit()
+            except Exception:
+                pass
+            self._runtime._active_id = None
+        return {"ok": True, "disconnected": True}
 
     def query(self, name: str) -> dict:
         """

--- a/src/sim/drivers/matlab/driver.py
+++ b/src/sim/drivers/matlab/driver.py
@@ -173,6 +173,10 @@ class MatlabDriver:
     def name(self) -> str:
         return "matlab"
 
+    @property
+    def supports_session(self) -> bool:
+        return True
+
     def detect(self, script: Path) -> bool:
         """Treat `.m` files as MATLAB scripts."""
         return script.suffix.lower() == ".m"

--- a/src/sim/drivers/openfoam/driver.py
+++ b/src/sim/drivers/openfoam/driver.py
@@ -89,6 +89,10 @@ class OpenFOAMDriver:
     def name(self) -> str:
         return "openfoam"
 
+    @property
+    def supports_session(self) -> bool:
+        return False
+
     # -- DriverProtocol -------------------------------------------------------
 
     def detect(self, script: Path) -> bool:

--- a/src/sim/drivers/pybamm/driver.py
+++ b/src/sim/drivers/pybamm/driver.py
@@ -54,6 +54,10 @@ class PyBaMMLDriver:
     def name(self) -> str:
         return "pybamm"
 
+    @property
+    def supports_session(self) -> bool:
+        return False
+
     def detect(self, script: Path) -> bool:
         """Check if script imports pybamm."""
         text = script.read_text(encoding="utf-8")

--- a/src/sim/server.py
+++ b/src/sim/server.py
@@ -21,9 +21,7 @@ import io
 import math
 import os
 import time
-import traceback
 import uuid
-from contextlib import redirect_stdout, redirect_stderr
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -89,58 +87,12 @@ class SessionState:
     ui_mode: str | None = None
     connected_at: float | None = None
     run_count: int = 0
-    session: Any = None
     driver: Any = None
     runs: list[dict] = field(default_factory=list)
     profile: str | None = None       # resolved profile name (label only)
 
 
 _state = SessionState()
-
-
-# ── Snippet execution (fluent inline path) ───────────────────────────────────
-
-def _execute_snippet(code: str, label: str) -> dict:
-    stdout_buf = io.StringIO()
-    stderr_buf = io.StringIO()
-    namespace: dict[str, Any] = {
-        "session": _state.session,
-        "_result": None,
-    }
-    if _state.mode == "meshing":
-        namespace["meshing"] = _state.session
-    else:
-        namespace["solver"] = _state.session
-
-    started = time.time()
-    ok = True
-    error = None
-
-    try:
-        with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
-            exec(code, namespace)  # noqa: S102
-    except Exception:
-        ok = False
-        error = traceback.format_exc()
-
-    elapsed = round(time.time() - started, 4)
-
-    run_record = {
-        "run_id": str(uuid.uuid4()),
-        "session_id": _state.session_id,
-        "label": label,
-        "code": code,
-        "ok": ok,
-        "stdout": stdout_buf.getvalue(),
-        "stderr": stderr_buf.getvalue(),
-        "error": error,
-        "result": namespace.get("_result"),
-        "elapsed_s": elapsed,
-        "started_at": started,
-    }
-    _state.runs.append(run_record)
-    _state.run_count += 1
-    return run_record
 
 
 # ── Endpoints ────────────────────────────────────────────────────────────────
@@ -202,7 +154,7 @@ def detect_solver(solver: str):
 
 
 def _have_active_session() -> bool:
-    return _state.session is not None
+    return _state.driver is not None and _state.session_id is not None
 
 
 def _resolve_profile(driver, solver: str):
@@ -246,20 +198,19 @@ def connect(req: ConnectRequest):
     if driver is None:
         raise HTTPException(400, f"unknown solver: {req.solver}")
 
+    if not getattr(driver, "supports_session", False):
+        raise HTTPException(
+            400,
+            f"{req.solver} does not support persistent sessions. "
+            "Use POST /run for one-shot execution.",
+        )
+
     try:
-        if req.solver in ("matlab", "comsol", "flotherm"):
-            info = driver.launch(ui_mode=req.ui_mode)
-            session = driver
-        elif req.solver == "fluent":
-            import ansys.fluent.core as pyfluent
-            session = pyfluent.launch_fluent(
-                mode=req.mode,
-                ui_mode=req.ui_mode,
-                processor_count=req.processors,
-            )
-            info = {"ok": True, "session_id": str(uuid.uuid4())}
-        else:
-            raise HTTPException(400, f"no launch path for solver: {req.solver}")
+        info = driver.launch(
+            mode=req.mode,
+            ui_mode=req.ui_mode,
+            processors=req.processors,
+        )
     except HTTPException:
         raise
     except Exception as e:
@@ -274,7 +225,6 @@ def connect(req: ConnectRequest):
     _state.ui_mode = req.ui_mode
     _state.connected_at = time.time()
     _state.run_count = 0
-    _state.session = session
     _state.driver = driver
     _state.runs = []
     _state.profile = profile.name if profile else None
@@ -299,16 +249,12 @@ def exec_snippet(req: ExecRequest):
     if not _have_active_session():
         raise HTTPException(400, "no active session — POST /connect first")
 
-    if _state.solver in ("matlab", "comsol", "flotherm"):
-        result = _state.driver.run(req.code, req.label)
-        result["session_id"] = _state.session_id
-        result["started_at"] = time.time()
-        _state.runs.append(result)
-        _state.run_count += 1
-        return {"ok": result["ok"], "data": result}
-
-    record = _execute_snippet(req.code, req.label)
-    return {"ok": record["ok"], "data": record}
+    result = _state.driver.run(req.code, req.label)
+    result.setdefault("session_id", _state.session_id)
+    result.setdefault("started_at", time.time())
+    _state.runs.append(result)
+    _state.run_count += 1
+    return {"ok": result.get("ok", True), "data": result}
 
 
 @app.post("/run")
@@ -425,18 +371,12 @@ def _teardown_active_session() -> str | None:
 
     sid = _state.session_id
 
-    if _state.solver in ("matlab", "comsol", "flotherm") and _state.driver:
+    if _state.driver is not None:
         try:
             _state.driver.disconnect()
         except Exception:
             pass
-    elif _state.session is not None:
-        try:
-            _state.session.exit()
-        except Exception:
-            pass
 
-    _state.session = None
     _state.session_id = None
     _state.solver = None
     _state.mode = None

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -280,7 +280,9 @@ class TestConnectIncludesSkillsBlock(unittest.TestCase):
 
         # Stub the comsol driver so launch() doesn't actually spawn COMSOL
         class _StubDriver:
-            def launch(self, ui_mode=None):
+            supports_session = True
+
+            def launch(self, **kwargs):
                 return {"ok": True, "session_id": "stub-sid"}
 
         original_get_driver = None
@@ -324,7 +326,9 @@ class TestConnectIncludesSkillsBlock(unittest.TestCase):
         os.environ["SIM_SKILLS_ROOT"] = str(self.tmp / "does-not-exist")
 
         class _StubDriver:
-            def launch(self, ui_mode=None):
+            supports_session = True
+
+            def launch(self, **kwargs):
                 return {"ok": True, "session_id": "stub-sid"}
 
         from sim import drivers as drivers_mod


### PR DESCRIPTION
Closes a companion sim-proj issue.

## Summary
- Add `supports_session` property and `launch()`/`run()`/`disconnect()` to `DriverProtocol`
- Server checks `driver.supports_session` instead of hardcoded solver-name tuples
- Delete `_execute_snippet()` — each driver owns its own exec logic via `run()`
- Add `disconnect()` to a session-style driver (was inline in server), `run()` stub to a GUI-style driver
- New drivers only need to implement `DriverProtocol` and register in `__init__.py` — no `server.py` changes

## Per-driver changes

| Driver | `supports_session` | Changes |
|---|---|---|
| Driver A | `True` | Add `disconnect()`, processors param, `**kwargs` |
| Driver B | `True` | Add property (already had session methods) |
| Driver C | `True` | Add property, `run()` stub, fix `disconnect()` return type |
| Driver D | `True` | Add property, fix `disconnect()` return type, `**kwargs` |
| Driver E | `False` | Add property only |
| Driver F | `False` | Add property (has no session methods — separate issue needed) |
| openfoam | `False` | Add property only |

## Test plan
- [x] `uv run python -m pytest` — 70 passed, 1 skipped
- [ ] `sim --host <test-host> connect --solver <driver> --ui-mode gui` → works
- [ ] `sim --host <test-host> disconnect` → clean process kill
- [ ] `sim connect --solver <stateless-driver>` → 400 "does not support persistent sessions"
