### PR TITLE
fix(driver): break cyclic result dict that RecursionErrors in FastAPI

### DIFF
--- a/src/sim/drivers/flotherm/driver.py
+++ b/src/sim/drivers/flotherm/driver.py
@@ -356,7 +356,7 @@ class FlothermDriver:
             wall_time_s=wall,
             exit_code=0 if result.get("ok") else 1,
             driver_name=self.name,
-            session_ns={"_result": result},
+            session_ns={},
             workdir_before=before,
         )
         diags, arts = collect_diagnostics(self.probes, ctx)


### PR DESCRIPTION
## Summary

- The driver's `run()` creates a cyclic result dict that causes FastAPI's `jsonable_encoder` to infinite-recurse.
- Every `/exec` call (even a harmless `status`) on this driver's session hits HTTP 500 with an empty body. Looks like a driver crash or a routing problem, but it's actually a serialization cycle.
- Fix is one line: stop advertising the driver's return dict as `session_ns["_result"]`.

## Recent regression — this driver only

This was introduced 2 days ago in [`8681ec3`](https://github.com/svd-ai-lab/sim-cli/commit/8681ec38) (`feat(inspect): generic_probes() base + driver probe wiring + condition-based waits`), the same commit that first wrapped this driver's `run()` with `InspectCtx + collect_diagnostics`. Before that commit, the driver had no probe pipeline at all, so there was no cycle and `/exec` worked.

The bug is **driver-only**. Every other driver that wires the probe pipeline this way passes the **inner** sub-dict from the user-code namespace, not the outer mutated dict:

```python
# all the other drivers do:
session_ns={"_result": result.get("result")}   # inner sub-dict, not the outer

# this driver did:
session_ns={"_result": result}                 # outer dict — same object that gets mutated below
```

`result.get("result")` is a different Python object from the outer `result`, so when the driver later writes `result["diagnostics"] = …` no cycle forms. This driver has no user-code-namespace pattern (no `exec(code, namespace)` with `_result = …`), so `_dispatch` just returns a summary dict, and storing that same dict in `session_ns["_result"]` closes the loop.

## The cycle

`Driver.run()`:

```python
result = self._dispatch(code, label)
ctx = InspectCtx(
    ...,
    session_ns={"_result": result},   # ← the same dict we're about to return
    ...,
)
diags, arts = collect_diagnostics(self.probes, ctx)
result["diagnostics"] = [d.to_dict() for d in diags]   # ← mutates the advertised dict
result["artifacts"] = [a.to_dict() for a in arts]
return result
```

`StdoutJsonTailProbe`, on empty stdout, surfaces the last `_result` the user set:

```python
parsed = ctx.session_ns.get("_result")
if isinstance(parsed, dict):
    return Diagnostic(..., extra={"value": parsed})   # ← shares the reference
```

So the returned dict now references a diagnostic whose `extra["value"]` references the dict itself:

```
result → result["diagnostics"][i] → extra["value"] → result
```

FastAPI's `jsonable_encoder` walks the cycle until it hits Python's recursion limit. The response ends up as HTTP 500 with an empty body.

## Why the driver, not the probe

`StdoutJsonTailProbe` behaves reasonably for solvers that run user code via `exec(code, namespace)` with `_result = ...`. This driver has no user-code-namespace pattern, so there is no legitimate "last `_result` the user set" to advertise. Passing `session_ns={}` matches the driver's actual semantics and breaks the cycle.

Behavior change: the probe will now emit nothing (instead of an echoed copy of the dispatch dict) when this driver produces empty stdout. That is a noise reduction, not a capability loss — the dispatch dict is already the return value.

## Reproduction

Pre-fix, on a Windows host with the solver installed:

```bash
uv run sim serve --host 0.0.0.0
# in another shell
sim connect --solver <driver> --ui-mode gui   # -> SID
sim --session $SID exec "status"              # -> HTTP 500 (empty body)
```

Server stderr (pre-fix) shows a long `RecursionError` chain ending in `fastapi.encoders.jsonable_encoder` / `pydantic` serialization.

## Verification

Post-fix, the same reproduction returns HTTP 200 with a clean JSON body that includes diagnostics.

Tested on a Windows test host, Python 3.12, sim-cli at `origin/main` (commit 423e77e).

## Test plan

- [x] `sim connect` + `/exec "status"` → HTTP 200 (previously 500)
- [x] Diagnostics list present in the returned JSON (probe still runs)
- [x] Driver unit tests pass: 8 passed, 5 skipped (skips need a real install). Full suite: 802 passed, 123 skipped.
- [ ] `/exec` with a script path in an interactive Windows session — blocked on this host by Session 0 isolation. Not regressing: the dialog-not-found path already existed; it was just being masked by the 500.

## Scope

Pure bug fix. One line. No behavior change for callers that were not relying on `_result` showing up in the diagnostic `extra` (nothing in-tree does).
