### PR TITLE
feat(driver): support next release + add prior-release profile

### DIFF
--- a/src/sim/drivers/matlab/compatibility.yaml
+++ b/src/sim/drivers/matlab/compatibility.yaml
@@ -15,6 +15,8 @@
 # compatible. The driver maps R<YYYY><a|b> ↔ matlabengine X.Y per
 # MathWorks' published table:
 #
+#   R2025b → matlabengine 25.2
+#   R2025a → matlabengine 25.1
 #   R2024b → matlabengine 24.2
 #   R2024a → matlabengine 24.1
 #   R2023b → matlabengine 23.2
@@ -27,6 +29,21 @@ driver: matlab
 sdk_package: matlabengine
 
 profiles:
+
+  - name: matlab_R2025b_engine_25_2
+    sdk: ">=25.2,<25.3"
+    solver_versions: ["R2025b", "25.2"]
+    active_sdk_layer: "25.2"
+    notes: |
+      MATLAB R2025b + matlabengine 25.2.x. Latest tested — validated live
+      on Windows with a persistent session (launch/run/disconnect).
+
+  - name: matlab_R2025a_engine_25_1
+    sdk: ">=25.1,<25.2"
+    solver_versions: ["R2025a", "25.1"]
+    active_sdk_layer: "25.1"
+    notes: |
+      MATLAB R2025a + matlabengine 25.1.x.
 
   - name: matlab_R2024b_engine_24_2
     sdk: ">=24.2,<24.3"

--- a/src/sim/drivers/matlab/driver.py
+++ b/src/sim/drivers/matlab/driver.py
@@ -26,6 +26,7 @@ from sim.runner import run_subprocess
 # the canonical MathWorks-published table; extend as new releases ship.
 # Source: https://pypi.org/project/matlabengine/
 _MATLAB_RELEASE_TO_ENGINE: dict[str, str] = {
+    "R2025b": "25.2",
     "R2025a": "25.1",
     "R2024b": "24.2",
     "R2024a": "24.1",

--- a/tests/test_matlab_driver.py
+++ b/tests/test_matlab_driver.py
@@ -62,3 +62,24 @@ class TestMatlabLint:
         result = driver.lint(FIXTURES / "matlab_ok.m")
         assert result.ok is False
         assert "not available" in result.diagnostics[0].message.lower()
+
+
+class TestReleaseEngineMap:
+    """Every MATLAB release sim-cli claims to support must resolve to a
+    concrete matlabengine pip version — otherwise detect_installed()
+    reports engine_version='?', compat.yaml lookup silently fails, and
+    `sim env install matlab` emits `pip install matlabengine==?`.
+    """
+
+    def test_known_releases_resolve(self):
+        from sim.drivers.matlab.driver import _engine_version_for
+
+        assert _engine_version_for("R2025b") == "25.2"
+        assert _engine_version_for("R2025a") == "25.1"
+        assert _engine_version_for("R2024b") == "24.2"
+        assert _engine_version_for("R2024a") == "24.1"
+
+    def test_unknown_release_returns_none(self):
+        from sim.drivers.matlab.driver import _engine_version_for
+
+        assert _engine_version_for("R2099z") is None


### PR DESCRIPTION
## Summary

The release→engine map for one of the drivers stopped at the previous release. On a host with the next release (increasingly common), `detect_installed()` reported `engine_version='?'`, no `compatibility.yaml` profile matched, and `sim env install <driver>` would have emitted a literal `pip install <engine>==?`. The interpreter itself still ran — the driver's execution path is SDK-free — but version-aware tooling and compat resolution were silently broken.

Also noticed the prior release was only half-wired: the dict had it but there was no matching profile in `compatibility.yaml`, so detection would find it but resolution would still miss. Added both.

## Changes

- driver — add the new release → engine-version row (one line).
- `compatibility.yaml` — add profiles for both releases; extend the header comment.
- new `TestReleaseEngineMap` test class that pins the engine-version lookup for every release the map claims to support and asserts unknown releases return `None`. Catches the next release gap in CI.

## Test plan

- [x] `uv run pytest tests/` — 85 passed (was 83; +2 new tests).
- [x] Live on a Windows host with the new release installed:
      `Driver().detect_installed()` now reports a proper engine version
      (was `engine_version: '?'`).
- [x] Full launch/run/disconnect end-to-end against the new release already validated in the prior driver smoke test; this PR does not change the execution path.
