### PR TITLE
test(ltspice): portable Path assertion for Windows

### DIFF
--- a/tests/drivers/ltspice/test_ltspice_driver.py
+++ b/tests/drivers/ltspice/test_ltspice_driver.py
@@ -101,8 +101,9 @@ class TestDetectInstalled:
         Install dataclass to sim-cli's SolverInstall shape."""
         from sim_ltspice.install import Install
 
+        fake_exe = Path("/fake/LTspice")
         fake = Install(
-            exe=Path("/fake/LTspice"),
+            exe=fake_exe,
             version="26.0.1",
             path="/fake",
             source="env:SIM_LTSPICE_EXE",
@@ -115,7 +116,8 @@ class TestDetectInstalled:
         assert inst.name == "ltspice"
         assert inst.version == "26.0.1"
         assert inst.source == "env:SIM_LTSPICE_EXE"
-        assert inst.extra["exe"] == "/fake/LTspice"
+        # str(Path(...)) emits OS-native separators — compare portably
+        assert inst.extra["exe"] == str(fake_exe)
 
 
 class TestParseOutput:


### PR DESCRIPTION
## Summary
- `TestDetectInstalled::test_maps_sim_ltspice_install_to_solver` hardcoded `"/fake/LTspice"` for the mapped `exe` string.
- On Windows, `str(Path("/fake/LTspice"))` emits `"\\fake\\LTspice"` — driver behaves correctly, test was wrong.
- Now compares against `str(fake_exe)` so the expected string is OS-native.

## Context
Found while verifying the new thin adapter (merged in #23) against real LTspice on win1. Driver + sim_ltspice delegation are correct — this is a test-only fix.

## Test plan
- [x] `uv run --extra dev pytest tests/drivers/ltspice/test_ltspice_driver.py` — 19/19 on macOS
- [ ] Same on win1 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)