### PR TITLE
feat: add `python -m sim` entry point (dev workaround for Scripts/sim.exe Windows lock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ changes at milestone boundaries.
 
 ### Added
 
+- **`python -m sim` invocation (equivalent to the `sim` console script).**
+  Adds `src/sim/__main__.py` so `python -m sim ...` reaches the same Click
+  group as the installed `sim` entry point. Lets developers launch
+  `sim serve --reload` without holding a Windows file lock on
+  `.venv\Scripts\sim.exe` — `uv sync` then re-prepares the editable install
+  (which rewrites `Scripts/sim.exe`) without the `os error 32` collision
+  that aborts the sync when the server is up. End-user PyPI workflow is
+  unchanged; the `sim` console script remains the canonical entry point.
+
 - **`sim check` without a solver aggregates across all drivers.** Calling
   `sim check` with no solver argument (or with the explicit `--all` flag)
   now enumerates every registered driver, calls `safe_detect_installed()`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -49,6 +49,24 @@ Auto-restarts the server when source files change. Useful during driver developm
 sim serve --reload
 ```
 
+On Windows, prefer the module-execution form when you also need to run
+`uv sync` mid-iteration:
+
+```bash
+python -m sim serve --reload
+```
+
+Both invocations reach the same Click group. The difference is only the
+running process's open file: `sim serve` holds `.venv\Scripts\sim.exe`,
+whereas `python -m sim serve` holds `.venv\Scripts\python.exe`. `uv sync`
+re-prepares the editable install on every sync, which means rewriting
+`Scripts/sim.exe`; on Windows that fails with `os error 32` if `sim.exe`
+is open as a process, and the entire sync aborts. Launching via
+`python -m sim` keeps `sim.exe` free, so `uv sync` can complete in-place
+while `--reload` continues to pick up source changes. End-user PyPI
+workflows aren't affected — they install `sim-runtime` as a regular wheel
+and never re-prepare the editable.
+
 ### `sim disconnect --stop-server`
 
 Convenience flag that tears down the session *and* stops the server in one call (equivalent to `sim disconnect && sim stop`):

--- a/src/sim/__main__.py
+++ b/src/sim/__main__.py
@@ -1,0 +1,24 @@
+"""Allow ``python -m sim ...`` invocation (equivalent to the ``sim`` console script).
+
+Why this exists
+---------------
+The console script ``sim`` (declared in ``[project.scripts]``) is the canonical
+entry point for end users — it stays unchanged. This module forwards
+``python -m sim ...`` to the same Click group so developers have a second
+invocation that does *not* hold a Windows file lock on
+``.venv/Scripts/sim.exe``.
+
+That lock is the whole reason this file exists: with the editable install,
+``uv sync`` rewrites ``Scripts/sim.exe`` on every sync, but a running
+``sim serve`` has the exe open, so Windows refuses the rewrite (``os error
+32``) and the entire sync aborts. Launching the dev server as
+``python -m sim serve --reload`` instead means the running process holds
+``python.exe`` (uv-managed, shared, not project-managed), and ``sim.exe``
+stays free for ``uv sync`` to rewrite while iteration proceeds.
+
+Same pattern used by pip, ruff, pytest, etc.
+"""
+from sim.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/base/test_cli.py
+++ b/tests/base/test_cli.py
@@ -1,6 +1,8 @@
 """Basic CLI smoke tests."""
 
 import json
+import subprocess
+import sys
 
 from click.testing import CliRunner
 
@@ -21,6 +23,28 @@ def test_help():
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
     assert "sim" in result.output
+
+
+def test_python_m_sim_invocation():
+    """``python -m sim --version`` must reach the same Click group as the
+    ``sim`` console script. CliRunner-based tests don't exercise the module-
+    execution path; this is the regression test for ``src/sim/__main__.py``,
+    which exists so dev users can launch ``sim serve`` without holding a
+    Windows file lock on ``Scripts/sim.exe`` during ``uv sync``.
+    """
+    from importlib.metadata import version
+
+    result = subprocess.run(
+        [sys.executable, "-m", "sim", "--version"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stderr
+    # Click reports prog_name as "python -m sim" here (sys.argv[0] is the
+    # module path); accept either form alongside the actual version string.
+    assert "version" in result.stdout
+    assert version("sim-runtime") in result.stdout
 
 
 def test_check_all_json_shape():


### PR DESCRIPTION
Follow-up to #40. Surface-area: 1 new file, 1 new test, 2 doc updates.

## Why

`uv sync` always re-prepares the editable install of `sim-runtime`, which means rewriting `.venv\Scripts\sim.exe`. On Windows, a live `sim serve` holds that exe open with an exclusive lock — uv hits `error: failed to remove file ...sim.exe... (os error 32)` and the entire sync aborts. So even a one-line dep change in `pyproject.toml` can't be applied without bouncing the server, and bouncing kills the RDP/GUI desktop session that GUI-mode automation depends on.

(See [`sim-proj` playbook entry "uv sync collides with a live sim serve"](https://github.com/svd-ai-lab/sim-proj/blob/main/dev-docs/playbook.md) for the full diagnosis. Filing an upstream uv feature request — "let `--no-install-project` actually skip the editable rebuild" — is a separate follow-up; not blocking this.)

## What

A 4-line `src/sim/__main__.py` forwards `python -m sim ...` to the existing `sim.cli.main` Click group. The running process for `python -m sim serve --reload` then holds `.venv\Scripts\python.exe` (uv-managed, shared) instead of `Scripts\sim.exe`, so `uv sync` can rewrite `sim.exe` in-place while `--reload` keeps picking up source changes.

## Out of scope (deliberate)

- **`[project.scripts]` console script unchanged** — `sim ...` still works.
- **`README.md` / `README.de.md` / `README.ja.md` / `README.zh.md` untouched** — end-user PyPI workflow is unaffected (they install a wheel, never re-prepare the editable, never hit the lock).
- **No CI changes** — repo only has `publish.yml` for tag-triggered PyPI publish.

## Validation plan

- [x] `python -m sim --version` returns the same version as `sim --version` (new test `test_python_m_sim_invocation` covers this; runs as a subprocess because `CliRunner` doesn't exercise the module-execution path)
- [x] flotherm + gui suites still green (44 passed, 5 skipped, 2 pre-existing failures unrelated to this branch)
- [ ] manual on Windows host: launch `uv run python -m sim serve --host 0.0.0.0 --reload` from RDP, then run `uv sync` from a separate terminal — should complete cleanly (no `os error 32`) even though `sim.exe` gets rewritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)