### PR TITLE
docs: refresh README driver tables across EN/DE/JA/ZH

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ The driver registry is **open and intentionally growing** — adding a new backe
 | Domain | Example backends shipping today | Sessions | Status |
 |---|---|---|---|
 | Electronics thermal | Simcenter Flotherm | persistent (GUI) | ✅ Working — model generation from natural language, XSD-validated FloSCRIPT, step-by-step build with checkpoints |
-| CFD | Ansys Fluent, OpenFOAM | persistent / one-shot | ✅ Working |
+| CFD | Ansys Fluent, OpenFOAM, Simcenter STAR-CCM+ | persistent / one-shot | ✅ Working |
 | Multiphysics | COMSOL Multiphysics | one-shot | ✅ Working |
+| CAE | Ansys Workbench, Ansys Mechanical, Abaqus | persistent / one-shot | ✅ Working |
 | Pre-processing | BETA CAE ANSA | persistent / one-shot | ✅ Working (Phase 1) |
 | Numerical / scripting | MATLAB | one-shot | ✅ Working (v0) |
 | Battery modeling | PyBaMM | one-shot | ✅ Working |

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -210,10 +210,11 @@ Die Driver-Registry ist **offen und absichtlich wachsend** — ein neuer Backend
 
 | Domäne | Beispiel-Backends, die heute funktionieren | Sessions | Status |
 |---|---|---|---|
-| CFD | Ansys Fluent, OpenFOAM | persistent / one-shot | ✅ Working |
+| Elektronik-Thermik | Simcenter Flotherm | persistent (GUI) | ✅ Working — Modellgenerierung aus natürlicher Sprache, XSD-validiertes FloSCRIPT, schrittweiser Aufbau mit Checkpoints |
+| CFD | Ansys Fluent, OpenFOAM, Simcenter STAR-CCM+ | persistent / one-shot | ✅ Working |
 | Multiphysik | COMSOL Multiphysics | one-shot | ✅ Working |
+| CAE | Ansys Workbench, Ansys Mechanical, Abaqus | persistent / one-shot | ✅ Working |
 | Vorverarbeitung | BETA CAE ANSA | persistent / one-shot | ✅ Working (Phase 1) |
-| Elektronik-Thermik | Simcenter Flotherm | one-shot | ✅ Working (Phase A) |
 | Numerik / Scripting | MATLAB | one-shot | ✅ Working (v0) |
 | Batteriemodellierung | PyBaMM | one-shot | ✅ Working |
 | **+ dein Solver** | PR öffnen — siehe [Entwicklung](#-entwicklung) | — | 🛠 |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -209,10 +209,11 @@ sim --host <server-ip> disconnect
 
 | ドメイン | 今日動く例示バックエンド | セッション | ステータス |
 |---|---|---|---|
-| CFD | Ansys Fluent、OpenFOAM | 持続 / ワンショット | ✅ Working |
+| 電子機器熱解析 | Simcenter Flotherm | 持続 (GUI) | ✅ Working ── 自然言語からのモデル生成、XSD 検証付き FloSCRIPT、チェックポイント付き段階構築 |
+| CFD | Ansys Fluent、OpenFOAM、Simcenter STAR-CCM+ | 持続 / ワンショット | ✅ Working |
 | マルチフィジックス | COMSOL Multiphysics | ワンショット | ✅ Working |
+| CAE | Ansys Workbench、Ansys Mechanical、Abaqus | 持続 / ワンショット | ✅ Working |
 | 前処理 | BETA CAE ANSA | 持続 / ワンショット | ✅ Working (Phase 1) |
-| 電子機器熱解析 | Simcenter Flotherm | ワンショット | ✅ Working (Phase A) |
 | 数値 / スクリプト | MATLAB | ワンショット | ✅ Working (v0) |
 | 電池モデリング | PyBaMM | ワンショット | ✅ Working |
 | **+ あなたのソルバー** | PR をどうぞ ── [開発](#-開発) を参照 | — | 🛠 |

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -208,10 +208,11 @@ sim --host <server-ip> disconnect
 
 | 领域 | 当前已支持的示例后端 | 会话模式 | 状态 |
 |---|---|---|---|
-| CFD | Ansys Fluent、OpenFOAM | 持久 / 一次性 | ✅ 可用 |
+| 电子热分析 | Simcenter Flotherm | 持久（GUI）| ✅ 可用 —— 自然语言驱动的模型生成、XSD 校验的 FloSCRIPT、带检查点的分步构建 |
+| CFD | Ansys Fluent、OpenFOAM、Simcenter STAR-CCM+ | 持久 / 一次性 | ✅ 可用 |
 | 多物理场 | COMSOL Multiphysics | 一次性 | ✅ 可用 |
+| CAE | Ansys Workbench、Ansys Mechanical、Abaqus | 持久 / 一次性 | ✅ 可用 |
 | 前处理 | BETA CAE ANSA | 持久 / 一次性 | ✅ 可用（Phase 1）|
-| 电子热分析 | Simcenter Flotherm | 一次性 | ✅ 可用（Phase A）|
 | 数值 / 脚本 | MATLAB | 一次性 | ✅ 可用（v0）|
 | 电池建模 | PyBaMM | 一次性 | ✅ 可用 |
 | **+ 你的求解器** | 提 PR —— 见 [Adding a driver](#-开发) | — | 🛠 |


### PR DESCRIPTION
## Summary
- Update README driver tables across EN, DE, JA, and ZH to reflect the current in-tree driver coverage.
- Tag persistent-mode driver entries appropriately and refresh per-driver capability descriptions.

## Test plan
- [x] Visual review of all four README driver tables
