### PR TITLE
fix: GUI-driver automation v2 + serve --reload

### DIFF
--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -44,15 +44,24 @@ def main(ctx, output_json, host, port):
 @click.option("--host", "serve_host", default="127.0.0.1",
               help="Bind address. Use 0.0.0.0 for Tailscale/network access.")
 @click.option("--port", "serve_port", default=7600, type=int)
-def serve(serve_host, serve_port):
+@click.option("--reload", is_flag=True, default=False,
+              help="Auto-reload on code changes (dev mode).")
+def serve(serve_host, serve_port, reload):
     """Start the sim HTTP server (like ollama serve)."""
     import uvicorn
-    from sim.server import app
 
     click.echo(f"[sim] server starting on {serve_host}:{serve_port}")
     if serve_host == "0.0.0.0":
         click.echo("[sim] accessible on network (Tailscale)")
-    uvicorn.run(app, host=serve_host, port=serve_port, log_level="info")
+    if reload:
+        click.echo("[sim] auto-reload enabled (watching for file changes)")
+    uvicorn.run(
+        "sim.server:app",
+        host=serve_host,
+        port=serve_port,
+        log_level="info",
+        reload=reload,
+    )
 
 
 # ── check ────────────────────────────────────────────────────────────────────

--- a/src/sim/drivers/flotherm/_win32_backend.py
+++ b/src/sim/drivers/flotherm/_win32_backend.py
@@ -1,88 +1,142 @@
 """Win32 GUI automation backend for Flotherm (Qt application).
 
-Uses pywinauto with UIA backend to automate:
-  Macro menu > Play FloSCRIPT > file dialog > script path
+Proven automation path:
+  1. Subprocess: pywinauto UIA expand() Macro > invoke() Play FloSCRIPT
+     (invoke blocks because the file dialog is modal — subprocess times out, dialog stays open)
+  2. Main process: raw Win32 ctypes to fill the file dialog and click Open
 
-Runs inside the sim-server process (interactive desktop session required).
-Flotherm uses Qt, so standard Win32 GetMenu() doesn't work — UIA is needed.
+This separation is critical:
+  - UIA invoke() throws COMError and corrupts COM state for the entire process
+  - Running UIA in a subprocess isolates the corruption
+  - Win32 ctypes for the standard file dialog works reliably from the main process
 """
 from __future__ import annotations
 
+import ctypes
+import ctypes.wintypes
+import os
+import subprocess
+import sys
 import time
 
 
-def play_floscript(script_path: str, timeout: float = 15) -> dict:
-    """Trigger Macro > Play FloSCRIPT and feed it the script path.
+user32 = ctypes.windll.user32 if os.name == "nt" else None
 
-    Uses pywinauto UIA backend for Qt menu automation.
-    """
-    try:
-        from pywinauto import Desktop
-    except ImportError:
-        return {"ok": False, "error": "pywinauto not installed"}
+WM_SETTEXT = 0x000C
+BM_CLICK = 0x00F5
+WM_CLOSE = 0x0010
 
-    # Step 1: Find Flotherm window
-    desktop = Desktop(backend="uia")
-    try:
-        flo_win = desktop.window(title_re=".*Simcenter Flotherm.*")
-        flo_win.wait("visible", timeout=10)
-    except Exception as e:
-        return {"ok": False, "error": f"Flotherm window not found: {e}"}
+_UIA_MENU_TRIGGER = """\
+import time
+from pywinauto.application import Application
+app = Application(backend="uia").connect(title_re=".*Simcenter Flotherm.*", found_index=0)
+win = app.window(title_re=".*Simcenter Flotherm.*", found_index=0)
+macro = win.child_window(control_type="MenuBar", found_index=0).child_window(title="Macro", control_type="MenuItem")
+macro.expand()
+time.sleep(0.5)
+submenu = macro.child_window(control_type="Menu")
+play = submenu.child_window(title_re=".*Play FloSCRIPT.*", control_type="MenuItem")
+try:
+    play.invoke()
+except Exception:
+    pass
+"""
 
-    # Step 2: Click Macro menu
-    try:
-        menu_bar = flo_win.child_window(control_type="MenuBar", found_index=0)
-        macro_item = menu_bar.child_window(title_re=".*Macro.*", control_type="MenuItem")
-        macro_item.click_input()
+
+def _enum_visible_windows() -> list[tuple[int, str]]:
+    """Return [(hwnd, title)] for all visible windows."""
+    results: list[int] = []
+
+    @ctypes.WINFUNCTYPE(ctypes.wintypes.BOOL, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
+    def cb(hwnd, _lp):
+        results.append(hwnd)
+        return True
+
+    user32.EnumWindows(cb, 0)
+    out = []
+    for hwnd in results:
+        if not user32.IsWindowVisible(hwnd):
+            continue
+        buf = ctypes.create_unicode_buffer(256)
+        user32.GetWindowTextW(hwnd, buf, 256)
+        if buf.value:
+            out.append((hwnd, buf.value))
+    return out
+
+
+def _dismiss_popups() -> list[str]:
+    """Close any Message Window or error popups. Returns list of dismissed titles."""
+    dismissed = []
+    for hwnd, title in _enum_visible_windows():
+        if "Message" in title:
+            user32.PostMessageW(hwnd, WM_CLOSE, 0, 0)
+            dismissed.append(title)
+    if dismissed:
         time.sleep(0.5)
-    except Exception as e:
-        # Try alternate: look for menu item directly
-        try:
-            macro_item = flo_win.child_window(title="Macro", control_type="MenuItem")
-            macro_item.click_input()
-            time.sleep(0.5)
-        except Exception as e2:
-            return {"ok": False, "error": f"Cannot find Macro menu: {e}, then {e2}"}
+    return dismissed
 
-    # Step 3: Click "Play FloSCRIPT"
-    try:
-        play_item = desktop.window(control_type="MenuItem", title_re=".*Play FloSCRIPT.*")
-        play_item.click_input()
-        time.sleep(1.0)
-    except Exception:
-        try:
-            play_item = desktop.window(control_type="MenuItem", title_re=".*Play.*")
-            play_item.click_input()
-            time.sleep(1.0)
-        except Exception as e:
-            return {"ok": False, "error": f"Cannot find Play FloSCRIPT menu item: {e}"}
 
-    # Step 4: Handle file dialog
-    try:
-        dialog = desktop.window(title_re=".*Play FloSCRIPT.*|.*Open.*")
-        dialog.wait("visible", timeout=timeout)
-
-        # Try setting the filename via the edit/combo control
-        try:
-            edit = dialog.child_window(control_type="Edit", found_index=0)
-            edit.set_text(script_path)
-        except Exception:
-            # Fallback: ComboBox
-            combo = dialog.child_window(control_type="ComboBox", title_re=".*File name.*|.*文件名.*")
-            edit = combo.child_window(control_type="Edit")
-            edit.set_text(script_path)
-
+def _find_dialog(title_substring: str, timeout: float = 10) -> int | None:
+    """Poll for a dialog window containing title_substring."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for hwnd, title in _enum_visible_windows():
+            if title_substring in title:
+                return hwnd
         time.sleep(0.3)
+    return None
 
-        # Click Open/OK button
-        try:
-            open_btn = dialog.child_window(title_re="Open|打开|OK", control_type="Button")
-            open_btn.click_input()
-        except Exception:
-            # Press Enter as fallback
-            edit.type_keys("{ENTER}")
 
-    except Exception as e:
-        return {"ok": False, "error": f"File dialog interaction failed: {e}"}
+def _fill_file_dialog(dialog_hwnd: int, file_path: str) -> bool:
+    """Set filename and click Open in a standard Windows file dialog."""
+    edit = user32.GetDlgItem(dialog_hwnd, 1148)
+    if not edit:
+        return False
+    user32.SendMessageW(edit, WM_SETTEXT, 0, ctypes.create_unicode_buffer(file_path))
+    time.sleep(0.3)
+    ok_btn = user32.GetDlgItem(dialog_hwnd, 1)
+    if not ok_btn:
+        return False
+    user32.SendMessageW(ok_btn, BM_CLICK, 0, 0)
+    return True
 
-    return {"ok": True, "method": "pywinauto_uia"}
+
+def play_floscript(script_path: str, timeout: float = 15) -> dict:
+    """Trigger Macro > Play FloSCRIPT and submit a FloSCRIPT XML file.
+
+    Returns dict with ``ok`` status and diagnostics.
+    """
+    if user32 is None:
+        return {"ok": False, "error": "Not on Windows"}
+
+    # Dismiss any existing popups
+    dismissed = _dismiss_popups()
+
+    # Step 1: Launch UIA subprocess to open Play FloSCRIPT dialog
+    # invoke() is modal so the subprocess will block — we kill it after timeout
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _UIA_MENU_TRIGGER],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+    time.sleep(1.0)
+
+    # Step 2: Find the Play FloSCRIPT file dialog
+    dialog = _find_dialog("Play FloSCRIPT", timeout=5)
+    if dialog is None:
+        return {
+            "ok": False,
+            "error": "Play FloSCRIPT dialog not found after menu trigger",
+            "dismissed_popups": dismissed,
+        }
+
+    # Step 3: Fill and submit
+    if not _fill_file_dialog(dialog, script_path):
+        return {"ok": False, "error": "Failed to fill file dialog controls"}
+
+    return {"ok": True, "method": "subprocess_uia_win32", "dismissed_popups": dismissed}

--- a/src/sim/drivers/flotherm/driver.py
+++ b/src/sim/drivers/flotherm/driver.py
@@ -255,35 +255,49 @@ class FlothermDriver:
         """
         text = code.strip()
 
-        # .pack file → load project + open in GUI via FloSCRIPT
+        # #!python → execute raw Python in server process (dev mode only)
+        # WARNING: This is exec() — arbitrary code execution. Only available
+        # when SIM_DEV_MODE=1 is set in the server environment.
+        if text.startswith("#!python"):
+            if not os.environ.get("SIM_DEV_MODE"):
+                return {"ok": False, "error": "#!python requires SIM_DEV_MODE=1 (security: arbitrary code execution)"}
+            return self._exec_python(text[len("#!python"):].strip())
+
+        # .pack file → import project into GUI via FloSCRIPT project_import
         if text.lower().endswith(".pack") and os.path.isfile(text):
             result = self.load_project(Path(text))
-            # Generate a FloSCRIPT to load the project in the GUI
-            from sim.drivers.flotherm._helpers import build_solve_and_save
-            project_name = result["project_name"]
-            # Just unlock + load (no solve)
-            load_script = (
+            # Clean up extracted dir so project_import can re-extract
+            import shutil
+            proj_path = os.path.join(result["workspace"], result["project_dir"])
+            if os.path.isdir(proj_path):
+                shutil.rmtree(proj_path)
+            # Generate import FloSCRIPT
+            import_script = (
                 '<?xml version="1.0" encoding="UTF-8"?>\n'
                 '<xml_log_file version="1.0">\n'
-                f'    <project_unlock project_name="{project_name}"/>\n'
-                f'    <project_load project_name="{project_name}"/>\n'
+                f'    <project_import filename="{text}" import_type="Pack File"/>\n'
                 '</xml_log_file>'
             )
-            script_path = self._write_script(load_script, "load_project")
+            script_path = self._write_script(import_script, "import_project")
             gui_result = self._play_floscript(script_path)
-            return {"ok": True, "action": "load_project", **result, "gui": gui_result}
+            return {"ok": True, "action": "import_project", **result, "gui": gui_result}
 
         # .xml FloSCRIPT → play via GUI automation
         if text.lower().endswith(".xml") and os.path.isfile(text):
             gui_result = self._play_floscript(text)
             return {"ok": True, "action": "play_floscript", "script": text, "gui": gui_result}
 
-        # "solve" → generate solve FloSCRIPT and play via GUI
+        # "solve" → play solve FloSCRIPT via GUI
         if text.lower() == "solve":
             if self._project is None:
                 return {"ok": False, "error": "No project loaded. Load a .pack first."}
-            from sim.drivers.flotherm._helpers import build_solve_and_save
-            script_content = build_solve_and_save(self._project["project_name"])
+            # Project is already loaded in GUI after import — just start solver
+            script_content = (
+                '<?xml version="1.0" encoding="UTF-8"?>\n'
+                '<xml_log_file version="1.0">\n'
+                '    <start start_type="solver"/>\n'
+                '</xml_log_file>'
+            )
             script_path = self._write_script(script_content, label or "solve")
             gui_result = self._play_floscript(script_path)
             return {"ok": True, "action": "solve", "script": script_path, "gui": gui_result}
@@ -293,50 +307,46 @@ class FlothermDriver:
             result = self.query_status()
             return {"ok": True, "action": "query_status", **result}
 
-        # "debug windows" → probe Win32 window hierarchy
-        if text.lower() == "debug windows":
-            return self._debug_windows()
-
         return {
             "ok": False,
             "error": f"Unknown command: {text!r}. "
-                     "Use a .pack path, .xml path, 'solve', or 'status'.",
+                     "Use a .pack path, .xml path, 'solve', 'status', or '#!python ...'.",
         }
 
-    def _debug_windows(self) -> dict:
-        """Probe the Win32 window hierarchy for debugging."""
+    def _exec_python(self, code: str) -> dict:
+        """Execute raw Python in the server process (dev mode).
+
+        WARNING: This runs arbitrary code via exec(). Only available when
+        SIM_DEV_MODE=1 is set. Never enable in production.
+        """
+        import io
+        import logging
+        import traceback
+        logging.warning("Flotherm #!python exec — dev mode, arbitrary code execution")
+        from contextlib import redirect_stdout, redirect_stderr
+
+        stdout_buf = io.StringIO()
+        stderr_buf = io.StringIO()
+        namespace = {"driver": self, "_result": None}
+
         try:
-            import ctypes
-            import ctypes.wintypes
-            user32 = ctypes.windll.user32
-
-            results_list = []
-            @ctypes.WINFUNCTYPE(ctypes.wintypes.BOOL, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
-            def enum_cb(hwnd, lparam):
-                results_list.append(hwnd)
-                return True
-            user32.EnumWindows(enum_cb, 0)
-
-            windows = []
-            for hwnd in results_list:
-                if not user32.IsWindowVisible(hwnd):
-                    continue
-                buf = ctypes.create_unicode_buffer(512)
-                user32.GetWindowTextW(hwnd, buf, 512)
-                cls_buf = ctypes.create_unicode_buffer(256)
-                user32.GetClassNameW(hwnd, cls_buf, 256)
-                hmenu = user32.GetMenu(hwnd)
-                title = buf.value
-                if title:
-                    windows.append({
-                        "hwnd": f"{hwnd:#x}",
-                        "class": cls_buf.value,
-                        "title": title[:80],
-                        "has_menu": hmenu != 0,
-                    })
-            return {"ok": True, "action": "debug_windows", "windows": windows}
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
+            with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
+                exec(code, namespace)  # noqa: S102
+            return {
+                "ok": True,
+                "action": "python",
+                "stdout": stdout_buf.getvalue(),
+                "stderr": stderr_buf.getvalue(),
+                "result": namespace.get("_result"),
+            }
+        except Exception:
+            return {
+                "ok": False,
+                "action": "python",
+                "stdout": stdout_buf.getvalue(),
+                "stderr": stderr_buf.getvalue(),
+                "error": traceback.format_exc(),
+            }
 
     def _play_floscript(self, script_path: str) -> dict:
         """Trigger Macro > Play FloSCRIPT via Win32 GUI automation."""


### PR DESCRIPTION
## Summary
The initial merge of #10 had an earlier version of the GUI automation and was missing `--reload` and dev-mode gating. This PR brings in the tested, working code.

- **`_win32_backend.py`**: Rewritten to use subprocess-isolated UIA (fixes COM corruption from `invoke()` on Qt menus) + raw Win32 ctypes for file dialog
- **`driver.py`**: Use `project_import` with `import_type="Pack File"`, solve with `<start/>` only (no unlock/load), `#!python` gated behind `SIM_DEV_MODE=1`, debug commands removed
- **`cli.py`**: Add `--reload` flag to `sim serve` for auto-restart on code changes

## Test plan
- [x] `sim connect --solver <driver> --ui-mode gui` — launches GUI
- [x] `sim exec '<pack_path>'` — imports a public demo case into the GUI
- [x] `sim exec 'solve'` — solver converges (~150k cells, steady-state)
- [x] `sim disconnect` — all processes killed cleanly
- [x] `#!python` blocked without `SIM_DEV_MODE=1`
- [x] `uv run python -m pytest` — 70 passed
