### PR TITLE
release: 0.2.2 — hotfix __version__ lookup after PyPI rename

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sim-runtime"
-version = "0.2.1"
+version = "0.2.2"
 description = "Make every engineering tool agent-native — a CLI runtime that lets LLM agents launch, drive, and observe CAD/CAE software"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sim/__init__.py
+++ b/src/sim/__init__.py
@@ -1,5 +1,8 @@
 """sim — unified CLI for LLM agents to control CAD/CAE simulation software."""
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = version("sim-cli")
+try:
+    __version__ = version("sim-runtime")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Summary

0.2.1 shipped broken — every `sim` invocation crashed at import:

\`\`\`
File "/.../sim/__init__.py", line 5, in <module>
    __version__ = version("sim-cli")
PackageNotFoundError: No package metadata was found for sim-cli
\`\`\`

After the PyPI rename to `sim-runtime`, the hardcoded distribution-name lookup in [src/sim/__init__.py](src/sim/__init__.py:5) fails. Fix: look up `sim-runtime`, wrap in `try/except PackageNotFoundError` so editable installs / source checkouts fall back to `0.0.0+unknown` instead of crashing.

Also yanking 0.2.1 on PyPI manually so users hitting `pip install sim-runtime` (no version pin) skip the broken release.

## Test plan

- [x] `uv build` produces `sim_runtime-0.2.2.*`, `twine check` passes
- [x] Clean venv install: `sim --version` → `sim, version 0.2.2`
- [x] `python -c "import sim; print(sim.__version__)"` → `0.2.2`
- [ ] After merge: tag `v0.2.2` from main → workflow ships 0.2.2 → fresh `pip install sim-runtime` resolves to 0.2.2 (after 0.2.1 yank)