### PR TITLE
fix(driver): add run_file so /run path works end-to-end

### DIFF
--- a/src/sim/drivers/comsol/driver.py
+++ b/src/sim/drivers/comsol/driver.py
@@ -17,10 +17,12 @@ import json
 import os
 import re
 import shutil
+import sys
 from pathlib import Path
 from typing import Callable
 
 from sim.driver import ConnectionInfo, Diagnostic, LintResult, SolverInstall
+from sim.runner import run_subprocess
 
 
 # ─── extension points (open for additions, closed for modifications) ──────
@@ -370,3 +372,17 @@ class ComsolDriver:
                 except json.JSONDecodeError:
                     continue
         return {}
+
+    def run_file(self, script: Path):
+        """Execute a one-shot COMSOL/MPh Python script.
+
+        The script runs in the same interpreter sim-cli is running under.
+        `mph` and its JPype/JVM dependencies must be importable in that
+        env — sim-cli itself is SDK-free, so `sim env install comsol`
+        (or a manual `pip install mph`) provisions the runtime.
+        """
+        return run_subprocess(
+            [sys.executable, str(script)],
+            script=script,
+            solver=self.name,
+        )

--- a/tests/test_comsol_driver.py
+++ b/tests/test_comsol_driver.py
@@ -84,34 +84,52 @@ class TestParseOutput:
 
 
 class TestRunFile:
-    def test_run_constructs_command(self, monkeypatch, tmp_path):
-        """Verify run_file uses execute_script correctly."""
-        script = tmp_path / "test.py"
-        script.write_text("import mph\nclient = mph.start()\n")
+    def test_run_file_invokes_python_subprocess(self, monkeypatch, tmp_path):
+        """driver.run_file shells out to the running Python with the script."""
+        import sys as _sys
+        from types import SimpleNamespace
 
-        from sim import runner
-        from sim.driver import RunResult
+        from sim.drivers.comsol import driver as comsol_driver_mod
+
+        script = tmp_path / "smoke.py"
+        script.write_text("import mph\nclient = mph.start()\n")
 
         captured = {}
 
-        def fake_execute(s, python=None, solver="unknown"):
-            captured["script"] = s
-            captured["solver"] = solver
-            return RunResult(
-                exit_code=0,
-                stdout="{}",
-                stderr="",
-                duration_s=0.1,
-                script=str(s),
-                solver=solver,
-                timestamp="2026-01-01T00:00:00+00:00",
-            )
+        def fake_run(command, capture_output, text):
+            captured["command"] = command
+            return SimpleNamespace(returncode=0, stdout="{}", stderr="")
 
-        monkeypatch.setattr(runner, "execute_script", fake_execute)
+        monkeypatch.setattr("sim.runner.subprocess.run", fake_run)
 
-        result = runner.execute_script(script, solver="comsol")
-        assert captured["solver"] == "comsol"
-        assert captured["script"] == script
+        driver = ComsolDriver()
+        result = driver.run_file(script)
+
+        assert captured["command"][0] == _sys.executable
+        assert captured["command"][1] == str(script)
+        assert result.solver == "comsol"
+        assert result.exit_code == 0
+
+    def test_run_file_routes_through_execute_script(self, monkeypatch, tmp_path):
+        """The /run server path calls execute_script(driver=...), which must
+        delegate to driver.run_file — this is the integration path that
+        previously blew up with AttributeError."""
+        from types import SimpleNamespace
+
+        from sim import runner
+
+        script = tmp_path / "smoke.py"
+        script.write_text("import mph\n")
+
+        def fake_run(command, capture_output, text):
+            return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+
+        monkeypatch.setattr("sim.runner.subprocess.run", fake_run)
+
+        driver = ComsolDriver()
+        result = runner.execute_script(script, solver="comsol", driver=driver)
+        assert result.exit_code == 0
+        assert result.solver == "comsol"
 
 
 def _make_import_blocker(blocked: str):


### PR DESCRIPTION
## Summary

- The driver's `run_file()` was missing, so `sim.runner.execute_script(driver=...)` crashed with `AttributeError` for every script in this driver. This regressed (latently) in the unified DriverProtocol refactor (f428ab6), which routed the driver through the one-shot `/run` path but never added the execution method.
- Add `run_file()` matching the sister driver's pattern (shell out to `sys.executable`).
- Replace a placebo `TestRunFile` test with two real ones — the old test monkeypatched `execute_script` then called `execute_script` directly, so it never touched the driver.

## Root cause

`server.py /run` → `runner.execute_script(driver=driver)` → `driver.run_file(script)` (see `src/sim/runner.py:47`). Before this PR, the driver had no `run_file`, so every call raised `AttributeError: 'Driver' object has no attribute 'run_file'`.

## Changes

- driver: add `run_file(self, script)` that delegates to `run_subprocess([sys.executable, str(script)], ...)`. Keeps the driver SDK-free at module load; the subprocess inherits whichever bridge / runtime is present in the env.
- tests: rewrite `TestRunFile`:
  - `test_run_file_invokes_python_subprocess`: asserts the subprocess command starts with `[sys.executable, script]`.
  - `test_run_file_routes_through_execute_script`: asserts `runner.execute_script(driver=driver)` completes without `AttributeError` — the exact integration path that was broken.

## Test plan

- [x] Offline suite: 84 passed on macOS (was 83; +1 new real test).
- [x] Live on a Windows host with the solver and bridge installed: `driver.run_file(script)` → bridge boot → `exit_code=0`, clean stdout JSON.
- [ ] Reviewer: sanity-check the subprocess pattern matches the sister driver.
