### PR TITLE
release: 0.2.1 — first PyPI publish under sim-runtime

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist + wheel
+        run: uv build
+
+      - name: Sanity-check artifacts
+        run: |
+          uv tool run twine check dist/*
+          ls -lh dist/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Upload to PyPI (trusted publishing)
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sim-runtime
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "sim-cli"
-version = "0.2.0"
+name = "sim-runtime"
+version = "0.2.1"
 description = "Make every engineering tool agent-native — a CLI runtime that lets LLM agents launch, drive, and observe CAD/CAE software"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Rename PyPI distribution `sim-cli` → `sim-runtime`. The `sim-cli` name was rejected by PyPI as too similar to the existing `simcli` placeholder. Import name (`import sim`) and console script (`sim`) are unchanged.
- Add `.github/workflows/publish.yml` using OIDC trusted publishing (no API tokens). Triggers on `v*` tags; uploads from the `pypi` GitHub environment.
- Bump version `0.2.0` → `0.2.1` to mark the first PyPI release.

PyPI trusted publisher is already configured at https://pypi.org/manage/account/publishing/ for repo `svd-ai-lab/sim-cli`, workflow `publish.yml`, environment `pypi`.

## Test plan

- [x] `uv build` produces `sim_runtime-0.2.1-py3-none-any.whl` + sdist
- [x] `twine check dist/*` PASSED
- [x] Wheel METADATA shows `Name: sim-runtime` / `Version: 0.2.1`
- [ ] After merge: tag `v0.2.1` from main → workflow fires → package live at https://pypi.org/project/sim-runtime/0.2.1/
- [ ] `pip install sim-runtime==0.2.1` in clean venv; `sim --help` works