### PR TITLE
docs: add NOTICE file and README trademark / SDK license disclaimers

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,72 @@
+sim-cli
+Copyright 2026 Weiqi Ji
+
+This product is licensed under the Apache License, Version 2.0 (the "License");
+see the accompanying LICENSE file for the full text.
+
+================================================================================
+Third-party solver SDKs (runtime, optional — not bundled)
+================================================================================
+
+sim-cli integrates with commercial and open-source solvers by dynamically
+importing their Python SDKs at runtime. No vendor SDK, solver binary, or vendor
+example/tutorial material is redistributed as part of this repository. Users
+install each SDK separately (via `sim env install`, optional extras in
+pyproject.toml, or their own package manager) and are responsible for
+complying with the license, copyright, and end-user agreement that ships
+with each SDK and each underlying solver.
+
+The drivers in `src/sim/drivers/` reference, but do not bundle, the following
+third-party Python SDKs. This list is informational and may lag the code —
+see `src/sim/drivers/<name>/compatibility.yaml` and `pyproject.toml` for the
+current version pins.
+
+  Ansys / PyAnsys family (© ANSYS, Inc.)
+    - ansys-fluent-core        https://github.com/ansys/pyfluent
+    - ansys-workbench-core     https://github.com/ansys/pyworkbench
+    - ansys-mechanical-core    https://github.com/ansys/pymechanical
+    - ansys-mapdl-core         https://github.com/ansys/pymapdl
+    - ansys-dyna-core          https://github.com/ansys/pydyna
+    - ansys-dpf-core           https://github.com/ansys/pydpf-core
+
+  COMSOL (© COMSOL AB)
+    - mph                       https://github.com/MPh-py/MPh
+      (third-party Python wrapper around COMSOL's Java API; requires a COMSOL
+      Multiphysics license)
+
+  MathWorks (© The MathWorks, Inc.)
+    - matlabengine              https://pypi.org/project/matlabengine/
+      (distributed by MathWorks; requires a MATLAB license)
+
+  Dassault Systèmes / Abaqus, Siemens STAR-CCM+ / Flotherm, BETA CAE ANSA,
+  Altair HyperMesh, Ansys ICEM CFD, Ansys CFX
+    - Driven via vendor CLIs / journal files / Python-in-solver interpreters.
+      No additional Python SDK is redistributed by sim-cli.
+
+  Open-source solvers and libraries
+    - PyBaMM, OpenFOAM, SU2, LAMMPS, CalculiX, Elmer FEM, Gmsh, meshio,
+      pyvista, PyMFEM, scikit-fem, SfePy, OpenSeesPy, Cantera, OpenMDAO,
+      FiPy, pymoo, Pyomo, SimPy, Trimesh, Devito, CoolProp, scikit-rf,
+      pandapower, ParaView (pvpython/pvbatch).
+      Each retains its own upstream license; consult the corresponding project
+      for terms.
+
+================================================================================
+Direct runtime dependencies (see pyproject.toml)
+================================================================================
+
+  click, httpx, fastapi, uvicorn, pyyaml, Pillow, lxml
+    — each distributed under its own open-source license (BSD / MIT / Apache-2.0
+      family); consult the respective package for terms.
+
+================================================================================
+Trademarks
+================================================================================
+
+Product, solver, and company names referenced in this repository (including
+Ansys®, Fluent®, Workbench®, Mechanical®, MAPDL, CFX®, LS-DYNA®, ICEM CFD™,
+Abaqus®, SIMULIA®, COMSOL Multiphysics®, MATLAB®, Simcenter™ STAR-CCM+,
+Simcenter Flotherm™, ANSA®, HyperMesh®, Altair®, ParaView®, OpenFOAM®) are
+trademarks or registered trademarks of their respective owners and are used
+solely for identification. sim-cli is an independent open-source project and
+is not affiliated with, endorsed by, or sponsored by any of these vendors.

--- a/README.md
+++ b/README.md
@@ -280,3 +280,26 @@ Highlights from the last few milestones — full history in [`CHANGELOG.md`](CHA
 ## 📄 License
 
 Apache-2.0 — see [LICENSE](LICENSE).
+
+### Third-party solver SDKs
+
+`sim-cli` is a thin wrapper/runtime — it does **not** bundle or redistribute any vendor solver or vendor SDK. Each solver backend is reached through a third-party SDK (e.g. `ansys-fluent-core`, `ansys-mapdl-core`, `ansys-workbench-core`, `ansys-mechanical-core`, `ansys-dyna-core`, `ansys-dpf-core`, `mph`, `matlabengine`) that the user installs separately via `sim env install` or as an optional extra.
+
+Users are responsible for obtaining a valid license for each underlying solver and for complying with the license, copyright, and EULA of every third-party SDK they choose to install alongside `sim-cli`. See [`NOTICE`](NOTICE) for the list of optional SDK dependencies and their upstream locations.
+
+### Trademarks
+
+All product, solver, and company names appearing in this repository are used for identification purposes only. Ownership is retained by the respective holders:
+
+- **Ansys®**, **Fluent®**, **Workbench®**, **Mechanical®**, **MAPDL**, **CFX®**, **LS-DYNA®**, **ICEM CFD™**, **DPF** are trademarks or registered trademarks of **ANSYS, Inc.**
+- **Abaqus®**, **SIMULIA®** are trademarks of **Dassault Systèmes**.
+- **COMSOL Multiphysics®** is a trademark of **COMSOL AB**.
+- **MATLAB®** is a registered trademark of **The MathWorks, Inc.**
+- **Simcenter™ STAR-CCM+**, **Simcenter Flotherm™** are trademarks of **Siemens Digital Industries Software**.
+- **ANSA®** is a trademark of **BETA CAE Systems**.
+- **HyperMesh®**, **Altair®** are trademarks of **Altair Engineering, Inc.**
+- **ParaView®** is a trademark of **Kitware, Inc.**
+- **OpenFOAM®** is a registered trademark of **OpenCFD Ltd.**
+- All other solver and product names are trademarks of their respective owners.
+
+`sim-cli` is an independent open-source project and is **not affiliated with, endorsed by, or sponsored by** any of the vendors listed above.


### PR DESCRIPTION
Adds a NOTICE file enumerating the third-party solver SDKs that sim-cli
integrates with at runtime (none are bundled) and a README section clarifying
that users must comply with each vendor SDK's license/EULA and that vendor
product names are trademarks of their respective owners. sim-cli is an
independent project, not affiliated with or endorsed by any solver vendor.