### PR TITLE
feat(ltspice): thin adapter over sim-ltspice (Stage 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,10 @@ dependencies = [
     "httpx>=0.28",
     "fastapi>=0.115",
     "uvicorn>=0.34",
-    "pyyaml>=6.0",          # reads driver compatibility.yaml files
-    "Pillow>=10",           # sim screenshot endpoint uses PIL.ImageGrab
-    "lxml>=5.0",            # XSD validation for FloSCRIPT lint
+    "pyyaml>=6.0", # reads driver compatibility.yaml files
+    "Pillow>=10", # sim screenshot endpoint uses PIL.ImageGrab
+    "lxml>=5.0", # XSD validation for FloSCRIPT lint
+    "sim-ltspice>=0.1", # LTspice file formats + runtime — sim-cli's LTspice driver delegates here
 ]
 
 [project.optional-dependencies]

--- a/src/sim/drivers/ltspice/driver.py
+++ b/src/sim/drivers/ltspice/driver.py
@@ -1,29 +1,24 @@
-"""LTspice driver for sim.
+"""LTspice driver for sim — thin adapter over ``sim_ltspice``.
 
-LTspice (Analog Devices) is a free SPICE3 circuit simulator. There is no
-Python API; control is via batch CLI:
+The heavy work (install discovery, subprocess invocation, `.log`
+encoding sniffing, `.raw` header parsing) lives in the standalone
+``sim-ltspice`` package on PyPI. This module only bridges between that
+library and sim-cli's ``DriverProtocol``.
 
-    macOS native   : LTspice -b <netlist>.net
-    Windows / wine : LTspice -Run -b <netlist>.net
-
-Produces (beside the netlist):
-
-    <stem>.log     UTF-16 LE text — .MEAS results, warnings, errors
-    <stem>.raw     UTF-16 LE header + binary waveform data
-    <stem>.op.raw  operating-point snapshot (if .op present)
-
-Scope v1 accepts ``.net``, ``.cir``, ``.sp`` netlists. ``.asc`` schematics
-need ``-netlist`` conversion which native macOS LTspice does not support;
-deferred until wine / Windows paths are wired up.
+Scope v1 still accepts ``.net``, ``.cir``, ``.sp`` netlists. ``.asc``
+schematic support lands once ``sim_ltspice`` grows ``run_asc``.
 """
 from __future__ import annotations
 
-import os
-import re
-import subprocess
-import sys
 import json
+import re
+from datetime import datetime, timezone
 from pathlib import Path
+
+from sim_ltspice import NETLIST_SUFFIXES, find_ltspice
+from sim_ltspice import RunResult as LtRunResult
+from sim_ltspice.install import Install
+from sim_ltspice.runner import LtspiceNotInstalled, UnsupportedInput, run_net
 
 from sim.driver import (
     ConnectionInfo,
@@ -32,10 +27,6 @@ from sim.driver import (
     RunResult,
     SolverInstall,
 )
-from sim.runner import run_subprocess
-
-
-NETLIST_SUFFIXES = (".net", ".cir", ".sp")
 
 
 _ANALYSIS_RE = re.compile(
@@ -43,248 +34,37 @@ _ANALYSIS_RE = re.compile(
     re.MULTILINE | re.IGNORECASE,
 )
 
-# LTspice .log lines like:  "vout_pk: MAX(v(out))=0.999955 FROM 0 TO 0.005"
-# Expr excludes newlines — Windows LTspice 26.x writes "Files loaded:\n<path>"
-# blocks where a drive letter like "C:" otherwise looks like a measure name.
-_MEAS_RE = re.compile(
-    r"^(?P<name>[A-Za-z_][\w]*)\s*:\s*"
-    r"(?P<expr>[^=\n\r]+?)=(?P<value>[-+0-9.eE]+(?:[a-zA-Z]*)?)"
-    r"(?:\s+FROM\s+(?P<from>[-+0-9.eE]+))?"
-    r"(?:\s+TO\s+(?P<to>[-+0-9.eE]+))?\s*$",
-    re.MULTILINE,
-)
 
-_ERROR_RE = re.compile(
-    r"^(?:Error[:\s]|Fatal[:\s]|Convergence failed|Singular matrix|"
-    r"Cannot find|Unknown (?:parameter|device))",
-    re.MULTILINE | re.IGNORECASE,
-)
-
-_WARN_RE = re.compile(r"^WARNING[:\s].*$", re.MULTILINE | re.IGNORECASE)
-
-_ELAPSED_RE = re.compile(
-    r"Total elapsed time:\s*([0-9.]+)\s*seconds",
-    re.IGNORECASE,
-)
-
-
-def _read_log(path: Path) -> str:
-    """Read an LTspice .log file.
-
-    Encoding varies by version:
-      - LTspice 17.x (macOS native): UTF-16 LE, no BOM
-      - LTspice 26.x (Windows): UTF-8, no BOM
-
-    Sniff BOM first, then detect UTF-16 LE by the "0x00 at every odd byte"
-    pattern (ASCII text under UTF-16 LE), else fall back to UTF-8.
-    A naive chain that tries utf-16-le first produces garbage on UTF-8 logs
-    because UTF-16 LE decoding never raises on arbitrary bytes.
-    """
-    if not path.is_file():
-        return ""
-    data = path.read_bytes()
-    if not data:
-        return ""
-    if data.startswith(b"\xff\xfe"):
-        return data[2:].decode("utf-16-le", errors="replace")
-    if data.startswith(b"\xfe\xff"):
-        return data[2:].decode("utf-16-be", errors="replace")
-    if data.startswith(b"\xef\xbb\xbf"):
-        return data[3:].decode("utf-8", errors="replace")
-    if len(data) >= 4 and data[1] == 0 and data[3] == 0:
-        return data.decode("utf-16-le", errors="replace")
-    return data.decode("utf-8", errors="replace")
-
-
-def _parse_log(text: str) -> dict:
-    """Extract structured fields from an LTspice .log body."""
-    measures: dict[str, dict] = {}
-    for m in _MEAS_RE.finditer(text):
-        try:
-            val = float(re.sub(r"[a-zA-Z]+$", "", m.group("value")))
-        except ValueError:
-            continue
-        entry: dict = {"expr": m.group("expr").strip(), "value": val}
-        if m.group("from"):
-            try:
-                entry["from"] = float(m.group("from"))
-            except ValueError:
-                pass
-        if m.group("to"):
-            try:
-                entry["to"] = float(m.group("to"))
-            except ValueError:
-                pass
-        measures[m.group("name")] = entry
-
-    errors = [m.group(0).strip() for m in _ERROR_RE.finditer(text)]
-    warnings = [m.group(0).strip() for m in _WARN_RE.finditer(text)]
-    elapsed: float | None = None
-    em = _ELAPSED_RE.search(text)
-    if em:
-        try:
-            elapsed = float(em.group(1))
-        except ValueError:
-            elapsed = None
-
-    return {
-        "measures": measures,
-        "errors": errors,
-        "warnings": warnings,
-        "elapsed_s": elapsed,
-    }
-
-
-def _raw_trace_names(raw_path: Path) -> list[str]:
-    """Return trace names from an LTspice .raw file.
-
-    Parses the UTF-16 LE header which contains ``Variables:`` / ``Binary:``
-    sections. No external dependency — the spec is well-understood and the
-    header format is stable across LTspice 17.x / 24.x / 26.x.
-    """
-    if not raw_path.is_file():
-        return []
-    head = raw_path.read_bytes()[:65536]
-    try:
-        text = head.decode("utf-16-le", errors="replace")
-    except Exception:
-        return []
-    # Header ends at 'Binary:' or 'Values:'
-    for sentinel in ("Binary:", "Values:"):
-        if sentinel in text:
-            text = text.split(sentinel, 1)[0]
-            break
-    if "Variables:" not in text:
-        return []
-    body = text.split("Variables:", 1)[1]
-    names: list[str] = []
-    for line in body.splitlines():
-        parts = line.strip().split()
-        # lines look like: "<idx>\t<name>\t<type>"
-        if len(parts) >= 2 and parts[0].isdigit():
-            names.append(parts[1])
-    return names
-
-
-# ---------------------------------------------------------------------------
-# Install discovery
-# ---------------------------------------------------------------------------
-
-def _macos_native_version(app_dir: Path) -> str | None:
-    """Read CFBundleShortVersionString from LTspice.app/Contents/Info.plist."""
-    info = app_dir / "Contents" / "Info.plist"
-    if not info.is_file():
-        return None
-    try:
-        # plutil is always present on macOS and handles both binary+xml plists.
-        proc = subprocess.run(
-            ["plutil", "-extract", "CFBundleShortVersionString",
-             "raw", "-o", "-", str(info)],
-            capture_output=True, text=True, timeout=5,
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return None
-    v = (proc.stdout or "").strip()
-    return v or None
-
-
-def _make_install(exe: Path, source: str) -> SolverInstall | None:
-    if not exe.is_file():
-        return None
-    version: str | None = None
-    app_dir: Path | None = None
-    if sys.platform == "darwin":
-        # exe sits at <...>.app/Contents/MacOS/LTspice
-        parent = exe.parent.parent.parent
-        if parent.suffix == ".app":
-            app_dir = parent
-            version = _macos_native_version(parent)
-    # Windows: try FileDescription via `wmic` is slow; skip — version stays None.
+def _install_to_solver(inst: Install) -> SolverInstall:
+    """Map ``sim_ltspice.Install`` → sim-cli ``SolverInstall``."""
     return SolverInstall(
         name="ltspice",
-        version=version or "unknown",
-        path=str(app_dir) if app_dir else str(exe.parent),
-        source=source,
-        extra={"exe": str(exe)},
+        version=inst.version or "unknown",
+        path=inst.path,
+        source=inst.source,
+        extra={"exe": str(inst.exe)},
     )
 
 
-def _candidates_macos() -> list[tuple[Path, str]]:
-    out: list[tuple[Path, str]] = []
-    for base in (
-        Path("/Applications/LTspice.app/Contents/MacOS/LTspice"),
-        Path.home() / "Applications/LTspice.app/Contents/MacOS/LTspice",
-    ):
-        if base.is_file():
-            out.append((base, "default-path:/Applications"))
+def _measures_to_dict(log) -> dict[str, dict]:
+    """Flatten ``sim_ltspice.LogResult.measures`` into sim-cli's JSON shape."""
+    out: dict[str, dict] = {}
+    for name, m in log.measures.items():
+        entry: dict = {"expr": m.expr, "value": m.value}
+        if m.window_from is not None:
+            entry["from"] = m.window_from
+        if m.window_to is not None:
+            entry["to"] = m.window_to
+        out[name] = entry
     return out
 
-
-def _candidates_windows() -> list[tuple[Path, str]]:
-    out: list[tuple[Path, str]] = []
-    user = os.environ.get("USERPROFILE", "")
-    win_candidates = [
-        (Path(r"C:\Program Files\ADI\LTspice\LTspice.exe"), "default-path:Program Files"),
-        (Path(r"C:\Program Files\LTC\LTspiceXVII\XVIIx64.exe"), "default-path:LTspiceXVII"),
-        (Path(r"C:\Program Files (x86)\LTC\LTspiceXVII\XVIIx64.exe"), "default-path:LTspiceXVII-x86"),
-        (Path(r"C:\Program Files (x86)\LTC\LTspiceIV\scad3.exe"), "default-path:LTspiceIV"),
-    ]
-    if user:
-        win_candidates.insert(
-            0,
-            (Path(user) / r"AppData\Local\Programs\ADI\LTspice\LTspice.exe",
-             "default-path:LocalAppData"),
-        )
-    for p, src in win_candidates:
-        if p.is_file():
-            out.append((p, src))
-    return out
-
-
-def _candidates_env() -> list[tuple[Path, str]]:
-    """$SIM_LTSPICE_EXE overrides everything else."""
-    override = os.environ.get("SIM_LTSPICE_EXE")
-    if not override:
-        return []
-    p = Path(override).expanduser()
-    if p.is_file():
-        return [(p, "env:SIM_LTSPICE_EXE")]
-    return []
-
-
-def _scan_installs() -> list[SolverInstall]:
-    finders = [_candidates_env]
-    if sys.platform == "darwin":
-        finders.append(_candidates_macos)
-    elif sys.platform == "win32":
-        finders.append(_candidates_windows)
-    # else: linux via wine is not auto-detected in v1; users can set SIM_LTSPICE_EXE.
-
-    found: dict[str, SolverInstall] = {}
-    for finder in finders:
-        try:
-            cands = finder()
-        except Exception:
-            continue
-        for path, source in cands:
-            inst = _make_install(path, source=source)
-            if inst is None:
-                continue
-            key = str(Path(inst.extra["exe"]).resolve())
-            found.setdefault(key, inst)
-    # Stable order: env override first, then platform default.
-    return list(found.values())
-
-
-# ---------------------------------------------------------------------------
-# Driver
-# ---------------------------------------------------------------------------
 
 class LTspiceDriver:
     """Sim driver for LTspice — one-shot batch execution.
 
     Sessions are not supported: LTspice exposes no Python API or stdin
-    protocol. Every invocation is a subprocess batch run.
+    protocol. Every invocation is a subprocess batch run routed through
+    ``sim_ltspice.run_net``.
     """
 
     @property
@@ -373,7 +153,7 @@ class LTspiceDriver:
         )
 
     def detect_installed(self) -> list[SolverInstall]:
-        return _scan_installs()
+        return [_install_to_solver(i) for i in find_ltspice()]
 
     def parse_output(self, stdout: str) -> dict:
         """Return the last JSON line written by run_file."""
@@ -392,44 +172,48 @@ class LTspiceDriver:
                 f"ltspice driver only accepts {NETLIST_SUFFIXES} "
                 f"(got {script.suffix})"
             )
-        installs = self.detect_installed()
-        if not installs:
+        # Mirror the driver-protocol contract: raise RuntimeError if
+        # nothing is installed, preserving the sim-cli error surface even
+        # though sim_ltspice raises its own LtspiceNotInstalled.
+        if not self.detect_installed():
             raise RuntimeError(
                 "LTspice is not installed; set SIM_LTSPICE_EXE or install it."
             )
-        exe = installs[0].extra["exe"]
 
-        script = script.resolve()
-        # Native macOS LTspice accepts only '-b <netlist>'. Windows/wine
-        # additionally accept '-Run' (same effect as -b here).
-        if sys.platform == "darwin":
-            cmd = [exe, "-b", script.as_posix()]
-        else:
-            cmd = [exe, "-Run", "-b", script.as_posix()]
+        try:
+            lt: LtRunResult = run_net(script)
+        except LtspiceNotInstalled as exc:
+            raise RuntimeError(str(exc)) from exc
+        except UnsupportedInput as exc:
+            raise RuntimeError(str(exc)) from exc
 
-        result = run_subprocess(cmd, script=script, solver=self.name)
-
-        # LTspice doesn't write to stdout on batch success; parse the sibling
-        # .log file for measurements + errors + warnings, then append a JSON
-        # summary so parse_output() can pick it up.
-        log_path = script.with_suffix(".log")
-        raw_path = script.with_suffix(".raw")
-        log_text = _read_log(log_path)
-        parsed = _parse_log(log_text) if log_text else {
-            "measures": {}, "errors": [], "warnings": [], "elapsed_s": None,
+        # Fold sim_ltspice's structured log + trace list into the JSON
+        # summary so parse_output() can pick it up from stdout.
+        parsed = {
+            "measures": _measures_to_dict(lt.log),
+            "errors": list(lt.log.errors),
+            "warnings": list(lt.log.warnings),
+            "elapsed_s": lt.log.elapsed_s,
+            "traces": list(lt.raw_traces),
+            "log": str(lt.log_path) if lt.log_path else None,
+            "raw": str(lt.raw_path) if lt.raw_path else None,
         }
-        parsed["traces"] = _raw_trace_names(raw_path)
-        parsed["log"] = str(log_path) if log_path.is_file() else None
-        parsed["raw"] = str(raw_path) if raw_path.is_file() else None
 
-        # If log reports errors, promote them into RunResult.errors and mark
-        # the run as failed even if LTspice's own exit code was 0.
-        log_errors = parsed["errors"]
-        if log_errors:
-            result.errors = list(result.errors) + [f"[log] {e}" for e in log_errors]
-            if result.exit_code == 0:
-                result.exit_code = 1
+        errors: list[str] = [f"[log] {e}" for e in lt.log.errors]
+        exit_code = lt.exit_code
+        if exit_code == 0 and errors:
+            exit_code = 1
 
         summary_json = json.dumps(parsed, separators=(",", ":"))
-        result.stdout = (result.stdout + "\n" + summary_json).strip()
-        return result
+        stdout = (lt.stdout + "\n" + summary_json).strip() if lt.stdout else summary_json
+
+        return RunResult(
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=lt.stderr,
+            duration_s=lt.duration_s,
+            script=str(Path(script).resolve()),
+            solver=self.name,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            errors=errors,
+        )

--- a/tests/drivers/ltspice/test_ltspice_driver.py
+++ b/tests/drivers/ltspice/test_ltspice_driver.py
@@ -1,4 +1,11 @@
-"""Tier 1 protocol-compliance tests for the LTspice driver."""
+"""Protocol-compliance tests for the LTspice driver.
+
+The driver itself is now a thin adapter over ``sim_ltspice``; heavy
+file-format testing (log parsing, raw header parsing, install discovery)
+lives in the sim-ltspice repo. These tests exercise only the adapter
+surface that sim-cli is responsible for: `detect`, `lint`, `connect`,
+`parse_output`, and the glue in `run_file`.
+"""
 from __future__ import annotations
 
 from pathlib import Path
@@ -7,7 +14,6 @@ import pytest
 
 from sim.driver import SolverInstall
 from sim.drivers.ltspice import LTspiceDriver
-from sim.drivers.ltspice.driver import _parse_log, _read_log
 
 FIXTURES = Path(__file__).parent.parent.parent / "fixtures"
 
@@ -89,6 +95,29 @@ class TestConnect:
         assert info.version == "17.2.4"
 
 
+class TestDetectInstalled:
+    def test_maps_sim_ltspice_install_to_solver(self, monkeypatch):
+        """detect_installed delegates to sim_ltspice.find_ltspice and maps the
+        Install dataclass to sim-cli's SolverInstall shape."""
+        from sim_ltspice.install import Install
+
+        fake = Install(
+            exe=Path("/fake/LTspice"),
+            version="26.0.1",
+            path="/fake",
+            source="env:SIM_LTSPICE_EXE",
+        )
+        monkeypatch.setattr(
+            "sim.drivers.ltspice.driver.find_ltspice", lambda: [fake]
+        )
+        [inst] = LTspiceDriver().detect_installed()
+        assert isinstance(inst, SolverInstall)
+        assert inst.name == "ltspice"
+        assert inst.version == "26.0.1"
+        assert inst.source == "env:SIM_LTSPICE_EXE"
+        assert inst.extra["exe"] == "/fake/LTspice"
+
+
 class TestParseOutput:
     def setup_method(self):
         self.driver = LTspiceDriver()
@@ -100,87 +129,6 @@ class TestParseOutput:
 
     def test_no_json(self):
         assert self.driver.parse_output("nope") == {}
-
-
-class TestLogParser:
-    """_parse_log is the core of output extraction — cover it directly."""
-
-    def test_measure_with_from_to(self):
-        log = (
-            "solver = Normal\n"
-            "vout_pk: MAX(v(out))=0.999955 FROM 0 TO 0.005\n"
-            "Total elapsed time: 0.003 seconds.\n"
-        )
-        out = _parse_log(log)
-        assert out["measures"]["vout_pk"]["value"] == pytest.approx(0.999955)
-        assert out["measures"]["vout_pk"]["from"] == 0.0
-        assert out["measures"]["vout_pk"]["to"] == 0.005
-        assert out["elapsed_s"] == pytest.approx(0.003)
-        assert out["errors"] == []
-        assert out["warnings"] == []
-
-    def test_measure_with_suffix_unit(self):
-        log = "gain: V(out)/V(in)=2.5V\n"
-        out = _parse_log(log)
-        # regex strips trailing letters before float conversion
-        assert out["measures"]["gain"]["value"] == 2.5
-
-    def test_errors_detected(self):
-        log = (
-            "Error: convergence failed at step 1\n"
-            "Singular matrix\n"
-            "Total elapsed time: 0.001 seconds.\n"
-        )
-        out = _parse_log(log)
-        assert len(out["errors"]) >= 1
-        assert any("conv" in e.lower() or "singular" in e.lower() for e in out["errors"])
-
-    def test_warnings_detected(self):
-        log = "WARNING: node N001 floating\nOK otherwise\n"
-        out = _parse_log(log)
-        assert len(out["warnings"]) == 1
-        assert "floating" in out["warnings"][0]
-
-    def test_windows_log_with_drive_letter_path(self):
-        """Windows LTspice 26 emits 'Files loaded:\\n<C:\\path>' — don't let
-        the `C:` drive letter masquerade as a measure name."""
-        log = (
-            "LTspice 26.0.1 for Windows\n"
-            "Files loaded:\n"
-            "C:\\Users\\jiwei\\tmp\\rc.net\n"
-            "\n"
-            "vout_pk: MAX(V(out))=0.999954938889 FROM 0 TO 0.005\n"
-            "Total elapsed time: 0.061 seconds.\n"
-        )
-        out = _parse_log(log)
-        assert list(out["measures"].keys()) == ["vout_pk"]
-        assert out["measures"]["vout_pk"]["value"] == pytest.approx(0.999955, rel=1e-4)
-        assert out["measures"]["vout_pk"]["expr"] == "MAX(V(out))"
-
-
-class TestReadLog:
-    """Both encodings seen in the wild — macOS 17.x is UTF-16 LE, Windows 26.x is UTF-8."""
-
-    def test_utf16_le_no_bom(self, tmp_path):
-        log = tmp_path / "mac.log"
-        text = "vout_pk: MAX(v(out))=0.999 FROM 0 TO 0.005\n"
-        log.write_bytes(text.encode("utf-16-le"))
-        assert "vout_pk" in _read_log(log)
-
-    def test_utf8_windows(self, tmp_path):
-        log = tmp_path / "win.log"
-        log.write_text(
-            "LTspice 26.0.1 for Windows\n"
-            "vout_pk: MAX(V(out))=0.999 FROM 0 TO 0.005\n",
-            encoding="utf-8",
-        )
-        assert "vout_pk" in _read_log(log)
-
-    def test_utf8_bom(self, tmp_path):
-        log = tmp_path / "bom.log"
-        log.write_bytes("\ufeffvout_pk: MAX(v(out))=1.0\n".encode("utf-8"))
-        out = _read_log(log)
-        assert out.startswith("vout_pk"), out
 
 
 class TestRunFile:
@@ -204,3 +152,83 @@ class TestRunFile:
         monkeypatch.setattr(d, "detect_installed", lambda: [])
         with pytest.raises(RuntimeError, match="(?i)ltspice"):
             d.run_file(FIXTURES / "ltspice_good.net")
+
+    def test_folds_sim_ltspice_result_into_json_summary(self, monkeypatch):
+        """run_file translates sim_ltspice.RunResult into a sim-cli RunResult
+        with the JSON summary appended to stdout."""
+        from sim_ltspice import RunResult as LtRunResult
+        from sim_ltspice.log import LogResult, Measure
+
+        d = LTspiceDriver()
+        monkeypatch.setattr(
+            d, "detect_installed",
+            lambda: [SolverInstall(
+                name="ltspice", version="17.2.4", path="/x", source="test",
+                extra={"exe": "/x/LTspice"},
+            )],
+        )
+
+        script = FIXTURES / "ltspice_good.net"
+        log_path = script.with_suffix(".log")
+        raw_path = script.with_suffix(".raw")
+
+        fake_log = LogResult(
+            measures={
+                "vout_pk": Measure(expr="MAX(V(out))", value=0.999955,
+                                   window_from=0.0, window_to=0.005)
+            },
+            errors=[],
+            warnings=["WARNING: node N001 floating"],
+            elapsed_s=0.003,
+        )
+        fake_lt = LtRunResult(
+            exit_code=0, stdout="", stderr="",
+            duration_s=0.12, script=script, started_at="",
+            log=fake_log,
+            log_path=log_path, raw_path=raw_path,
+            raw_traces=["time", "V(out)", "V(in)"],
+        )
+        monkeypatch.setattr(
+            "sim.drivers.ltspice.driver.run_net", lambda _s: fake_lt
+        )
+
+        result = d.run_file(script)
+        assert result.exit_code == 0
+        parsed = d.parse_output(result.stdout)
+        assert parsed["measures"]["vout_pk"]["value"] == pytest.approx(0.999955)
+        assert parsed["measures"]["vout_pk"]["from"] == 0.0
+        assert parsed["measures"]["vout_pk"]["to"] == 0.005
+        assert parsed["traces"] == ["time", "V(out)", "V(in)"]
+        assert parsed["warnings"] == ["WARNING: node N001 floating"]
+        assert parsed["log"] == str(log_path)
+        assert parsed["raw"] == str(raw_path)
+
+    def test_log_errors_promote_exit_code(self, monkeypatch):
+        """Errors found in the .log file force exit_code != 0 even when
+        LTspice itself exited cleanly."""
+        from sim_ltspice import RunResult as LtRunResult
+        from sim_ltspice.log import LogResult
+
+        d = LTspiceDriver()
+        monkeypatch.setattr(
+            d, "detect_installed",
+            lambda: [SolverInstall(
+                name="ltspice", version="17.2.4", path="/x", source="test",
+                extra={"exe": "/x/LTspice"},
+            )],
+        )
+        fake_log = LogResult(
+            errors=["Error: convergence failed"],
+        )
+        script = FIXTURES / "ltspice_good.net"
+        fake_lt = LtRunResult(
+            exit_code=0, stdout="", stderr="",
+            duration_s=0.01, script=script, started_at="",
+            log=fake_log, log_path=None, raw_path=None, raw_traces=[],
+        )
+        monkeypatch.setattr(
+            "sim.drivers.ltspice.driver.run_net", lambda _s: fake_lt
+        )
+        result = d.run_file(script)
+        assert result.exit_code == 1
+        assert any("convergence" in e.lower() for e in result.errors)

--- a/uv.lock
+++ b/uv.lock
@@ -1922,6 +1922,7 @@ dependencies = [
     { name = "lxml" },
     { name = "pillow" },
     { name = "pyyaml" },
+    { name = "sim-ltspice" },
     { name = "uvicorn" },
 ]
 
@@ -1957,9 +1958,19 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+    { name = "sim-ltspice", specifier = ">=0.1" },
     { name = "uvicorn", specifier = ">=0.34" },
 ]
 provides-extras = ["fluent", "matlab", "comsol", "pybamm", "dev"]
+
+[[package]]
+name = "sim-ltspice"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/c1/0692f2db98e72d7174419d2803a6bb5fd9f8a7ff434a856d930fa908ffb8/sim_ltspice-0.1.0.tar.gz", hash = "sha256:9f60fec0e9abc728ff2cc48e8896e24dd01c8524fb4cdb9fa4343e2d12a7ba78", size = 48466 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/a6/a8023441aa5b88d84a25cd9ad1df71af779ad4c9994aad06bc69d08f3bd9/sim_ltspice-0.1.0-py3-none-any.whl", hash = "sha256:1b64a244683f0ba40f83e0883ad2a49507da04dc74661d7e6b6e168e67ce2450", size = 32138 },
+]
 
 [[package]]
 name = "six"


### PR DESCRIPTION
## Summary

Completes **Stage 3** of the [LTspice portfolio plan](https://github.com/svd-ai-lab/sim-ltspice): sim-cli's LTspice driver is now a ~220-line adapter over the standalone [\`sim-ltspice\`](https://pypi.org/project/sim-ltspice/) package on PyPI. Heavy file-format code moved out of sim-cli.

## Before / after

- Driver: **436 → 219 LOC** (-50 %). All file-format logic (log encoding, raw header parser, install discovery, subprocess glue) now lives in \`sim_ltspice\`.
- Tests shrink to protocol-surface coverage plus mocking \`sim_ltspice.*\` for the \`run_file\` fold. Heavy file-format tests now live in the sim-ltspice repo.
- Net diff: -374 lines / +198 lines across driver + tests.

## What moves to sim_ltspice

| Old in-tree symbol | New home |
|---|---|
| \`_read_log\`, \`_parse_log\` | \`sim_ltspice.log\` |
| \`_raw_trace_names\` | \`sim_ltspice.raw\` |
| \`_candidates_*\`, \`_make_install\`, \`_scan_installs\` | \`sim_ltspice.install\` |
| \`run_file\`'s subprocess invocation | \`sim_ltspice.runner.run_net\` |

## What stays in the driver

- \`detect\`, \`lint\` (sim-cli-specific netlist lint)
- \`connect\`, \`parse_output\` (sim-cli DriverProtocol idioms)
- \`run_file\` folds \`sim_ltspice.RunResult\` back into sim-cli's JSON-tail stdout contract so every downstream consumer is unchanged

## Dependency

Adds \`sim-ltspice>=0.1\` to core dependencies.

## Test plan

- [x] \`uv run pytest tests/drivers/ltspice/ -v\` → **20/20 green** on macOS (19 unit + 1 real-LTspice e2e). E2E runs \`rc.net\` through installed LTspice, asserts \`vout_pk ≈ 1.0\` and \`V(out)\` appears in trace list — same gate as before Stage 3.
- [x] \`uv run pytest -q\` → 767 pass, 3 pre-existing failures in \`tests/drivers/workbench/\` (unrelated to this PR; same failures on main).
- [ ] Verify on win1 (\`sim --host 100.90.110.79 run <net>\`) once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)