### PR TITLE
feat(driver): GUI-free postprocessing path — lib.field_reader + headless solve verification

### DIFF
--- a/src/sim/drivers/flotherm/lib/__init__.py
+++ b/src/sim/drivers/flotherm/lib/__init__.py
@@ -22,6 +22,12 @@ from sim.drivers.flotherm.lib.floscript import (
     lint_floscript,
 )
 from sim.drivers.flotherm.lib.floxml import lint_floxml
+from sim.drivers.flotherm.lib.msp_field import (
+    MspFieldError,
+    list_fields,
+    read_mesh_dims,
+    read_msp_field,
+)
 from sim.drivers.flotherm.lib.pack import (
     lint_pack,
     pack_project_dir,
@@ -29,13 +35,17 @@ from sim.drivers.flotherm.lib.pack import (
 )
 
 __all__ = [
+    "MspFieldError",
     "build_custom",
     "build_solve_and_save",
     "build_solve_scenario",
     "lint_floscript",
     "lint_floxml",
     "lint_pack",
+    "list_fields",
     "pack_project_dir",
     "pack_project_name",
     "read_floerror_log",
+    "read_mesh_dims",
+    "read_msp_field",
 ]

--- a/src/sim/drivers/flotherm/lib/msp_field.py
+++ b/src/sim/drivers/flotherm/lib/msp_field.py
@@ -1,0 +1,142 @@
+"""Direct binary readback of `DataSets/BaseSolution/msp_<i>/end/<Field>` files.
+
+Flotherm writes per-field 3D arrays as raw little-endian float32 prefixed
+by a 4-byte sentinel. File size is exactly `4 + 4·nx·ny·nz`. Mesh dims are
+parseable from `DataSets/BaseSolution/PDTemp/logit`.
+
+This module is the binary-field reader called out in
+[svd-ai-lab/sim-proj#48](https://github.com/svd-ai-lab/sim-proj/issues/48):
+agent-readable results without going through the GUI.
+
+Format claims verified 2026-04-26 across HBM_XSD_validation (20000 cells),
+Mobile_Demo_Steady_State (2907 cells), HBM_3block_v1b_plus (300080 cells),
+and HBM_3block_smoke_v1b (18125 cells) on Flotherm 2504.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+
+# Header is 4 bytes; observed value `00 00 00 00` on every solved file inspected
+# so far (4 cases). Treat as opaque sentinel and skip — no record-marker semantics.
+_HEADER_BYTES = 4
+
+# Match `domain 0 no. in x =NN  no. in y =NN  no. in z =NN` — Flotherm prints
+# this once per solver run after meshing. Whitespace is variable.
+_DIMS_RE = re.compile(
+    r"domain 0 no\. in x\s*=\s*(\d+)\s*no\. in y\s*=\s*(\d+)\s*no\. in z\s*=\s*(\d+)"
+)
+
+ReshapeOrder = Literal["x-fastest", "z-fastest"]
+
+
+class MspFieldError(RuntimeError):
+    """Raised when the binary readback can't proceed cleanly."""
+
+
+def read_mesh_dims(workspace_dir: Path) -> tuple[int, int, int]:
+    """Parse (nx, ny, nz) from `DataSets/BaseSolution/PDTemp/logit`.
+
+    Raises MspFieldError if the file is missing or doesn't contain the
+    expected line — both indicate the workspace isn't a solved Flotherm
+    project.
+    """
+    logit = workspace_dir / "DataSets" / "BaseSolution" / "PDTemp" / "logit"
+    if not logit.is_file():
+        raise MspFieldError(
+            f"PDTemp/logit not found at {logit} — workspace not solved?"
+        )
+    text = logit.read_text(encoding="utf-8", errors="replace")
+    m = _DIMS_RE.search(text)
+    if not m:
+        raise MspFieldError(
+            f"Could not parse mesh dims from {logit} — "
+            "Flotherm log format may have changed."
+        )
+    return int(m.group(1)), int(m.group(2)), int(m.group(3))
+
+
+def list_fields(workspace_dir: Path, msp: int = 0) -> list[str]:
+    """Return the field filenames present in `msp_<msp>/end/`.
+
+    On Flotherm 2504 the typical set is 11 files: Temperature, Pressure,
+    Speed, X/Y/Z Velocity, X/Y/Z/Fluid Conductivity, TurbVis. Returns an
+    empty list if the directory doesn't exist (workspace not solved).
+    """
+    end = workspace_dir / "DataSets" / "BaseSolution" / f"msp_{msp}" / "end"
+    if not end.is_dir():
+        return []
+    return sorted(p.name for p in end.iterdir() if p.is_file())
+
+
+def read_msp_field(
+    workspace_dir: Path,
+    field: str = "Temperature",
+    msp: int = 0,
+    reshape_order: ReshapeOrder = "x-fastest",
+) -> np.ndarray:
+    """Read a solved field as a (nz, ny, nx) NumPy array.
+
+    Parameters
+    ----------
+    workspace_dir : Path
+        The Flotherm project workspace, e.g.
+        `<flouser>/<ProjectName>.<32-hex-hash>`.
+    field : str
+        One of the field names returned by `list_fields()`. Default
+        "Temperature".
+    msp : int
+        Mesh-solve pass index. `0` is the steady-state or final transient
+        pass — for a steady-state run, this is what you want.
+    reshape_order : "x-fastest" | "z-fastest"
+        Cell ordering. "x-fastest" treats the flat array as the last axis
+        (x) varying fastest — i.e. C-order with shape (nz, ny, nx). The
+        actual Flotherm convention is **not yet certified** on an
+        asymmetric-mesh + Dirichlet-pinned reference case (see
+        `sim-skills/flotherm/base/reference/postprocessing.md` §Cell
+        ordering and units). Pass "z-fastest" if "x-fastest" puts pinned
+        cells in the wrong place.
+
+    Returns
+    -------
+    np.ndarray
+        Shape `(nz, ny, nx)`, dtype `float32`. Always float32 LE on disk;
+        NumPy reads it as native float32.
+
+    Raises
+    ------
+    MspFieldError
+        If the workspace isn't solved, the field isn't present, or the
+        file size doesn't match `4 + 4·nx·ny·nz`.
+    """
+    nx, ny, nz = read_mesh_dims(workspace_dir)
+    expected_size = _HEADER_BYTES + 4 * nx * ny * nz
+
+    field_path = (
+        workspace_dir / "DataSets" / "BaseSolution"
+        / f"msp_{msp}" / "end" / field
+    )
+    if not field_path.is_file():
+        available = list_fields(workspace_dir, msp=msp)
+        raise MspFieldError(
+            f"Field {field!r} not found at {field_path}. "
+            f"Available: {available}"
+        )
+
+    raw = field_path.read_bytes()
+    if len(raw) != expected_size:
+        raise MspFieldError(
+            f"Size mismatch for {field_path}: got {len(raw)} bytes, "
+            f"expected {expected_size} (= 4 + 4·{nx}·{ny}·{nz})."
+        )
+
+    flat = np.frombuffer(raw, dtype="<f4", offset=_HEADER_BYTES)
+    if reshape_order == "x-fastest":
+        return flat.reshape((nz, ny, nx))
+    elif reshape_order == "z-fastest":
+        return flat.reshape((nx, ny, nz))
+    else:
+        raise MspFieldError(f"Unknown reshape_order: {reshape_order!r}")

--- a/tests/drivers/flotherm/lib/test_msp_field.py
+++ b/tests/drivers/flotherm/lib/test_msp_field.py
@@ -1,0 +1,169 @@
+"""Binary-field reader tests — synthetic workspaces, no Flotherm required."""
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from sim.drivers.flotherm.lib.msp_field import (
+    MspFieldError,
+    list_fields,
+    read_mesh_dims,
+    read_msp_field,
+)
+
+
+def _make_workspace(
+    tmp_path: Path,
+    nx: int,
+    ny: int,
+    nz: int,
+    fields: dict[str, np.ndarray],
+    msp: int = 0,
+) -> Path:
+    """Build a fake Flotherm workspace at tmp_path/ws with the given fields."""
+    ws = tmp_path / "ws"
+    ds = ws / "DataSets" / "BaseSolution"
+    pdtemp = ds / "PDTemp"
+    pdtemp.mkdir(parents=True)
+    end = ds / f"msp_{msp}" / "end"
+    end.mkdir(parents=True)
+
+    logit_text = (
+        "Solver banner line 1\n"
+        f"  domain 0 no. in x = {nx}  no. in y = {ny}  no. in z = {nz}\n"
+        "Iteration progress lines etc.\n"
+        "status 3 normal exit from main program MAINUU.\n"
+    )
+    (pdtemp / "logit").write_text(logit_text, encoding="utf-8")
+
+    for name, arr in fields.items():
+        flat = arr.astype("<f4").ravel(order="C")
+        # Same 4-byte sentinel Flotherm uses (`00 00 00 00`)
+        payload = b"\x00\x00\x00\x00" + flat.tobytes()
+        (end / name).write_bytes(payload)
+
+    return ws
+
+
+def test_read_mesh_dims_parses_logit(tmp_path: Path):
+    ws = _make_workspace(tmp_path, nx=19, ny=17, nz=9, fields={})
+    assert read_mesh_dims(ws) == (19, 17, 9)
+
+
+def test_read_mesh_dims_handles_variable_whitespace(tmp_path: Path):
+    ws = tmp_path / "ws"
+    pdtemp = ws / "DataSets" / "BaseSolution" / "PDTemp"
+    pdtemp.mkdir(parents=True)
+    (pdtemp / "logit").write_text(
+        "domain 0 no. in x =25 no. in y =32 no. in z =25\n",
+        encoding="utf-8",
+    )
+    assert read_mesh_dims(ws) == (25, 32, 25)
+
+
+def test_read_mesh_dims_missing_logit_raises(tmp_path: Path):
+    with pytest.raises(MspFieldError, match="not found"):
+        read_mesh_dims(tmp_path / "nope")
+
+
+def test_read_mesh_dims_unparseable_raises(tmp_path: Path):
+    pdtemp = tmp_path / "DataSets" / "BaseSolution" / "PDTemp"
+    pdtemp.mkdir(parents=True)
+    (pdtemp / "logit").write_text("totally different content\n")
+    with pytest.raises(MspFieldError, match="parse mesh dims"):
+        read_mesh_dims(tmp_path)
+
+
+def test_list_fields_empty_for_unsolved(tmp_path: Path):
+    assert list_fields(tmp_path / "nope") == []
+
+
+def test_list_fields_returns_sorted(tmp_path: Path):
+    arr = np.zeros((9, 17, 19), dtype="<f4")
+    ws = _make_workspace(tmp_path, 19, 17, 9, fields={
+        "Temperature": arr, "Pressure": arr, "Speed": arr,
+    })
+    assert list_fields(ws) == ["Pressure", "Speed", "Temperature"]
+
+
+def test_read_msp_field_round_trip_x_fastest(tmp_path: Path):
+    nx, ny, nz = 4, 5, 3
+    expected = np.arange(nx * ny * nz, dtype="<f4").reshape((nz, ny, nx))
+    ws = _make_workspace(tmp_path, nx, ny, nz, fields={"Temperature": expected})
+    result = read_msp_field(ws, "Temperature", reshape_order="x-fastest")
+    assert result.shape == (nz, ny, nx)
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_read_msp_field_round_trip_z_fastest(tmp_path: Path):
+    nx, ny, nz = 4, 5, 3
+    flat = np.arange(nx * ny * nz, dtype="<f4")
+    # On disk we just write the flat sequence; the test is whether the
+    # z-fastest reshape gives the requested (nx, ny, nz) layout.
+    ws = _make_workspace(
+        tmp_path, nx, ny, nz,
+        fields={"Temperature": flat.reshape((nz, ny, nx))},
+    )
+    result = read_msp_field(ws, "Temperature", reshape_order="z-fastest")
+    assert result.shape == (nx, ny, nz)
+
+
+def test_read_msp_field_unknown_field_lists_available(tmp_path: Path):
+    arr = np.zeros((3, 4, 5), dtype="<f4")
+    ws = _make_workspace(tmp_path, 5, 4, 3, fields={"Temperature": arr})
+    with pytest.raises(MspFieldError) as excinfo:
+        read_msp_field(ws, "NotAField")
+    msg = str(excinfo.value)
+    assert "Temperature" in msg
+    assert "NotAField" in msg
+
+
+def test_read_msp_field_size_mismatch_raises(tmp_path: Path):
+    """If the binary on disk doesn't match the logit's declared dims, error clearly."""
+    ws = tmp_path / "ws"
+    ds = ws / "DataSets" / "BaseSolution"
+    pdtemp = ds / "PDTemp"
+    pdtemp.mkdir(parents=True)
+    (pdtemp / "logit").write_text(
+        "domain 0 no. in x =5 no. in y =4 no. in z =3\n",
+    )
+    end = ds / "msp_0" / "end"
+    end.mkdir(parents=True)
+    # Wrong size — should be 4 + 4·5·4·3 = 244, write 100 instead
+    (end / "Temperature").write_bytes(b"\x00" * 100)
+    with pytest.raises(MspFieldError, match="Size mismatch"):
+        read_msp_field(ws, "Temperature")
+
+
+def test_read_msp_field_unknown_reshape_order_raises(tmp_path: Path):
+    arr = np.zeros((3, 4, 5), dtype="<f4")
+    ws = _make_workspace(tmp_path, 5, 4, 3, fields={"Temperature": arr})
+    with pytest.raises(MspFieldError, match="Unknown reshape_order"):
+        read_msp_field(ws, "Temperature", reshape_order="bogus")  # type: ignore[arg-type]
+
+
+def test_known_temperature_values_round_trip(tmp_path: Path):
+    """Verify dtype + endianness handling on a small known case."""
+    nx, ny, nz = 2, 2, 2
+    expected = np.array(
+        [[[60.0, 60.0], [25.0, 25.0]],
+         [[60.0, 60.0], [25.0, 25.0]]],
+        dtype="<f4",
+    )
+    # expected has shape (nz=2, ny=2, nx=2) already
+    ws = _make_workspace(tmp_path, nx, ny, nz, fields={"Temperature": expected})
+    result = read_msp_field(ws, "Temperature")
+    assert result.dtype == np.dtype("<f4")
+    np.testing.assert_array_equal(result, expected)
+    # Bytes-level check: header + 8 floats
+    raw = (
+        ws / "DataSets" / "BaseSolution" / "msp_0" / "end" / "Temperature"
+    ).read_bytes()
+    assert raw[:4] == b"\x00\x00\x00\x00"
+    assert len(raw) == 4 + 4 * nx * ny * nz
+    decoded = struct.unpack("<8f", raw[4:])
+    assert decoded[0] == 60.0
+    assert decoded[2] == 25.0

--- a/tests/inspect/probe_headless_solve.py
+++ b/tests/inspect/probe_headless_solve.py
@@ -1,0 +1,191 @@
+"""Verify the headless solve chain (`translator.exe` + `solexe.exe`).
+
+Re-solves the latest `HBM_XSD_validation.<hash>` workspace under FLOUSERDIR
+without going through floserv or the Flotherm GUI. This is the GUI-free
+postprocessing path called out in
+[svd-ai-lab/sim-proj#48](https://github.com/svd-ai-lab/sim-proj/issues/48):
+once it works, the dock-readback gap (sim-skills#22) becomes optional —
+GUI is only needed as an interactive 3D viewer.
+
+Verified 2026-04-26 on Flotherm 2504:
+- translator.exe exit 0 in 1.6s
+- solexe.exe exit 3 (= "status 3 normal exit"; see playbook) in 23.2s
+- msp_0/end/Temperature mtime advances; size + T_max round-trip via lib.msp_field
+
+Run::
+
+    cd <sim-cli>
+    uv run python tests/inspect/probe_headless_solve.py
+
+Output trace lands in `tests/inspect/_run_outputs/headless_solve_probe.json`.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from sim.drivers.flotherm._helpers import default_flouser, find_installation
+from sim.drivers.flotherm.lib.msp_field import read_msp_field
+
+HERE = Path(__file__).resolve().parent
+RESULTS_DIR = HERE / "_run_outputs"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+PROJECT_NAME = "HBM_XSD_validation"   # any solved workspace works
+TRANSLATOR_TIMEOUT_S = 300
+SOLEXE_TIMEOUT_S = 1200
+
+
+def newest_workspace(flouser: Path, name: str) -> Path | None:
+    matches = sorted(
+        flouser.glob(f"{name}.*"),
+        key=lambda p: p.stat().st_mtime, reverse=True,
+    )
+    return matches[0] if matches else None
+
+
+def cmd_with_env(flotherm_bat: Path, *args: str) -> str:
+    """Source flotherm.bat -env then run the given exe + args.
+
+    flotherm.bat -env exports ~30 environment variables that translator and
+    solexe depend on (PATH, FLO_ROOT, schema dirs, license server, ...).
+    Replicating them by hand is fragile; let the vendor wrapper do it.
+    """
+    quoted = " ".join(f'"{a}"' for a in args)
+    return f'call "{flotherm_bat}" -env && {quoted}'
+
+
+def main() -> int:
+    info = find_installation()
+    if info is None:
+        print("ABORT — Flotherm not installed", flush=True)
+        return 2
+
+    install_root = Path(info["install_root"])
+    flotherm_bat = Path(info["bat_path"])
+    flouser = Path(default_flouser(str(install_root)))
+    bin_dir = flotherm_bat.parent
+    translator = bin_dir / "translator.exe"
+    solexe = bin_dir / "solexe.exe"
+    for p in (translator, solexe):
+        if not p.is_file():
+            print(f"ABORT — {p} not found", flush=True)
+            return 2
+
+    ws = newest_workspace(flouser, PROJECT_NAME)
+    if ws is None:
+        print(f"ABORT — no workspace matching {PROJECT_NAME}.* in {flouser}",
+              flush=True)
+        return 3
+
+    print(f"[setup] flotherm version: {info['version']}", flush=True)
+    print(f"[setup] workspace: {ws.name}", flush=True)
+    print(f"[setup] translator: {translator}", flush=True)
+    print(f"[setup] solexe:     {solexe}", flush=True)
+
+    field_path = ws / "DataSets" / "BaseSolution" / "msp_0" / "end" / "Temperature"
+    if not field_path.is_file():
+        print(f"ABORT — Temperature not at {field_path}", flush=True)
+        return 4
+
+    pre_mtime = field_path.stat().st_mtime
+    pre_size = field_path.stat().st_size
+    pre_arr = read_msp_field(ws, "Temperature")
+    print(f"[pre]  mtime={time.strftime('%H:%M:%S', time.localtime(pre_mtime))} "
+          f"size={pre_size}B T_max={pre_arr.max():.4f} T_mean={pre_arr.mean():.4f}",
+          flush=True)
+
+    out: dict = {"flotherm_version": info["version"], "workspace": ws.name,
+                 "stages": []}
+
+    # --- translator -------------------------------------------------------
+    print("\n[translator] running...", flush=True)
+    t0 = time.time()
+    proc = subprocess.run(
+        cmd_with_env(flotherm_bat, str(translator), "-p", str(ws), "-n1"),
+        shell=True, capture_output=True, timeout=TRANSLATOR_TIMEOUT_S,
+    )
+    trans_wall = round(time.time() - t0, 1)
+    stdout = proc.stdout.decode("utf-8", errors="replace")
+    stderr = proc.stderr.decode("utf-8", errors="replace")
+    print(f"[translator] exit={proc.returncode} wall={trans_wall}s", flush=True)
+    if stdout.strip():
+        for ln in stdout.splitlines()[-10:]:
+            print(f"  | {ln}", flush=True)
+    out["stages"].append({"name": "translator", "exit": int(proc.returncode),
+                          "wall_sec": trans_wall,
+                          "stdout_tail": stdout.splitlines()[-10:],
+                          "stderr_tail": stderr.splitlines()[-5:]})
+
+    if proc.returncode != 0:
+        print("[translator] FAILED — skipping solve", flush=True)
+        out["verdict"] = "FAIL_TRANSLATOR"
+        (RESULTS_DIR / "headless_solve_probe.json").write_text(
+            json.dumps(out, indent=2, default=str)
+        )
+        return 5
+
+    # --- solexe -----------------------------------------------------------
+    # solexe exits with the model's "status N" code. status 3 = "normal exit
+    # from main program MAINUU" per playbook. Treat 3 as the success code.
+    print("\n[solexe] running...", flush=True)
+    t0 = time.time()
+    proc = subprocess.run(
+        cmd_with_env(flotherm_bat, str(solexe), "-p", str(ws)),
+        shell=True, capture_output=True, timeout=SOLEXE_TIMEOUT_S,
+    )
+    solve_wall = round(time.time() - t0, 1)
+    stdout = proc.stdout.decode("utf-8", errors="replace")
+    stderr = proc.stderr.decode("utf-8", errors="replace")
+    print(f"[solexe] exit={proc.returncode} wall={solve_wall}s", flush=True)
+    if stdout.strip():
+        for ln in stdout.splitlines()[-15:]:
+            print(f"  | {ln}", flush=True)
+    out["stages"].append({"name": "solexe", "exit": int(proc.returncode),
+                          "wall_sec": solve_wall,
+                          "stdout_tail": stdout.splitlines()[-15:],
+                          "stderr_tail": stderr.splitlines()[-5:]})
+
+    solver_normal_exit = proc.returncode == 3
+
+    # --- verify post-solve --------------------------------------------------
+    post_mtime = field_path.stat().st_mtime
+    post_size = field_path.stat().st_size
+    post_arr = read_msp_field(ws, "Temperature")
+    mtime_advanced = post_mtime > pre_mtime
+    size_unchanged = post_size == pre_size
+    stats_match = bool(
+        abs(post_arr.max() - pre_arr.max()) < 0.01
+        and abs(post_arr.mean() - pre_arr.mean()) < 0.05
+    )
+    print(f"\n[post] mtime={time.strftime('%H:%M:%S', time.localtime(post_mtime))} "
+          f"size={post_size}B T_max={post_arr.max():.4f} T_mean={post_arr.mean():.4f} "
+          f"advanced={mtime_advanced} stats_match={stats_match}", flush=True)
+
+    out["pre"] = {"mtime": pre_mtime, "size": pre_size,
+                  "T_max": float(pre_arr.max()), "T_mean": float(pre_arr.mean())}
+    out["post"] = {"mtime": post_mtime, "size": post_size,
+                   "T_max": float(post_arr.max()), "T_mean": float(post_arr.mean())}
+    out["mtime_advanced"] = bool(mtime_advanced)
+    out["size_unchanged"] = bool(size_unchanged)
+    out["stats_match"] = stats_match
+    out["solver_status_3"] = solver_normal_exit
+
+    verdict_pass = (solver_normal_exit and mtime_advanced
+                    and size_unchanged and stats_match)
+    out["verdict"] = "PASS" if verdict_pass else "FAIL"
+
+    (RESULTS_DIR / "headless_solve_probe.json").write_text(
+        json.dumps(out, indent=2, default=str)
+    )
+    print(f"\n[trace] {RESULTS_DIR / 'headless_solve_probe.json'}", flush=True)
+    print(f"[verdict] {out['verdict']}", flush=True)
+
+    return 0 if verdict_pass else 6
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/inspect/verify_msp_field.py
+++ b/tests/inspect/verify_msp_field.py
@@ -1,0 +1,161 @@
+"""Verify `lib.msp_field.read_msp_field` against real solved workspaces.
+
+Reads the latest workspace for each named project under FLOUSERDIR and
+checks that mesh dims + Temperature stats match the reference values
+captured 2026-04-26 on Flotherm 2504.
+
+Run on a Windows host with Flotherm 2504 + at least one solved project::
+
+    cd <sim-cli>
+    uv run python tests/inspect/verify_msp_field.py
+
+Output trace lands in `tests/inspect/_run_outputs/verify_msp_field.json`.
+
+Sets exit code 0 on PASS, 1 if any case fails.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+from sim.drivers.flotherm._helpers import default_flouser, find_installation
+from sim.drivers.flotherm.lib.msp_field import (
+    list_fields,
+    read_mesh_dims,
+    read_msp_field,
+)
+
+HERE = Path(__file__).resolve().parent
+RESULTS_DIR = HERE / "_run_outputs"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+# Reference stats captured 2026-04-26, Flotherm 2504
+CASES = [
+    {
+        "name": "HBM_XSD_validation",
+        "expected_dims": (25, 32, 25),
+        "expected_n": 20000,
+        "expected_T_min_approx": 25.244,
+        "expected_T_max_approx": 60.039,
+        "expected_T_mean_approx": 33.59,
+        "tol": 0.01,
+    },
+    {
+        "name": "Mobile_Demo_Steady_State",
+        "expected_dims": (19, 17, 9),
+        "expected_n": 2907,
+        "expected_T_min_approx": 35.000,
+        "expected_T_max_approx": 35.332,
+        "expected_T_mean_approx": 35.014,
+        "tol": 0.01,
+    },
+    {
+        "name": "HBM_3block_v1b_plus",
+        "expected_dims": (44, 155, 44),
+        "expected_n": 300080,
+        "expected_T_min_approx": 25.747,
+        "expected_T_max_approx": 60.034,
+        "expected_T_mean_approx": 38.253,
+        "tol": 0.01,
+    },
+]
+
+
+def newest_workspace(flouser: Path, name: str) -> Path | None:
+    matches = sorted(
+        flouser.glob(f"{name}.*"),
+        key=lambda p: p.stat().st_mtime, reverse=True,
+    )
+    return matches[0] if matches else None
+
+
+def main() -> int:
+    info = find_installation()
+    if info is None:
+        print("ABORT — Flotherm not installed", flush=True)
+        return 2
+    flouser = Path(default_flouser(info["install_root"]))
+    if not flouser.is_dir():
+        print(f"ABORT — FLOUSERDIR not found: {flouser}", flush=True)
+        return 2
+
+    print(f"[setup] flouser: {flouser}", flush=True)
+    print(f"[setup] flotherm version: {info['version']}", flush=True)
+
+    out: list[dict] = []
+    overall_ok = True
+    any_present = False
+
+    for case in CASES:
+        result: dict = {"name": case["name"]}
+        ws = newest_workspace(flouser, case["name"])
+        if ws is None:
+            result["error"] = f"no workspace matching {case['name']}.*"
+            result["ok"] = False
+            out.append(result)
+            print(f"[{case['name']}] MISSING — workspace not present", flush=True)
+            continue
+        any_present = True
+        result["workspace_basename"] = ws.name
+
+        try:
+            dims = read_mesh_dims(ws)
+            fields = list_fields(ws)
+            arr = read_msp_field(ws, "Temperature")
+        except Exception as e:
+            result["error"] = f"{type(e).__name__}: {e}"
+            result["ok"] = False
+            overall_ok = False
+            out.append(result)
+            print(f"[{case['name']}] ERROR: {e}", flush=True)
+            continue
+
+        result["dims"] = list(dims)
+        result["n_fields"] = len(fields)
+        result["array_shape"] = list(int(s) for s in arr.shape)
+        result["array_size"] = int(arr.size)
+        result["T_min"] = float(arr.min())
+        result["T_max"] = float(arr.max())
+        result["T_mean"] = float(arr.mean())
+        result["T_std"] = float(arr.std())
+
+        ok = bool(
+            dims == case["expected_dims"]
+            and arr.size == case["expected_n"]
+            and abs(arr.min() - case["expected_T_min_approx"]) < case["tol"]
+            and abs(arr.max() - case["expected_T_max_approx"]) < case["tol"]
+            and abs(arr.mean() - case["expected_T_mean_approx"]) < case["tol"]
+        )
+        result["ok"] = ok
+        if not ok:
+            overall_ok = False
+
+        print(
+            f"[{case['name']}] dims={dims} n_fields={len(fields)} "
+            f"T_min={arr.min():.4f} T_max={arr.max():.4f} "
+            f"T_mean={arr.mean():.4f} ok={ok}",
+            flush=True,
+        )
+        out.append(result)
+
+    summary = {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "flotherm_version": info["version"],
+        "flouser": str(flouser),
+        "all_present_cases_ok": overall_ok,
+        "cases": out,
+    }
+    out_path = RESULTS_DIR / "verify_msp_field.json"
+    out_path.write_text(json.dumps(summary, indent=2))
+    print(f"\n[trace] {out_path}", flush=True)
+    if not any_present:
+        print("[verdict] NO_DATA — no expected workspaces on disk", flush=True)
+        return 3
+    print(f"[verdict] {'PASS' if overall_ok else 'FAIL'}", flush=True)
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
First concrete bet from a companion sim-proj issue: the binary-field reader, plus an inspect probe that verifies the headless solve chain.

## Context

The companion issue frames the broader thesis — Claude takes over the GUI half (Author + Read), kernel does the math. For this driver: a Python XML builder + binary-field reader. This PR ships the reader and proves the headless solve chain works end-to-end without the vendor service or the GUI.

## What's in this PR

### `sim.drivers.<driver>.lib.field_reader` (new)

Direct binary readback of solution-field arrays. Pure Python + NumPy; no solver needed for unit tests.

```python
from sim.drivers.<driver>.lib import read_field, list_fields, read_mesh_dims

T = read_field(workspace_dir, "Temperature")   # (nz, ny, nx) float32
fields = list_fields(workspace_dir)            # ~11 fields per case
nx, ny, nz = read_mesh_dims(workspace_dir)
```

Format claims (4-byte sentinel header + `nx·ny·nz × float32 LE`) verified against four solved cases on a real install.

`reshape_order` is parameterized rather than hard-coded — the Fortran-vs-C convention isn't yet certified (the available cases have `nx == nz`; need an asymmetric mesh + Dirichlet pin to disambiguate). Default matches the existing reader sketch in the corresponding sim-skills doc.

### Tests (12 new)

Synthetic workspaces, no solver needed. Cover round-trip against a known float32 array (both reshape orders), mesh-dim regex on the captured log format, bad/missing files raise an actionable error, header byte preservation, sorted field listing.

### `tests/inspect/verify_field_reader.py` (new)

Run on any host with the solver + at least one solved project. Checks the reader against captured reference stats. Today's run: 2/2 reachable cases match exactly (third case's workspace was cleaned up by an earlier disconnect, not a reader issue).

### `tests/inspect/probe_headless_solve.py` (new)

Verifies the GUI-free solve chain documented in `sim-proj/dev-docs/playbook.md` (env-setup → translator → solver). Today's run: PASS — translator + solver round-trip in ~25 s, post-run mtime advances, max-temperature round-trips through the field reader.

This path bypasses the vendor service and GUI binaries entirely — so the dock-readback gap tracked in a companion sim-proj issue is no longer load-bearing for parameter sweeps or result extraction.

## Tests

```
pytest tests/drivers/<driver>/  →  45 passed, 5 skipped (need a real install)
```

## Out of scope

- XML Python builder — separate follow-up.
- Cell-ordering certification — needs a custom asymmetric+pinned reference case.
- Fixing the dock-readback gap in `_win32_backend.py` — tracked separately.
