### PR TITLE
deps: bump sim-ltspice to >=0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pyyaml>=6.0", # reads driver compatibility.yaml files
     "Pillow>=10", # sim screenshot endpoint uses PIL.ImageGrab
     "lxml>=5.0", # XSD validation for FloSCRIPT lint
-    "sim-ltspice>=0.1", # LTspice file formats + runtime — sim-cli's LTspice driver delegates here
+    "sim-ltspice>=0.2", # LTspice file formats + runtime — sim-cli's LTspice driver delegates here
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1958,18 +1958,22 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
-    { name = "sim-ltspice", specifier = ">=0.1" },
+    { name = "sim-ltspice", specifier = ">=0.2" },
     { name = "uvicorn", specifier = ">=0.34" },
 ]
 provides-extras = ["fluent", "matlab", "comsol", "pybamm", "dev"]
 
 [[package]]
 name = "sim-ltspice"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/c1/0692f2db98e72d7174419d2803a6bb5fd9f8a7ff434a856d930fa908ffb8/sim_ltspice-0.1.0.tar.gz", hash = "sha256:9f60fec0e9abc728ff2cc48e8896e24dd01c8524fb4cdb9fa4343e2d12a7ba78", size = 48466 }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/52/73416f7afa64c579f6c41e813746219dd5f882f811fc322eac493cb6cf63/sim_ltspice-0.2.0.tar.gz", hash = "sha256:868dbe4f45bb3c292e1698943c6f2de1ac4ffe8c3b642864b41789b70f0475b1", size = 171494 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/a6/a8023441aa5b88d84a25cd9ad1df71af779ad4c9994aad06bc69d08f3bd9/sim_ltspice-0.1.0-py3-none-any.whl", hash = "sha256:1b64a244683f0ba40f83e0883ad2a49507da04dc74661d7e6b6e168e67ce2450", size = 32138 },
+    { url = "https://files.pythonhosted.org/packages/06/34/8c5630f602c682ec5a3fad07ae794a882652fcb5f1f148dfc909661d241f/sim_ltspice-0.2.0-py3-none-any.whl", hash = "sha256:14d5c459ec246546005d82473a82a9c7c2d1db3e14a6c5d89769056ffc8424da", size = 42838 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bump the pinned floor on `sim-ltspice` from `>=0.1` to `>=0.2`. sim-cli's LTspice driver is a thin adapter — the new 0.2.0 surface lands on the caller side automatically.

What 0.2.0 brings that callers can now use through the driver:

- `RawRead` — full binary + ASCII `.raw` parser (real/double/complex layouts).
- Cursor helpers: `.max`, `.min`, `.mean`, `.rms`, `.sample_at`.
- `RawRead.eval("V(out)-V(in)")` — AST-whitelisted expression evaluator.
- `RawRead.to_csv` / `.to_dataframe` (DataFrame gated on `[dataframe]` extra).
- `sim_ltspice.diff.diff(a, b)` — two-run regression helper with `.ok` + per-trace `TraceDiff`.
- **Fix (Windows):** `run_net` enforces a default 300 s subprocess timeout with `exit_code=124` on hang — addresses the session-0 indefinite-wait that was blocking CI for ~20 minutes.

## Test plan

- [x] `uv lock` regenerated cleanly: `Updated sim-ltspice v0.1.0 -> v0.2.0`.
- [x] `uv run --extra dev pytest tests/drivers/ltspice/ -q` → 20 passed.
- [x] Broader sweep (`pytest --ignore=fluent/matlab/comsol`) → 745 passed, 3 failures pre-existing in the Workbench driver (confirmed via `git stash` bisect; unrelated to this bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)