### PR TITLE
driver: dock readback + ok-honesty + reload session-drop docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,12 @@ FastAPI app exposing:
 
 The server keeps a single global `_state: SessionState` (one session per server process).
 
+**`sim serve --reload` drops the session on any source change under the watched tree.** uvicorn's reload watchdog observes file mtimes in `src/sim/**`; any edit (git pull, scp of a modified driver, even touching an unrelated module) restarts the worker, wiping `_state`. Child solver processes (Flotherm GUI, Fluent, etc.) survive the reload because they're spawned separately, but the session handle to them is gone — you have to `connect` again. Driver temp files (written to the solver's workspace, e.g. `flouser/_sim_*.xml`) live outside `src/` so they don't retrigger. Practical rules:
+
+- Don't edit driver code mid-experiment; finish the run, then edit.
+- For long autonomous experiments where you're editing driver code iteratively, launch **without** `--reload` and restart manually when you want the new code picked up.
+- Reconnecting after a reload takes ~20s for GUI-mode Flotherm (the existing GUI process is re-adopted; no re-launch needed).
+
 ### Driver protocol (`src/sim/driver.py`)
 `DriverProtocol` (a `runtime_checkable` `Protocol`):
 - `name: str` — registered driver name

--- a/src/sim/drivers/flotherm/_win32_backend.py
+++ b/src/sim/drivers/flotherm/_win32_backend.py
@@ -101,16 +101,102 @@ def _fill_file_dialog(dialog_hwnd: int, file_path: str) -> bool:
     return True
 
 
+_MESSAGE_DOCK_READ = r"""
+import io, sys
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+from pywinauto import Desktop
+main = next((w for w in Desktop(backend="uia").windows()
+             if w.class_name() == "FloMainWindow"), None)
+if main:
+    dock = next((d for d in main.descendants(control_type="Window")
+                 if "Message Window" in (d.window_text() or "")), None)
+    if dock:
+        seen = set()
+        for d in dock.descendants():
+            t = (d.window_text() or "").strip()
+            if t and len(t) > 3 and t not in seen:
+                seen.add(t)
+                print(t)
+"""
+
+
+def read_message_dock(timeout: float = 15) -> list[str]:
+    """Return all text lines currently in Flotherm's Message Window dock.
+
+    The dock is a ``flohelp::DockWidget`` embedded inside ``FloMainWindow``,
+    not a top-level window, so the caller-side popup-dismiss machinery misses
+    it. This helper enumerates the dock's UIA descendants and returns the
+    text lines. Runs UIA in a subprocess to keep the main process's COM
+    apartment clean (pywinauto enumeration has a history of COM pollution).
+    """
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", _MESSAGE_DOCK_READ],
+            capture_output=True,
+            timeout=timeout,
+        )
+        out = proc.stdout.decode("utf-8", errors="replace")
+        return [ln.strip() for ln in out.splitlines() if ln.strip()]
+    except Exception:
+        return []
+
+
+_DOCK_CLEAR = """
+import time
+from pywinauto import Desktop
+main = next((w for w in Desktop(backend="uia").windows()
+             if w.class_name() == "FloMainWindow"), None)
+if main:
+    dock = next((d for d in main.descendants(control_type="Window")
+                 if "Message Window" in (d.window_text() or "")), None)
+    if dock:
+        for b in dock.descendants(control_type="Button"):
+            if b.window_text() == "Clear":
+                b.click_input(); time.sleep(0.4); break
+"""
+
+
+def _clear_message_dock(timeout: float = 5) -> None:
+    """Click the Clear button in Flotherm's Message Window dock.
+
+    Without this, the dock's deduplicated readback returns *every* error
+    from prior plays in the same session, masking the actual outcome of
+    the current play. Click via UIA in a subprocess (consistent with the
+    other dock helpers, keeps COM apartment clean).
+    """
+    try:
+        subprocess.run(
+            [sys.executable, "-c", _DOCK_CLEAR],
+            capture_output=True, timeout=timeout,
+        )
+    except Exception:
+        pass
+
+
 def play_floscript(script_path: str, timeout: float = 15) -> dict:
     """Trigger Macro > Play FloSCRIPT and submit a FloSCRIPT XML file.
 
-    Returns dict with ``ok`` status and diagnostics.
+    Returns dict with ``ok`` status and diagnostics. When Flotherm's
+    Message Window dock records new ``ERROR``/``WARN`` lines during the
+    play, they are surfaced as ``errors``/``warnings`` and ``ok`` is
+    flipped to ``False`` — the dock captures runtime failures the CLI
+    would otherwise miss (E/15002 etc.).
+
+    The dock is cleared before each play because its readback is
+    deduplicated set-style: stale errors from earlier plays would
+    otherwise be reported again here and mask the current play's
+    actual result.
     """
     if user32 is None:
         return {"ok": False, "error": "Not on Windows"}
 
     # Dismiss any existing popups
     dismissed = _dismiss_popups()
+
+    # Clear the embedded Message Window dock so post_dock readback only
+    # contains errors/warnings from THIS play
+    _clear_message_dock()
+    pre_dock: set[str] = set()
 
     # Step 1: Launch UIA subprocess to open Play FloSCRIPT dialog
     # invoke() is modal so the subprocess will block — we kill it after timeout
@@ -139,4 +225,20 @@ def play_floscript(script_path: str, timeout: float = 15) -> dict:
     if not _fill_file_dialog(dialog, script_path):
         return {"ok": False, "error": "Failed to fill file dialog controls"}
 
-    return {"ok": True, "method": "subprocess_uia_win32", "dismissed_popups": dismissed}
+    # Step 4: give Flotherm a beat to render any runtime errors in the dock
+    time.sleep(1.5)
+    post_dock = read_message_dock()
+    new_lines = [ln for ln in post_dock if ln not in pre_dock]
+    errors = [ln for ln in new_lines if "ERROR" in ln]
+    warnings = [ln for ln in new_lines if "WARN" in ln]
+
+    result = {
+        "ok": not errors,
+        "method": "subprocess_uia_win32",
+        "dismissed_popups": dismissed,
+    }
+    if errors:
+        result["errors"] = errors
+    if warnings:
+        result["warnings"] = warnings
+    return result

--- a/src/sim/drivers/flotherm/driver.py
+++ b/src/sim/drivers/flotherm/driver.py
@@ -330,7 +330,12 @@ class FlothermDriver:
         # .xml FloSCRIPT → play via GUI automation
         if text.lower().endswith(".xml") and os.path.isfile(text):
             gui_result = self._play_floscript(text)
-            return {"ok": True, "action": "play_floscript", "script": text, "gui": gui_result}
+            return {
+                "ok": gui_result.get("ok", False),
+                "action": "play_floscript",
+                "script": text,
+                "gui": gui_result,
+            }
 
         # "solve" → play solve FloSCRIPT via GUI
         if text.lower() == "solve":


### PR DESCRIPTION
## Summary

Three changes that unblocked the XML-authoring + script pipeline for an internal Phase 1a milestone (verified end-to-end on a Windows test host):

- **Surface dock errors** — the win32 backend's playback helper reads the GUI's embedded message-window dock before/after each play, flips `ok=False` when new ERROR lines appear. The dock is a child widget inside the main window, not a top-level window, so the existing popup-dismissal mechanism missed it. Catches several known error codes (library-node, property-name, schema-validation).
- **Clear dock before each play** — without this, dock readback is set-deduped across plays. Every prior session's errors are reported as "current," masking actual outcome. Click via UIA subprocess (consistent with other dock helpers).
- **Honest `ok` in driver** — `driver.run()` was hard-coding `ok=True` for any `.xml` playback. Now respects `gui_result.ok`.

`CLAUDE.md` also documents the `--reload` session-drop behavior — uvicorn watches `src/sim/**` mtimes; any edit (even unrelated module) restarts the worker and wipes `_state`. Solver child processes survive but the session handle is gone.

## Test plan

- [x] An internal 3-block test case imports + solves cleanly via `sim --host exec`
- [x] Dock errors propagate to `sim CLI` JSON response
- [ ] CI lint passes (pre-existing helper-module lint errors unrelated)
- [ ] Once review converges, re-validate on the Windows host
