### PR TITLE
fix(driver): close 4 gaps surfaced by uv 0.9.x venv auto-prune (#39)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "lxml>=5.0", # XSD validation for FloSCRIPT lint
     "sim-ltspice>=0.2", # LTspice file formats + runtime — sim-cli's LTspice driver delegates here
     "tomli>=2.0; python_version<'3.11'", # TOML parser for config.py; stdlib tomllib is 3.11+
+    "pywinauto>=0.6.8; sys_platform == 'win32'", # GUI automation backend for Flotherm (and other solvers without a batch API). Spawned in a subprocess via sys.executable, so must live in the same venv as sim-server.
 ]
 
 [project.optional-dependencies]

--- a/src/sim/drivers/flotherm/_helpers.py
+++ b/src/sim/drivers/flotherm/_helpers.py
@@ -121,6 +121,7 @@ def default_flouser(install_root: str) -> str:
 # ---------------------------------------------------------------------------
 
 _FLOSCRIPT_ROOT = "xml_log_file"
+_FLOXML_ROOTS = ("xml_case", "sm_xml_case")
 _SOLVE_COMMANDS = ("solve_all", "solve_scenario", "start")
 
 
@@ -215,6 +216,35 @@ def lint_floscript(
                 level="warning",
                 message="No solve/start command found \u2014 "
                         "script may configure but not run a simulation."))
+    return LintResult(ok=True, diagnostics=diagnostics)
+
+
+def lint_floxml(script: Path) -> LintResult:
+    """Validate a Flotherm FloXML authoring file (`<xml_case>` / `<sm_xml_case>` root).
+
+    FloXML is the vendor-blessed model-exchange format. Unlike FloSCRIPT,
+    sim-skills does not yet ship a public XSD for FloXML, so this lint is
+    structural-only: well-formed XML + a recognized root tag. When/if an
+    XSD becomes available it can hook in via the same path as FloSCRIPT.
+    """
+    diagnostics: list[Diagnostic] = []
+    try:
+        text = script.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return LintResult(ok=False, diagnostics=[
+            Diagnostic(level="error", message=f"Cannot read file: {e}")])
+    if not text.strip():
+        return LintResult(ok=False, diagnostics=[
+            Diagnostic(level="error", message="FloXML file is empty")])
+    try:
+        root = ElementTree.fromstring(text)
+    except ElementTree.ParseError as e:
+        return LintResult(ok=False, diagnostics=[
+            Diagnostic(level="error", message=f"XML parse error: {e}")])
+    if root.tag not in _FLOXML_ROOTS:
+        return LintResult(ok=False, diagnostics=[Diagnostic(
+            level="error",
+            message=f"Expected FloXML root <xml_case> or <sm_xml_case>, got <{root.tag}>.")])
     return LintResult(ok=True, diagnostics=diagnostics)
 
 

--- a/src/sim/drivers/flotherm/_win32_backend.py
+++ b/src/sim/drivers/flotherm/_win32_backend.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 from sim.gui._win32_dialog import (
     dismiss_windows_by_title_fragment,
@@ -28,6 +29,16 @@ from sim.gui._win32_dialog import (
     find_dialog_by_title as _find_dialog,
     user32,
 )
+
+
+def _drain(pipe) -> str:
+    """Read whatever is buffered on a subprocess pipe without blocking forever."""
+    if pipe is None:
+        return ""
+    try:
+        return pipe.read().decode("utf-8", errors="replace").strip()
+    except Exception:
+        return ""
 
 _UIA_MENU_TRIGGER = """\
 import time
@@ -140,6 +151,11 @@ def play_floscript(script_path: str, timeout: float = 15) -> dict:
     if user32 is None:
         return {"ok": False, "error": "Not on Windows"}
 
+    # Flotherm's standard file-open dialog rejects forward-slash separators
+    # ("The file name is not valid"). The FloSCRIPT body itself accepts /,
+    # but the WM_SETTEXT into the dialog edit control needs native form.
+    script_path = str(Path(script_path))
+
     # Dismiss any existing popups
     dismissed = _dismiss_popups()
 
@@ -160,15 +176,25 @@ def play_floscript(script_path: str, timeout: float = 15) -> dict:
     except subprocess.TimeoutExpired:
         proc.kill()
 
+    # Surface subprocess output so silent failures (missing pywinauto, COM
+    # error, Qt mismatch) don't reduce to a generic "dialog not found".
+    sub_stderr = _drain(proc.stderr)
+    sub_stdout = _drain(proc.stdout)
+
     # Step 2: Find the Play FloSCRIPT file dialog.
     # find_dialog already polls (up to 5s) so no sleep needed before it.
     dialog = _find_dialog("Play FloSCRIPT", timeout=5)
     if dialog is None:
-        return {
+        result = {
             "ok": False,
             "error": "Play FloSCRIPT dialog not found after menu trigger",
             "dismissed_popups": dismissed,
         }
+        if sub_stderr:
+            result["subprocess_stderr"] = sub_stderr
+        if sub_stdout:
+            result["subprocess_stdout"] = sub_stdout
+        return result
 
     # Step 3: Fill and submit
     if not _fill_file_dialog(dialog, script_path):

--- a/src/sim/drivers/flotherm/driver.py
+++ b/src/sim/drivers/flotherm/driver.py
@@ -42,6 +42,7 @@ from sim.drivers.flotherm._helpers import (
     detect_job_state,
     find_installation,
     lint_floscript,
+    lint_floxml,
     lint_pack,
     pack_project_dir,
     pack_project_name,
@@ -170,13 +171,19 @@ class FlothermDriver:
         return False
 
     def lint(self, script: Path) -> LintResult:
-        """Validate a .pack or FloSCRIPT .xml file. No Flotherm required.
+        """Validate a .pack, FloSCRIPT, or FloXML file. No Flotherm required.
 
-        When sim-skills is available, FloSCRIPT files are validated against
-        the XSD schema for the detected Flotherm version.
+        FloSCRIPT (`<xml_log_file>`) gets full XSD validation when sim-skills
+        ships the schema for the detected version. FloXML (`<xml_case>` /
+        `<sm_xml_case>`) is structural-only — sim-skills doesn't yet ship a
+        FloXML XSD; that's a follow-up.
         """
         ext = script.suffix.lower()
         if ext == ".xml":
+            blob = _XML_COMMENT_RE.sub(b"", script.read_bytes()[:_DETECT_SCAN_BYTES])
+            header = blob.decode("utf-8", errors="replace")
+            if any(m in header for m in ("<xml_case", "<sm_xml_case")):
+                return lint_floxml(script)
             return lint_floscript(
                 script, schema_dir=self._find_schema_dir())
         if ext == ".pack":

--- a/src/sim/drivers/flotherm/driver.py
+++ b/src/sim/drivers/flotherm/driver.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import signal
 import subprocess
 import time
@@ -53,6 +54,13 @@ from sim.drivers.flotherm._helpers import (
 #   - Project FloXML (`<xml_case>`)        — vendor-blessed model exchange format
 #   - SmartPart FloXML (`<sm_xml_case>`)   — SmartPart-scoped FloXML
 _FLOTHERM_XML_MARKERS = ("<xml_log_file", "<xml_case", "<sm_xml_case")
+
+# FloXML files routinely carry multi-paragraph descriptive comments before
+# the root element (geometry tables, phase notes, etc.) that can push the
+# root tag well past 512 bytes. Scan a generous window and strip comments
+# before searching for a marker.
+_DETECT_SCAN_BYTES = 16384
+_XML_COMMENT_RE = re.compile(rb"<!--.*?-->", re.DOTALL)
 
 
 def _default_flotherm_probes(enable_gui: bool = True) -> list:
@@ -154,7 +162,8 @@ class FlothermDriver:
             return True
         if ext == ".xml":
             try:
-                header = script.read_bytes()[:512].decode("utf-8", errors="replace")
+                blob = _XML_COMMENT_RE.sub(b"", script.read_bytes()[:_DETECT_SCAN_BYTES])
+                header = blob.decode("utf-8", errors="replace")
                 return any(m in header for m in _FLOTHERM_XML_MARKERS)
             except OSError:
                 return False

--- a/src/sim/drivers/flotherm/driver.py
+++ b/src/sim/drivers/flotherm/driver.py
@@ -48,7 +48,11 @@ from sim.drivers.flotherm._helpers import (
     snapshot_result_files,
 )
 
-_FLOSCRIPT_MARKER = "<xml_log_file"
+# Flotherm authoring/exchange XML formats sim-cli claims for `detect()`:
+#   - FloSCRIPT (`<xml_log_file>`)         — command recordings, played via Macro > Play FloSCRIPT
+#   - Project FloXML (`<xml_case>`)        — vendor-blessed model exchange format
+#   - SmartPart FloXML (`<sm_xml_case>`)   — SmartPart-scoped FloXML
+_FLOTHERM_XML_MARKERS = ("<xml_log_file", "<xml_case", "<sm_xml_case")
 
 
 def _default_flotherm_probes(enable_gui: bool = True) -> list:
@@ -144,14 +148,14 @@ class FlothermDriver:
         return True
 
     def detect(self, script: Path) -> bool:
-        """Return True for Flotherm files (.pack, FloSCRIPT .xml)."""
+        """Return True for Flotherm files (.pack, FloSCRIPT or FloXML .xml)."""
         ext = script.suffix.lower()
         if ext == ".pack":
             return True
         if ext == ".xml":
             try:
                 header = script.read_bytes()[:512].decode("utf-8", errors="replace")
-                return _FLOSCRIPT_MARKER in header
+                return any(m in header for m in _FLOTHERM_XML_MARKERS)
             except OSError:
                 return False
         return False

--- a/tests/drivers/flotherm/test_flotherm_detect.py
+++ b/tests/drivers/flotherm/test_flotherm_detect.py
@@ -1,0 +1,69 @@
+"""Regression tests for FlothermDriver.detect() across .pack and the three
+Flotherm XML flavors (FloSCRIPT, FloXML, SmartPart FloXML).
+
+Issue #39: detect() previously matched only FloSCRIPT (`<xml_log_file`),
+so `sim lint` mis-routed FloXML authoring files to PyBaMM.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sim.drivers.flotherm.driver import FlothermDriver
+
+
+@pytest.fixture
+def driver() -> FlothermDriver:
+    return FlothermDriver()
+
+
+class TestDetectXml:
+    def test_floscript(self, driver, tmp_path):
+        p = tmp_path / "import.xml"
+        p.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<xml_log_file version="1.0">\n'
+            '  <project_import filename="C:/tmp/x.xml" import_type="FloXML"/>\n'
+            "</xml_log_file>\n",
+            encoding="utf-8",
+        )
+        assert driver.detect(p) is True
+
+    def test_floxml_xml_case(self, driver, tmp_path):
+        p = tmp_path / "model.xml"
+        p.write_text(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n'
+            "<xml_case>\n  <name>HBM_demo</name>\n</xml_case>\n",
+            encoding="utf-8",
+        )
+        assert driver.detect(p) is True
+
+    def test_smartpart_floxml(self, driver, tmp_path):
+        p = tmp_path / "smartpart.xml"
+        p.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            "<sm_xml_case>\n  <name>part</name>\n</sm_xml_case>\n",
+            encoding="utf-8",
+        )
+        assert driver.detect(p) is True
+
+    def test_unrelated_xml_rejected(self, driver, tmp_path):
+        p = tmp_path / "other.xml"
+        p.write_text(
+            '<?xml version="1.0"?>\n<not_flotherm><foo/></not_flotherm>\n',
+            encoding="utf-8",
+        )
+        assert driver.detect(p) is False
+
+
+class TestDetectPack:
+    def test_pack_extension_claimed(self, driver, tmp_path):
+        p = tmp_path / "model.pack"
+        p.write_bytes(b"")  # contents irrelevant — extension drives detection
+        assert driver.detect(p) is True
+
+    def test_other_binary_extension(self, driver, tmp_path):
+        p = tmp_path / "model.bin"
+        p.write_bytes(b"\x00\x01\x02")
+        assert driver.detect(p) is False

--- a/tests/drivers/flotherm/test_flotherm_detect.py
+++ b/tests/drivers/flotherm/test_flotherm_detect.py
@@ -56,6 +56,26 @@ class TestDetectXml:
         )
         assert driver.detect(p) is False
 
+    def test_floxml_with_long_leading_comment(self, driver, tmp_path):
+        """Real FloXML files (e.g. hbm-flotherm/build/hbm_3block.xml) carry
+        a multi-paragraph descriptive comment before the root, which can push
+        the `<xml_case>` element past byte 512. detect() must look further
+        and/or strip comments."""
+        # Generate >1 KB of comment content to push root past the old 512-byte window.
+        comment_body = "\n".join(
+            f"  Phase note line {i}: lorem ipsum dolor sit amet "
+            "consectetur adipiscing elit." for i in range(40)
+        )
+        p = tmp_path / "model.xml"
+        p.write_text(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n'
+            f"<!--\n{comment_body}\n-->\n"
+            "<xml_case>\n  <name>HBM</name>\n</xml_case>\n",
+            encoding="utf-8",
+        )
+        assert p.stat().st_size > 1024  # sanity: comment really is past 512 bytes
+        assert driver.detect(p) is True
+
 
 class TestDetectPack:
     def test_pack_extension_claimed(self, driver, tmp_path):

--- a/tests/drivers/flotherm/test_flotherm_lint.py
+++ b/tests/drivers/flotherm/test_flotherm_lint.py
@@ -1,10 +1,11 @@
-"""Tests for Flotherm FloSCRIPT linting with XSD validation."""
+"""Tests for Flotherm FloSCRIPT and FloXML linting."""
 from pathlib import Path
 import textwrap
 
 import pytest
 
-from sim.drivers.flotherm._helpers import lint_floscript
+from sim.drivers.flotherm._helpers import lint_floscript, lint_floxml
+from sim.drivers.flotherm.driver import FlothermDriver
 
 # XSD schemas in sim-skills (may not be available in CI)
 _SCHEMA_DIR = (
@@ -187,4 +188,69 @@ class TestXSDValidation:
         """)
         # bogus_command won't be caught without XSD
         result = lint_floscript(p, schema_dir=None)
+        assert result.ok is True
+
+
+# ── FloXML linting ──────────────────────────────────────────────────
+
+
+class TestFloxmlLint:
+    def test_xml_case_minimal(self, tmp_path):
+        p = _write_xml(tmp_path, """\
+            <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <xml_case>
+              <name>HBM_demo</name>
+            </xml_case>
+        """)
+        result = lint_floxml(p)
+        assert result.ok is True
+
+    def test_sm_xml_case_minimal(self, tmp_path):
+        p = _write_xml(tmp_path, """\
+            <?xml version="1.0"?>
+            <sm_xml_case>
+              <name>SmartPart</name>
+            </sm_xml_case>
+        """)
+        result = lint_floxml(p)
+        assert result.ok is True
+
+    def test_wrong_root(self, tmp_path):
+        p = _write_xml(tmp_path, "<not_floxml/>")
+        result = lint_floxml(p)
+        assert result.ok is False
+        assert "xml_case" in result.diagnostics[0].message
+
+    def test_empty_file(self, tmp_path):
+        p = _write_xml(tmp_path, "")
+        result = lint_floxml(p)
+        assert result.ok is False
+
+    def test_invalid_xml(self, tmp_path):
+        p = _write_xml(tmp_path, "<xml_case><not closed")
+        result = lint_floxml(p)
+        assert result.ok is False
+
+
+class TestDriverLintRouting:
+    """`FlothermDriver.lint` must dispatch FloSCRIPT vs FloXML by root tag."""
+
+    def test_routes_floscript(self, tmp_path):
+        p = _write_xml(tmp_path, """\
+            <?xml version="1.0"?>
+            <xml_log_file version="1.0">
+              <start start_type="solver"/>
+            </xml_log_file>
+        """)
+        result = FlothermDriver().lint(p)
+        assert result.ok is True
+
+    def test_routes_floxml(self, tmp_path):
+        p = _write_xml(tmp_path, """\
+            <?xml version="1.0"?>
+            <xml_case>
+              <name>X</name>
+            </xml_case>
+        """)
+        result = FlothermDriver().lint(p)
         assert result.ok is True

--- a/uv.lock
+++ b/uv.lock
@@ -400,6 +400,15 @@ wheels = [
 ]
 
 [[package]]
+name = "comtypes"
+version = "1.4.16"
+source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
+sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/c6/2a/65274c13327f637ec13af8d39f2cf579d9ebe7a0e683696b5f05236d2805/comtypes-1.4.16.tar.gz", hash = "sha256:cd66d1add01265cface4df51ba1e31cd1657e04463c281c802e737e79e1ba93c", size = 260252 }
+wheels = [
+    { url = "https://mirrors.ustc.edu.cn/pypi/packages/5f/7c/0eb685107290b6221c03c46d39214a4e42a124189691cb83ae3228257f46/comtypes-1.4.16-py3-none-any.whl", hash = "sha256:e18d85179ff12955524c5a8c3bc09cb3c0d890f1da4d7123d14244c7b78f84c8", size = 296230 },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
@@ -1544,6 +1553,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pywinauto"
+version = "0.6.9"
+source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
+dependencies = [
+    { name = "comtypes", marker = "sys_platform == 'win32'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "six" },
+]
+sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/2c/85/cc65e3b64e7473cc86c07f0b5c415d509402c03ef19dadc39c583835eb5f/pywinauto-0.6.9.tar.gz", hash = "sha256:94d710bfa796df245250f952ffa65d97233d9807bcd42e052b71b81af469b6de", size = 434734 }
+wheels = [
+    { url = "https://mirrors.ustc.edu.cn/pypi/packages/44/46/f2283648e0c237af451dc50ebc42121abfd198d12391fd9ad4df1c6b97d2/pywinauto-0.6.9-py2.py3-none-any.whl", hash = "sha256:5924b3072864a1d730c5546bbeb17cf4063ba518b618dbc5e43c18276c7c9356", size = 363041 },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
@@ -1926,7 +1949,7 @@ wheels = [
 
 [[package]]
 name = "sim-runtime"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1934,6 +1957,7 @@ dependencies = [
     { name = "httpx" },
     { name = "lxml" },
     { name = "pillow" },
+    { name = "pywinauto", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
     { name = "sim-ltspice" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -1970,6 +1994,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10" },
     { name = "pybamm", marker = "extra == 'pybamm'", specifier = ">=24.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pywinauto", marker = "sys_platform == 'win32'", specifier = ">=0.6.8" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "sim-ltspice", specifier = ">=0.2" },


### PR DESCRIPTION
Closes a companion sim-proj issue.

## What's broken

End-to-end driver GUI demo (XML → import → save → solve → verify) breaks on a fresh `uv` workflow. `uv` 0.9.x's `uv run` performs an exact-sync that removes packages not in the lock; the GUI driver's UIA subprocess then `ModuleNotFoundError`s on missing `pywinauto`, and the driver swallows the subprocess output, so the user sees only the generic `Play <script> dialog not found after menu trigger`.

## Changes

- **pyproject.toml** + **uv.lock** — declare `pywinauto>=0.6.8 ; sys_platform == 'win32'` as a core dep so a freshly synced `.venv` always has it. Lock pulls in `pywinauto`, `comtypes`, `six` (existing `pywin32` already locked).
- **`_win32_backend.py`**
  - Normalize `script_path` to native separators (`str(Path(...))`) before `WM_SETTEXT`. The standard file-open dialog rejects forward-slash paths with `"The file name is not valid"`; script body content is unaffected.
  - Capture subprocess `stdout`/`stderr` after `wait`/`kill` and surface them in the `gui_result` on the dialog-not-found path. Previously the pipes were created but never read, so missing deps / COM errors / Qt mismatches all collapsed to the same opaque message.
- **`driver.py`** — extend the script-marker recognizer to also accept the project-XML and SmartPart-XML root elements. `sim lint` was previously routing those XML files to PyBaMM (`No pybamm import found`).
- **detect tests** — 6 new regression tests covering all three XML markers + `.pack` + negatives.

## Test results

```
tests/drivers/<driver>/  +  tests/gui/   →   27 passed, 5 skipped
```

Pre-existing failures on `main` (unrelated drivers + a known logs test) are out of scope for this branch.

## End-to-end verification

Verified on a Windows test host using a public demo case:

| step | result |
|---|---|
| `sim connect --solver <driver> --ui-mode gui` | session ready |
| `sim exec C:\\tmp\\import.xml` | XML imported (~17 s) |
| `sim exec C:\\tmp\\save_then_solve.xml` | saved + solver triggered |
| solver convergence | normal exit (~70 s, 300k cells) |
| Temperature field | T_max matched the published demo baseline exactly |
| `sim disconnect` | clean teardown |

## Test plan

- [x] new detect tests pass locally
- [x] driver + gui suites pass locally
- [ ] CI green
- [ ] manual: fresh `uv venv && uv sync` on a Windows host, confirm `pywinauto` is present in `.venv\\Lib\\site-packages` without a separate `uv pip install`
- [ ] manual: end-to-end demo against this PR's commit
