### PR TITLE
feat(server): multi-session support via X-Sim-Session header (#26, rebased)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,17 +54,18 @@ Click app with subcommands: `serve`, `check`, `lint`, `run`, `connect`, `exec`, 
 
 ### HTTP server (`src/sim/server.py`)
 FastAPI app exposing:
-- `POST /connect` — launch a solver, hold session in module-level `_state`
-- `POST /exec` — `exec()` a Python snippet against the live `session`/`meshing`/`solver` namespace, capture stdout/stderr/return value, append to `_state.runs`
-- `GET /inspect/<name>` — query `session.summary`, `session.mode`, `last.result`, `workflow.summary`
+- `POST /connect` — launch a solver, register a new session in `_sessions: dict[str, SessionState]` keyed by session_id
+- `POST /exec` — `exec()` a Python snippet against the live `session`/`meshing`/`solver` namespace for the session selected by `X-Sim-Session` header (or the single live session if unambiguous); capture stdout/stderr/return value, append to that session's runs
+- `GET /inspect/<name>` — query `session.summary`, `session.mode`, `last.result`, `workflow.summary` (session-scoped)
 - `POST /run` — one-shot script execution (no session required)
-- `GET /ps` — current session status
+- `GET /ps` — list of all live sessions + default_session (set only when exactly one live)
 - `GET /screenshot` — base64 PNG of the server's desktop
-- `POST /disconnect` — tear down the session
+- `POST /disconnect` — tear down the session selected by `X-Sim-Session` (or the sole live session)
+- `POST /shutdown` — tear down all sessions, exit the server process
 
-The server keeps a single global `_state: SessionState` (one session per server process).
+The server supports multiple concurrent sessions keyed by session_id. Each `SessionState` carries its own `threading.Lock` so exec/inspect against different sessions can run in parallel. A single solver name can only be live once (driver instances are module-level singletons).
 
-**`sim serve --reload` drops the session on any source change under the watched tree.** uvicorn's reload watchdog observes file mtimes in `src/sim/**`; any edit (git pull, scp of a modified driver, even touching an unrelated module) restarts the worker, wiping `_state`. Child solver processes (Flotherm GUI, Fluent, etc.) survive the reload because they're spawned separately, but the session handle to them is gone — you have to `connect` again. Driver temp files (written to the solver's workspace, e.g. `flouser/_sim_*.xml`) live outside `src/` so they don't retrigger. Practical rules:
+**`sim serve --reload` drops all sessions on any source change under the watched tree.** uvicorn's reload watchdog observes file mtimes in `src/sim/**`; any edit (git pull, scp of a modified driver, even touching an unrelated module) restarts the worker, wiping `_sessions`. Child solver processes (Flotherm GUI, Fluent, etc.) survive the reload because they're spawned separately, but the session handles to them are gone — you have to `connect` again. Driver temp files (written to the solver's workspace, e.g. `flouser/_sim_*.xml`) live outside `src/` so they don't retrigger. Practical rules:
 
 - Don't edit driver code mid-experiment; finish the run, then edit.
 - For long autonomous experiments where you're editing driver code iteratively, launch **without** `--reload` and restart manually when you want the new code picked up.
@@ -117,10 +118,12 @@ LS-DYNA is a special case: the *solver* is one-shot (no live process to connect 
 4. `sim logs <id>` reads back via `history.get_by_id`; `sim logs --solver X --all` filters
 
 ### Execution pipeline — persistent session (`exec`)
-1. `cli.connect` → HTTP `POST /connect` to server → `driver.launch(...)` → `_state.session` populated
-2. `cli.exec` → HTTP `POST /exec` with code → server `_execute_snippet()` runs `exec(code, namespace)` where `namespace` has `session`, `meshing`/`solver`, `_result`
-3. `cli.inspect <name>` → HTTP `GET /inspect/<name>` → driver- or session-specific query
-4. `cli.disconnect` → HTTP `POST /disconnect` → driver-specific teardown, clear `_state`
+1. `cli.connect` → HTTP `POST /connect` to server → `driver.launch(...)` → new `SessionState` added to `_sessions`; response carries the session_id which the client stores
+2. `cli.exec` → HTTP `POST /exec` with code + `X-Sim-Session: <id>` → server routes to that session, then `_execute_snippet()` runs `exec(code, namespace)` where `namespace` has `session`, `meshing`/`solver`, `_result`
+3. `cli.inspect <name>` → HTTP `GET /inspect/<name>` (session-scoped) → driver- or session-specific query
+4. `cli.disconnect` → HTTP `POST /disconnect` (session-scoped) → driver-specific teardown, remove from `_sessions`
+
+Session routing rules: an explicit `X-Sim-Session` header wins (404 if unknown); otherwise the server falls back to the sole live session; otherwise `/exec` returns 400. Clients can also set `SIM_SESSION` env var or pass `sim --session <id> ...` to scope a whole CLI invocation.
 
 ## Adding a new driver
 
@@ -193,6 +196,6 @@ Tests that need a real solver are gated by import-availability flags (e.g. `HAS_
 ## Notes
 
 - Global run history lives in `~/.sim/history.jsonl` (append-only; override dir via `SIM_HOME`); git-ignored
-- The server holds **one** session at a time (single global `_state`) — multi-tenant is not yet implemented
+- The server supports multiple concurrent sessions keyed by `X-Sim-Session` header; a solver name can only be live once per server process (driver instances are module-level singletons)
 - Project uses `uv` for dependency locking (`uv.lock`)
 - Companion knowledge / skills / workflows live in the sibling `sim-skills/` tree, one folder per solver

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -23,8 +23,11 @@ from sim.runner import execute_script
                    "Default: SIM_HOST env > config [server].host > localhost.")
 @click.option("--port", default=None, type=int,
               help="sim-server port. Default: SIM_PORT env > config [server].port > 7600.")
+@click.option("--session", "session_id", default=None,
+              help="Target session id (multi-session). "
+                   "Default: SIM_SESSION env > server's sole session.")
 @click.pass_context
-def main(ctx, output_json, host, port):
+def main(ctx, output_json, host, port, session_id):
     """sim — unified CLI for LLM agents to control CAD/CAE simulation software."""
     ctx.ensure_object(dict)
     ctx.obj["json"] = output_json
@@ -35,6 +38,7 @@ def main(ctx, output_json, host, port):
     # user explicitly asked.
     ctx.obj["host"] = host or os.environ.get("SIM_HOST") or "localhost"
     ctx.obj["port"] = port if port is not None else _cfg.resolve_server_port()
+    ctx.obj["session"] = session_id or os.environ.get("SIM_SESSION") or None
 
 
 # ── serve ────────────────────────────────────────────────────────────────────
@@ -366,7 +370,8 @@ def connect(ctx, solver, mode, ui_mode, processors):
     """Launch a solver and hold a persistent session."""
     from sim.session import SessionClient
 
-    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"])
+    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"],
+                           session_id=ctx.obj.get("session"))
     result = client.connect(
         solver=solver,
         mode=mode,
@@ -378,9 +383,12 @@ def connect(ctx, solver, mode, ui_mode, processors):
         click.echo(json_mod.dumps(result, indent=2, default=str))
     else:
         if result.get("ok"):
-            click.echo("[sim] connect: session ready")
-            if result.get("data"):
-                click.echo(json_mod.dumps(result["data"], indent=4, default=str))
+            data = result.get("data") or {}
+            sid = data.get("session_id", "?")
+            click.echo(f"[sim] connect: session ready (id={sid})")
+            click.echo(f"[sim] hint: use `sim --session {sid} ...` or set SIM_SESSION={sid}")
+            if data:
+                click.echo(json_mod.dumps(data, indent=4, default=str))
         else:
             click.echo(f"[sim] connect: failed - {result.get('error', 'unknown')}", err=True)
             sys.exit(1)
@@ -402,7 +410,8 @@ def exec_cmd(ctx, code, code_file, label):
         sys.exit(1)
 
     from sim.session import SessionClient
-    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"])
+    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"],
+                           session_id=ctx.obj.get("session"))
     result = client.run(code=code, label=label)
 
     if ctx.obj["json"]:
@@ -444,7 +453,8 @@ def inspect(ctx, name):
       ...
     """
     from sim.session import SessionClient
-    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"])
+    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"],
+                           session_id=ctx.obj.get("session"))
     result = client.query(name=name)
 
     if ctx.obj["json"]:
@@ -462,18 +472,39 @@ def inspect(ctx, name):
 @main.command()
 @click.pass_context
 def ps(ctx):
-    """List active sessions."""
+    """List active sessions.
+
+    Shape: {sessions: [...], default_session, server_pid}. The 'default'
+    session is the one that applies to per-session calls when neither
+    --session nor X-Sim-Session is set.
+    """
     from sim.session import SessionClient
-    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"])
+    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"],
+                           session_id=ctx.obj.get("session"))
     result = client.status()
 
     if ctx.obj["json"]:
         click.echo(json_mod.dumps(result, indent=2, default=str))
-    else:
-        if result.get("connected"):
-            click.echo(json_mod.dumps(result, indent=2, default=str))
-        else:
-            click.echo("[sim] no active session")
+        return
+
+    # Server may be unreachable (no 'sessions' key when an error dict is returned).
+    if "sessions" not in result:
+        click.echo(f"[sim] ps: {result.get('error', 'unreachable')}", err=True)
+        sys.exit(1)
+
+    sessions = result.get("sessions") or []
+    default = result.get("default_session")
+    if not sessions:
+        click.echo("[sim] no active sessions")
+        return
+    click.echo(f"[sim] {len(sessions)} session(s) — default: {default or '(none; set --session)'}")
+    for s in sessions:
+        marker = "*" if s["session_id"] == default else " "
+        click.echo(
+            f"  {marker} {s['session_id']:<10}  {s['solver']:<10}  "
+            f"mode={s.get('mode','-')}  ui={s.get('ui_mode','-')}  "
+            f"runs={s.get('run_count', 0)}  profile={s.get('profile') or '-'}"
+        )
 
 
 # ── disconnect ───────────────────────────────────────────────────────────────
@@ -495,7 +526,8 @@ def disconnect(ctx, stop_server):
     on its own).
     """
     from sim.session import SessionClient
-    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"])
+    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"],
+                           session_id=ctx.obj.get("session"))
     result = client.disconnect()
 
     if stop_server:
@@ -539,7 +571,8 @@ def stop(ctx):
     to call `sim disconnect` first.
     """
     from sim.session import SessionClient
-    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"])
+    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"],
+                           session_id=ctx.obj.get("session"))
     result = client.stop()
 
     if ctx.obj["json"]:
@@ -568,7 +601,8 @@ def screenshot(ctx, output):
     from pathlib import Path
 
     from sim.session import SessionClient
-    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"])
+    client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"],
+                           session_id=ctx.obj.get("session"))
     result = client.screenshot()
 
     if not result.get("ok"):

--- a/src/sim/server.py
+++ b/src/sim/server.py
@@ -1,4 +1,4 @@
-"""sim serve — HTTP server that holds a live simulation session.
+"""sim serve — HTTP server that holds one or more live simulation sessions.
 
 Like `ollama serve`: start once, then use `sim connect/exec/inspect/disconnect`.
 
@@ -6,26 +6,37 @@ Like `ollama serve`: start once, then use `sim connect/exec/inspect/disconnect`.
     sim serve --host 0.0.0.0           # expose on network (Tailscale)
     sim serve --host 0.0.0.0 --port 8000
 
+Multi-session model (issue #26):
+
+Each `/connect` opens an independent session with a fresh `session_id`.
+Subsequent per-session calls route by the `X-Sim-Session` header. When
+only one session is live, the header is optional — the server picks the
+sole session as default. With two or more sessions live and no header,
+per-session endpoints return 400. See
+`docs/architecture/multi-session-and-config.md` for the full contract.
+
 Endpoints:
-    POST /connect     {solver, mode, ui_mode, processors}
-    POST /exec        {code, label}
-    POST /run         {script, solver}  — one-shot, no session needed
-    GET  /inspect/<name>
-    GET  /ps
-    POST /disconnect
-    POST /shutdown
+    POST /connect     {solver, mode, ui_mode, processors}     → header-less
+    POST /exec        {code, label}                           → header-routed
+    POST /run         {script, solver}                        → header-less (one-shot)
+    GET  /inspect/<name>                                      → header-routed
+    GET  /ps                                                  → header-less (lists all)
+    GET  /screenshot                                          → header-less (global)
+    POST /disconnect                                          → header-routed
+    POST /shutdown                                            → header-less (tears down all)
 """
 from __future__ import annotations
 
 import io
 import math
 import os
+import threading
 import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
-from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
+from fastapi import BackgroundTasks, FastAPI, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -55,7 +66,7 @@ class _NaNSafeJSONResponse(JSONResponse):
         return super().render(_sanitize_for_json(content))
 
 
-app = FastAPI(title="sim", version="0.1.0", default_response_class=_NaNSafeJSONResponse)
+app = FastAPI(title="sim", version="0.2.0", default_response_class=_NaNSafeJSONResponse)
 
 
 # ── Request models ───────────────────────────────────────────────────────────
@@ -81,18 +92,66 @@ class RunRequest(BaseModel):
 
 @dataclass
 class SessionState:
-    session_id: str | None = None
-    solver: str | None = None
+    session_id: str
+    solver: str
     mode: str | None = None
     ui_mode: str | None = None
+    processors: int = 1
     connected_at: float | None = None
     run_count: int = 0
     driver: Any = None
     runs: list[dict] = field(default_factory=list)
-    profile: str | None = None       # resolved profile name (label only)
+    profile: str | None = None
+    lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
 
-_state = SessionState()
+# Module-level multi-session registry. Two independent locks: `_sessions_lock`
+# for dict mutations (add/remove/iter), per-session `.lock` for body-of-work
+# serialization (exec calls on the same driver).
+_sessions: dict[str, SessionState] = {}
+_sessions_lock = threading.Lock()
+
+
+# ── Session selector ─────────────────────────────────────────────────────────
+
+
+def _select_session(header_val: str | None) -> SessionState:
+    """Resolve the target session from header + default-picking rules.
+
+    Rules (design note §6):
+      1. If header is set, use it. 404 on unknown id.
+      2. Else if exactly one session live, pick it.
+      3. Else 400 with a helpful message.
+    """
+    with _sessions_lock:
+        if header_val:
+            s = _sessions.get(header_val)
+            if s is None:
+                raise HTTPException(404, f"unknown session_id: {header_val}")
+            return s
+        if len(_sessions) == 1:
+            return next(iter(_sessions.values()))
+        if not _sessions:
+            raise HTTPException(400, "no active sessions — POST /connect first")
+        raise HTTPException(
+            400,
+            f"{len(_sessions)} sessions live; set X-Sim-Session header or use `sim --session <id>`",
+        )
+
+
+def _register_session(state: SessionState) -> None:
+    with _sessions_lock:
+        _sessions[state.session_id] = state
+
+
+def _drop_session(session_id: str) -> SessionState | None:
+    with _sessions_lock:
+        return _sessions.pop(session_id, None)
+
+
+def _list_sessions() -> list[SessionState]:
+    with _sessions_lock:
+        return list(_sessions.values())
 
 
 # ── Endpoints ────────────────────────────────────────────────────────────────
@@ -153,10 +212,6 @@ def detect_solver(solver: str):
     }
 
 
-def _have_active_session() -> bool:
-    return _state.driver is not None and _state.session_id is not None
-
-
 def _resolve_profile(driver, solver: str):
     """Best-effort lookup of which compat.yaml profile applies to the
     detected install. Returns the Profile, or None on miss / failure.
@@ -181,7 +236,7 @@ def _resolve_profile(driver, solver: str):
 
 @app.post("/connect")
 def connect(req: ConnectRequest):
-    """Open a solver session.
+    """Open a solver session. Multi-session: never conflicts with an existing one.
 
     sim-cli runs every driver in its own process — the same Python that
     runs sim serve also imports the SDK directly. There is no subprocess
@@ -190,9 +245,6 @@ def connect(req: ConnectRequest):
     can know which compat.yaml entry is in effect.
     """
     from sim.drivers import get_driver
-
-    if _have_active_session():
-        raise HTTPException(400, "session already active — POST /disconnect first")
 
     driver = get_driver(req.solver)
     if driver is None:
@@ -204,6 +256,20 @@ def connect(req: ConnectRequest):
             f"{req.solver} does not support persistent sessions. "
             "Use POST /run for one-shot execution.",
         )
+
+    # Single-driver-instance limitation: the current `DriverProtocol`
+    # classes are module-level singletons, so holding two concurrent
+    # sessions on the *same* driver class would alias driver internal
+    # state. Multi-solver parallelism (fluent + mechanical) is the
+    # supported case; two fluent sessions is not yet.
+    with _sessions_lock:
+        for s in _sessions.values():
+            if s.solver == req.solver:
+                raise HTTPException(
+                    400,
+                    f"a {req.solver} session is already live (id={s.session_id}); "
+                    "two concurrent sessions on the same driver aren't supported yet",
+                )
 
     try:
         info = driver.launch(
@@ -219,15 +285,20 @@ def connect(req: ConnectRequest):
     from sim.compat import skills_block_for_profile
     profile = _resolve_profile(driver, req.solver)
 
-    _state.session_id = info.get("session_id", str(uuid.uuid4()))
-    _state.solver = req.solver
-    _state.mode = req.mode
-    _state.ui_mode = req.ui_mode
-    _state.connected_at = time.time()
-    _state.run_count = 0
-    _state.driver = driver
-    _state.runs = []
-    _state.profile = profile.name if profile else None
+    sid = info.get("session_id") or f"s-{uuid.uuid4().hex[:8]}"
+    state = SessionState(
+        session_id=sid,
+        solver=req.solver,
+        mode=req.mode,
+        ui_mode=req.ui_mode,
+        processors=req.processors,
+        connected_at=time.time(),
+        run_count=0,
+        driver=driver,
+        runs=[],
+        profile=profile.name if profile else None,
+    )
+    _register_session(state)
 
     # Tool advertisement (Phase 3). Tells the agent which cross-driver
     # actuation objects are live in the exec namespace for this session,
@@ -243,13 +314,13 @@ def connect(req: ConnectRequest):
     return {
         "ok": True,
         "data": {
-            "session_id": _state.session_id,
+            "session_id": state.session_id,
             "solver": req.solver,
-            "mode": _state.mode,
-            "ui_mode": _state.ui_mode,
-            "connected_at": _state.connected_at,
+            "mode": state.mode,
+            "ui_mode": state.ui_mode,
+            "connected_at": state.connected_at,
             "run_count": 0,
-            "profile": _state.profile,
+            "profile": state.profile,
             "skills": skills_block_for_profile(req.solver, profile),
             "tools": tools,
             "tool_refs": tool_refs,
@@ -258,15 +329,18 @@ def connect(req: ConnectRequest):
 
 
 @app.post("/exec")
-def exec_snippet(req: ExecRequest):
-    if not _have_active_session():
-        raise HTTPException(400, "no active session — POST /connect first")
-
-    result = _state.driver.run(req.code, req.label)
-    result.setdefault("session_id", _state.session_id)
-    result.setdefault("started_at", time.time())
-    _state.runs.append(result)
-    _state.run_count += 1
+def exec_snippet(
+    req: ExecRequest,
+    x_sim_session: str | None = Header(default=None, alias="X-Sim-Session"),
+):
+    state = _select_session(x_sim_session)
+    # Serialize calls on the same session; different sessions run in parallel.
+    with state.lock:
+        result = state.driver.run(req.code, req.label)
+        result.setdefault("session_id", state.session_id)
+        result.setdefault("started_at", time.time())
+        state.runs.append(result)
+        state.run_count += 1
     return {"ok": result.get("ok", True), "data": result}
 
 
@@ -299,28 +373,30 @@ def run_script(req: RunRequest):
 
 
 @app.get("/inspect/{name}")
-def inspect(name: str):
-    if not _have_active_session():
-        raise HTTPException(400, "no active session")
+def inspect(
+    name: str,
+    x_sim_session: str | None = Header(default=None, alias="X-Sim-Session"),
+):
+    state = _select_session(x_sim_session)
 
     if name == "session.summary":
         return {
             "ok": True,
             "data": {
-                "session_id": _state.session_id,
-                "solver": _state.solver,
-                "mode": _state.mode,
-                "ui_mode": _state.ui_mode,
-                "connected_at": _state.connected_at,
-                "run_count": _state.run_count,
-                "profile": _state.profile,
+                "session_id": state.session_id,
+                "solver": state.solver,
+                "mode": state.mode,
+                "ui_mode": state.ui_mode,
+                "connected_at": state.connected_at,
+                "run_count": state.run_count,
+                "profile": state.profile,
                 "connected": True,
             },
         }
     if name == "last.result":
-        if not _state.runs:
+        if not state.runs:
             return {"ok": True, "data": {"has_last_run": False}}
-        last = _state.runs[-1]
+        last = state.runs[-1]
         return {
             "ok": True,
             "data": {
@@ -330,7 +406,7 @@ def inspect(name: str):
         }
     # Fallback: ask the active driver to handle driver-specific inspect targets
     # (e.g. ls_dyna's deck.summary, mechanical.project_directory)
-    driver = _state.driver
+    driver = state.driver
     if driver is not None and hasattr(driver, "query"):
         try:
             result = driver.query(name)
@@ -345,23 +421,39 @@ def inspect(name: str):
 
 @app.get("/ps")
 def ps():
-    if not _have_active_session():
-        return {"connected": False}
+    """List all active sessions (new multi-session shape).
+
+    With no sessions: `{sessions: [], default_session: null}`.
+    With one or more: `{sessions: [...], default_session: <id>}`.
+    """
+    sessions = _list_sessions()
+    rows = [
+        {
+            "session_id": s.session_id,
+            "solver": s.solver,
+            "mode": s.mode,
+            "ui_mode": s.ui_mode,
+            "processors": s.processors,
+            "connected_at": s.connected_at,
+            "run_count": s.run_count,
+            "profile": s.profile,
+        }
+        for s in sessions
+    ]
+    default = sessions[0].session_id if len(sessions) == 1 else None
     return {
-        "connected": True,
-        "session_id": _state.session_id,
-        "solver": _state.solver,
-        "mode": _state.mode,
-        "ui_mode": _state.ui_mode,
-        "connected_at": _state.connected_at,
-        "run_count": _state.run_count,
-        "profile": _state.profile,
+        "sessions": rows,
+        "default_session": default,
+        "server_pid": os.getpid(),
     }
 
 
 @app.get("/screenshot")
 def screenshot():
-    """Capture the server's desktop and return as PNG."""
+    """Capture the server's desktop and return as PNG.
+
+    Not session-scoped — there's one physical desktop per server host.
+    """
     import base64
 
     try:
@@ -385,40 +477,32 @@ def screenshot():
     }
 
 
-def _teardown_active_session() -> str | None:
-    """Best-effort: tear down whatever session is currently held.
-
-    Reused by /disconnect and /shutdown. Returns the session id that was
-    torn down, or None if there was no active session.
-    """
-    if not _have_active_session():
+def _teardown_session(session_id: str) -> str | None:
+    """Best-effort: tear down one session by id. Returns the id torn down, or None."""
+    state = _drop_session(session_id)
+    if state is None:
         return None
-
-    sid = _state.session_id
-
-    if _state.driver is not None:
+    if state.driver is not None:
         try:
-            _state.driver.disconnect()
+            state.driver.disconnect()
         except Exception:
             pass
+    return state.session_id
 
-    _state.session_id = None
-    _state.solver = None
-    _state.mode = None
-    _state.ui_mode = None
-    _state.connected_at = None
-    _state.run_count = 0
-    _state.driver = None
-    _state.runs = []
-    _state.profile = None
-    return sid
+
+def _teardown_all() -> list[str]:
+    """Tear down every session. Returns the ids that were torn down."""
+    with _sessions_lock:
+        ids = list(_sessions.keys())
+    return [sid for sid in (_teardown_session(i) for i in ids) if sid]
 
 
 @app.post("/disconnect")
-def disconnect():
-    if not _have_active_session():
-        raise HTTPException(400, "no active session")
-    sid = _teardown_active_session()
+def disconnect(
+    x_sim_session: str | None = Header(default=None, alias="X-Sim-Session"),
+):
+    state = _select_session(x_sim_session)
+    sid = _teardown_session(state.session_id)
     return {"ok": True, "data": {"session_id": sid, "disconnected": True}}
 
 
@@ -426,7 +510,7 @@ def disconnect():
 def shutdown(request: Request, background_tasks: BackgroundTasks):
     """Stop the sim-server process cleanly.
 
-    Disconnects any active session, then schedules the process to exit
+    Tears down ALL active sessions, then schedules the process to exit
     once the response has been flushed. Localhost-only — when sim serve
     is exposed via --host 0.0.0.0 we don't want a LAN peer to be able
     to take it down.
@@ -438,7 +522,7 @@ def shutdown(request: Request, background_tasks: BackgroundTasks):
             f"/shutdown is localhost-only (request from {client_host})",
         )
 
-    sid = _teardown_active_session()
+    torn_down = _teardown_all()
 
     def _exit_after_flush() -> None:
         import time as _t
@@ -450,6 +534,6 @@ def shutdown(request: Request, background_tasks: BackgroundTasks):
         "ok": True,
         "data": {
             "shutting_down": True,
-            "disconnected_session": sid,
+            "disconnected_sessions": torn_down,
         },
     }

--- a/src/sim/session.py
+++ b/src/sim/session.py
@@ -5,6 +5,11 @@ Always HTTP, whether local or remote:
   sim connect --solver pyfluent --host 100.90.x.x  # talks to remote sim-server
 
 If no server is running locally, `connect` auto-starts one as a background process.
+
+Multi-session (issue #26): the client carries an optional `session_id`. When
+set, every per-session call (`run`, `query`, `disconnect`, `screenshot`)
+sends `X-Sim-Session: <id>`. When unset, the server picks the sole live
+session as default — so single-session callers work unchanged.
 """
 from __future__ import annotations
 
@@ -38,12 +43,23 @@ def _httpx_client(host: str, timeout: float) -> httpx.Client:
 
 
 class SessionClient:
-    """HTTP client for sim-server. Works with local or remote servers."""
+    """HTTP client for sim-server. Works with local or remote servers.
 
-    def __init__(self, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT):
+    `session_id` is used as the `X-Sim-Session` header on per-session
+    endpoints. Leave it None to use the server's default-picking rules
+    (works whenever exactly one session is live).
+    """
+
+    def __init__(
+        self,
+        host: str = DEFAULT_HOST,
+        port: int = DEFAULT_PORT,
+        session_id: str | None = None,
+    ):
         self._base = f"http://{host}:{port}"
         self._host = host
         self._port = port
+        self.session_id = session_id
 
     def _is_local(self) -> bool:
         return self._host in ("localhost", "127.0.0.1")
@@ -63,8 +79,6 @@ class SessionClient:
         stdout/stderr from uvicorn (or any import-time print) crashes the
         subprocess. Redirecting stdio to DEVNULL avoids that.
         """
-        # Use a log file under the current SIM_DIR so auto-start failures are
-        # diagnosable. A full console would be overkill; DEVNULL hides bugs.
         import os
         sim_dir = Path(os.environ.get("SIM_DIR") or (Path.cwd() / ".sim"))
         sim_dir.mkdir(parents=True, exist_ok=True)
@@ -107,10 +121,24 @@ class SessionClient:
             time.sleep(0.3)
         return False
 
-    def _request(self, method: str, path: str, timeout: float = CMD_TIMEOUT_S, **kwargs) -> dict:
+    def _session_headers(self) -> dict[str, str]:
+        return {"X-Sim-Session": self.session_id} if self.session_id else {}
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        timeout: float = CMD_TIMEOUT_S,
+        session_scoped: bool = False,
+        **kwargs,
+    ) -> dict:
+        headers = kwargs.pop("headers", {}) or {}
+        if session_scoped:
+            headers = {**self._session_headers(), **headers}
         try:
             with _httpx_client(self._host, timeout=timeout) as c:
-                r = getattr(c, method)(f"{self._base}{path}", **kwargs)
+                r = getattr(c, method)(f"{self._base}{path}", headers=headers, **kwargs)
                 data = r.json()
                 if r.status_code >= 400:
                     return {"ok": False, "error": data.get("detail", str(data))}
@@ -133,35 +161,52 @@ class SessionClient:
             "solver": solver, "mode": mode,
             "ui_mode": ui_mode, "processors": processors,
         }
-        return self._request("post", "/connect", timeout=CONNECT_TIMEOUT_S, json=body)
+        resp = self._request("post", "/connect", timeout=CONNECT_TIMEOUT_S, json=body)
+        # Remember the new session_id so subsequent calls on this client
+        # route to it even if another session shows up later.
+        if resp.get("ok"):
+            new_sid = (resp.get("data") or {}).get("session_id")
+            if new_sid:
+                self.session_id = new_sid
+        return resp
 
     def run(self, code: str, label: str = "cli-snippet") -> dict:
-        return self._request("post", "/exec", json={"code": code, "label": label})
+        return self._request(
+            "post", "/exec",
+            json={"code": code, "label": label},
+            session_scoped=True,
+        )
 
     def query(self, name: str) -> dict:
-        return self._request("get", f"/inspect/{name}", timeout=30)
+        return self._request(
+            "get", f"/inspect/{name}",
+            timeout=30,
+            session_scoped=True,
+        )
 
     def disconnect(self) -> dict:
-        return self._request("post", "/disconnect", timeout=30)
+        return self._request(
+            "post", "/disconnect",
+            timeout=30,
+            session_scoped=True,
+        )
 
     def stop(self) -> dict:
-        """Stop the sim-server process itself (not just the session).
+        """Stop the sim-server process itself (tears down all sessions).
 
-        POSTs /shutdown. The server tears down the active session if any,
-        flushes the response, then exits cleanly via os._exit(0). Because
-        the process dies mid-stream, the connection often closes before
-        we read the body — that's expected, treat it as success.
+        POSTs /shutdown. The server tears down active sessions, flushes
+        the response, then exits cleanly via os._exit(0). Because the
+        process dies mid-stream, the connection often closes before we
+        read the body — that's expected, treat it as success.
         """
         try:
             with _httpx_client(self._host, timeout=10) as c:
                 r = c.post(f"{self._base}/shutdown")
-                # Race: process may already be dead before .json() returns.
                 try:
                     return r.json()
                 except Exception:
                     return {"ok": True, "data": {"shutting_down": True}}
         except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.ReadError):
-            # Server vanished mid-response — that IS the success path.
             return {"ok": True, "data": {"shutting_down": True}}
         except httpx.TimeoutException:
             return {"ok": False, "error": "timed out waiting for /shutdown"}
@@ -169,6 +214,7 @@ class SessionClient:
             return {"ok": False, "error": str(e)}
 
     def status(self) -> dict:
+        """GET /ps — returns the multi-session shape {sessions: [...], default_session}."""
         return self._request("get", "/ps", timeout=10)
 
     def screenshot(self) -> dict:

--- a/tests/base/test_compat.py
+++ b/tests/base/test_compat.py
@@ -258,9 +258,9 @@ class TestConnectIncludesSkillsBlock(unittest.TestCase):
         self._saved = os.environ.pop("SIM_SKILLS_ROOT", None)
         os.environ["SIM_SKILLS_ROOT"] = str(self.tmp)
 
-        # Reset server state between tests
+        # Reset server state between tests (multi-session registry)
         from sim import server
-        server._state = server.SessionState()
+        server._sessions.clear()
 
     def tearDown(self):
         shutil.rmtree(self.tmp)
@@ -269,7 +269,7 @@ class TestConnectIncludesSkillsBlock(unittest.TestCase):
         else:
             os.environ.pop("SIM_SKILLS_ROOT", None)
         from sim import server
-        server._state = server.SessionState()
+        server._sessions.clear()
 
     def test_connect_response_carries_skills_block(self):
         from fastapi.testclient import TestClient
@@ -315,7 +315,7 @@ class TestConnectIncludesSkillsBlock(unittest.TestCase):
             if original_get_driver is not None:
                 drivers_mod.get_driver = original_get_driver
             # Cleanup any lingering session
-            server._state = server.SessionState()
+            server._sessions.clear()
 
     def test_connect_response_skills_root_none_when_tree_absent(self):
         from fastapi.testclient import TestClient
@@ -349,7 +349,7 @@ class TestConnectIncludesSkillsBlock(unittest.TestCase):
             self.assertIn("hint", skills)
         finally:
             drivers_mod.get_driver = original
-            server._state = server.SessionState()
+            server._sessions.clear()
 
 
 if __name__ == "__main__":

--- a/tests/base/test_multi_session.py
+++ b/tests/base/test_multi_session.py
@@ -1,0 +1,193 @@
+"""Multi-session server tests (issue #26).
+
+Uses FastAPI TestClient + monkey-patched fake drivers so no real solver
+is needed. Covers:
+  - Two sessions on different solvers run concurrently
+  - X-Sim-Session routes /exec to the correct session
+  - /ps reports both; default_session is set only when n==1
+  - Header-less /exec on n>1 returns 400 with a helpful message
+  - /disconnect tears down one; /shutdown tears down all
+  - Two sessions on the same solver are rejected (until per-instance drivers)
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sim import server
+
+
+class FakeDriver:
+    """Minimal driver that pretends to launch and echoes exec payloads."""
+
+    supports_session = True
+
+    def __init__(self, name: str):
+        self.name = name
+        self._launched = False
+        self._disconnected = False
+
+    def launch(self, **kwargs):
+        self._launched = True
+        return {"ok": True}
+
+    def run(self, code: str, label: str = "snippet"):
+        return {
+            "ok": True,
+            "code": code,
+            "label": label,
+            "solver": self.name,
+            "stdout": f"ran on {self.name}",
+            "stderr": "",
+        }
+
+    def query(self, name: str):
+        return {"ok": True, "solver": self.name, "target": name}
+
+    def disconnect(self):
+        self._disconnected = True
+
+
+@pytest.fixture
+def fake_drivers(monkeypatch):
+    """Register two fake drivers ("alpha", "beta") via get_driver monkeypatch."""
+    instances = {"alpha": FakeDriver("alpha"), "beta": FakeDriver("beta")}
+
+    def _get(name: str):
+        return instances.get(name)
+
+    monkeypatch.setattr("sim.drivers.get_driver", _get)
+    # /connect imports inline — patch the module path it imports from, too.
+    import sim.drivers as drivers_mod
+    monkeypatch.setattr(drivers_mod, "get_driver", _get)
+    yield instances
+
+
+@pytest.fixture(autouse=True)
+def clean_sessions():
+    """Ensure every test starts/ends with an empty session registry."""
+    server._sessions.clear()
+    yield
+    server._sessions.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(server.app)
+
+
+def _connect(client, solver: str) -> str:
+    r = client.post("/connect", json={
+        "solver": solver, "mode": "solver",
+        "ui_mode": "no_gui", "processors": 1,
+    })
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["session_id"]
+
+
+class TestMultiSession:
+    def test_two_sessions_coexist(self, client, fake_drivers):
+        sid_a = _connect(client, "alpha")
+        sid_b = _connect(client, "beta")
+        assert sid_a != sid_b
+
+        r = client.get("/ps")
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["sessions"]) == 2
+        # Two sessions → no default (must explicitly select)
+        assert body["default_session"] is None
+        solvers = {s["solver"] for s in body["sessions"]}
+        assert solvers == {"alpha", "beta"}
+
+    def test_exec_routes_by_header(self, client, fake_drivers):
+        sid_a = _connect(client, "alpha")
+        sid_b = _connect(client, "beta")
+
+        r_a = client.post("/exec", json={"code": "x", "label": "t"},
+                          headers={"X-Sim-Session": sid_a})
+        assert r_a.status_code == 200
+        assert r_a.json()["data"]["solver"] == "alpha"
+
+        r_b = client.post("/exec", json={"code": "x", "label": "t"},
+                          headers={"X-Sim-Session": sid_b})
+        assert r_b.status_code == 200
+        assert r_b.json()["data"]["solver"] == "beta"
+
+    def test_exec_without_header_errors_when_multiple_live(self, client, fake_drivers):
+        _connect(client, "alpha")
+        _connect(client, "beta")
+        r = client.post("/exec", json={"code": "x", "label": "t"})
+        assert r.status_code == 400
+        assert "X-Sim-Session" in r.json()["detail"]
+
+    def test_exec_default_session_when_single_live(self, client, fake_drivers):
+        _connect(client, "alpha")
+        r = client.post("/exec", json={"code": "x", "label": "t"})
+        assert r.status_code == 200
+        assert r.json()["data"]["solver"] == "alpha"
+
+        r_ps = client.get("/ps").json()
+        assert r_ps["default_session"] is not None
+
+    def test_unknown_session_id_404(self, client, fake_drivers):
+        _connect(client, "alpha")
+        r = client.post("/exec", json={"code": "x"},
+                        headers={"X-Sim-Session": "nope"})
+        assert r.status_code == 404
+
+    def test_disconnect_one_leaves_other(self, client, fake_drivers):
+        sid_a = _connect(client, "alpha")
+        sid_b = _connect(client, "beta")
+
+        r = client.post("/disconnect", headers={"X-Sim-Session": sid_a})
+        assert r.status_code == 200
+        assert r.json()["data"]["session_id"] == sid_a
+
+        # beta still live and usable
+        r_exec = client.post("/exec", json={"code": "x"},
+                             headers={"X-Sim-Session": sid_b})
+        assert r_exec.status_code == 200
+        assert r_exec.json()["data"]["solver"] == "beta"
+
+        ps = client.get("/ps").json()
+        assert len(ps["sessions"]) == 1
+        assert ps["default_session"] == sid_b
+        assert fake_drivers["alpha"]._disconnected is True
+        assert fake_drivers["beta"]._disconnected is False
+
+    def test_same_solver_twice_rejected(self, client, fake_drivers):
+        _connect(client, "alpha")
+        # Second connect on same solver should fail — see server.py note.
+        r = client.post("/connect", json={
+            "solver": "alpha", "mode": "solver",
+            "ui_mode": "no_gui", "processors": 1,
+        })
+        assert r.status_code == 400
+        assert "already live" in r.json()["detail"]
+
+    def test_inspect_routes_by_header(self, client, fake_drivers):
+        sid_a = _connect(client, "alpha")
+        sid_b = _connect(client, "beta")
+
+        r_a = client.get("/inspect/deck.summary",
+                         headers={"X-Sim-Session": sid_a})
+        assert r_a.status_code == 200
+        assert r_a.json()["data"]["solver"] == "alpha"
+
+        r_b = client.get("/inspect/deck.summary",
+                         headers={"X-Sim-Session": sid_b})
+        assert r_b.json()["data"]["solver"] == "beta"
+
+    def test_exec_with_no_sessions_errors(self, client, fake_drivers):
+        r = client.post("/exec", json={"code": "x"})
+        assert r.status_code == 400
+        assert "no active sessions" in r.json()["detail"].lower()
+
+    def test_ps_empty(self, client):
+        r = client.get("/ps")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["sessions"] == []
+        assert body["default_session"] is None
+        assert "server_pid" in body

--- a/tests/drivers/fluent/test_fluent_mixing_elbow.py
+++ b/tests/drivers/fluent/test_fluent_mixing_elbow.py
@@ -84,21 +84,22 @@ pytestmark = pytest.mark.integration
 
 @pytest.fixture(scope="module")
 def server_state_reset():
-    """Reset sim.server._state before and after the test so a stale
-    session from a prior run doesn't poison /connect."""
+    """Reset sim.server session registry before and after the test so a
+    stale session from a prior run doesn't poison /connect."""
     from sim import server
-    server._state = server.SessionState()
+    server._sessions.clear()
     yield
     # Best-effort teardown — ignore errors so the fixture cleanup never
     # masks the actual test failure.
     try:
         from fastapi.testclient import TestClient
         c = TestClient(server.app)
-        if c.get("/ps").json().get("connected"):
-            c.post("/disconnect")
+        ps = c.get("/ps").json()
+        for sess in ps.get("sessions", []):
+            c.post("/disconnect", headers={"X-Sim-Session": sess["session_id"]})
     except Exception:
         pass
-    server._state = server.SessionState()
+    server._sessions.clear()
 
 
 @pytest.fixture(scope="module")

--- a/tests/gui/test_connect_tools_field.py
+++ b/tests/gui/test_connect_tools_field.py
@@ -62,8 +62,7 @@ def client(monkeypatch):
     monkeypatch.setattr(srv, "_resolve_profile", lambda driver, solver: None)
 
     # Reset global state in case another test left something
-    srv._state.session_id = None
-    srv._state.driver = None
+    srv._sessions.clear()
 
     return TestClient(srv.app)
 


### PR DESCRIPTION
Reopens svd-ai-lab/sim-proj#64 against \`main\`. The original PR svd-ai-lab/sim-cli#29 merged into the stacked \`feat/issue-5-config\` branch 28 seconds *after* PR svd-ai-lab/sim-cli#28 squash-merged that branch into main, so the multi-session commits never made it to main.

Same code as svd-ai-lab/sim-cli#29, cherry-picked cleanly onto current main (which already has the svd-ai-lab/sim-proj#60 / svd-ai-lab/sim-cli#28 config+history changes).

Reopens svd-ai-lab/sim-proj#64.