### PR TITLE
ltspice: dispatch .asc schematics through sim_ltspice.run_asc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ changes at milestone boundaries.
 
 ### Added
 
+- **LTspice driver accepts `.asc` schematics.** `LTspiceDriver.detect`,
+  `lint`, and `run_file` now route `.asc` inputs through
+  `sim_ltspice.run_asc`, which flattens the schematic to a sibling `.net`
+  via the pure-Python `schematic_to_netlist` path before LTspice runs.
+  The GUI is no longer needed to author or transform a schematic — only
+  to render waveforms (already replaceable via `sim-ltspice.raw`). Lint
+  for `.asc` checks the `Version ` header and that at least one
+  `TEXT … !.<analysis>` directive is present. `FlattenError` from the
+  flattener surfaces as `RuntimeError` through the driver protocol.
+  Requires `sim-ltspice>=0.2.2`.
+
 - **`python -m sim` invocation (equivalent to the `sim` console script).**
   Adds `src/sim/__main__.py` so `python -m sim ...` reaches the same Click
   group as the installed `sim` entry point. Lets developers launch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pyyaml>=6.0", # reads driver compatibility.yaml files
     "Pillow>=10", # sim screenshot endpoint uses PIL.ImageGrab
     "lxml>=5.0", # XSD validation for FloSCRIPT lint
-    "sim-ltspice>=0.2", # LTspice file formats + runtime — sim-cli's LTspice driver delegates here
+    "sim-ltspice>=0.2.2", # LTspice file formats + runtime — sim-cli's LTspice driver delegates here. >=0.2.2 for run_asc.
     "tomli>=2.0; python_version<'3.11'", # TOML parser for config.py; stdlib tomllib is 3.11+
     "pywinauto>=0.6.8; sys_platform == 'win32'", # GUI automation backend for Flotherm (and other solvers without a batch API). Spawned in a subprocess via sys.executable, so must live in the same venv as sim-server.
 ]

--- a/src/sim/drivers/ltspice/driver.py
+++ b/src/sim/drivers/ltspice/driver.py
@@ -100,7 +100,6 @@ class LTspiceDriver:
             return False
 
     def lint(self, script: Path) -> LintResult:
-        diagnostics: list[Diagnostic] = []
         suffix = script.suffix.lower()
         if suffix not in _ACCEPTED_SUFFIXES:
             return LintResult(

--- a/src/sim/drivers/ltspice/driver.py
+++ b/src/sim/drivers/ltspice/driver.py
@@ -1,12 +1,13 @@
 """LTspice driver for sim — thin adapter over ``sim_ltspice``.
 
 The heavy work (install discovery, subprocess invocation, `.log`
-encoding sniffing, `.raw` header parsing) lives in the standalone
-``sim-ltspice`` package on PyPI. This module only bridges between that
-library and sim-cli's ``DriverProtocol``.
+encoding sniffing, `.raw` header parsing, `.asc` flattening) lives in
+the standalone ``sim-ltspice`` package on PyPI. This module only
+bridges between that library and sim-cli's ``DriverProtocol``.
 
-Scope v1 still accepts ``.net``, ``.cir``, ``.sp`` netlists. ``.asc``
-schematic support lands once ``sim_ltspice`` grows ``run_asc``.
+Accepts ``.net`` / ``.cir`` / ``.sp`` netlists and ``.asc``
+schematics. Schematics are flattened to a sibling netlist via
+``sim_ltspice.run_asc`` before the actual solve.
 """
 from __future__ import annotations
 
@@ -18,7 +19,13 @@ from pathlib import Path
 from sim_ltspice import NETLIST_SUFFIXES, find_ltspice
 from sim_ltspice import RunResult as LtRunResult
 from sim_ltspice.install import Install
-from sim_ltspice.runner import LtspiceNotInstalled, UnsupportedInput, run_net
+from sim_ltspice.netlist import FlattenError
+from sim_ltspice.runner import (
+    LtspiceNotInstalled,
+    UnsupportedInput,
+    run_asc,
+    run_net,
+)
 
 from sim.driver import (
     ConnectionInfo,
@@ -29,8 +36,17 @@ from sim.driver import (
 )
 
 
+_ASC_SUFFIX = ".asc"
+_ACCEPTED_SUFFIXES = NETLIST_SUFFIXES + (_ASC_SUFFIX,)
+
 _ANALYSIS_RE = re.compile(
     r"^\s*\.(tran|ac|dc|op|noise|tf|four|fft|meas)\b",
+    re.MULTILINE | re.IGNORECASE,
+)
+# In .asc schematics, analysis directives live inside TEXT ... ! lines:
+#   TEXT 0 200 Left 2 !.tran 0 5m 0 1u
+_ASC_ANALYSIS_RE = re.compile(
+    r"^\s*TEXT\b.*!\s*\.(tran|ac|dc|op|noise|tf|four|fft|meas)\b",
     re.MULTILINE | re.IGNORECASE,
 )
 
@@ -79,21 +95,21 @@ class LTspiceDriver:
 
     def detect(self, script: Path) -> bool:
         try:
-            return script.suffix.lower() in NETLIST_SUFFIXES and script.is_file()
+            return script.suffix.lower() in _ACCEPTED_SUFFIXES and script.is_file()
         except OSError:
             return False
 
     def lint(self, script: Path) -> LintResult:
         diagnostics: list[Diagnostic] = []
         suffix = script.suffix.lower()
-        if suffix not in NETLIST_SUFFIXES:
+        if suffix not in _ACCEPTED_SUFFIXES:
             return LintResult(
                 ok=False,
                 diagnostics=[Diagnostic(
                     level="error",
                     message=(
                         f"Unsupported file type: {suffix} "
-                        f"(expected one of {', '.join(NETLIST_SUFFIXES)})"
+                        f"(expected one of {', '.join(_ACCEPTED_SUFFIXES)})"
                     ),
                 )],
             )
@@ -105,6 +121,12 @@ class LTspiceDriver:
                 diagnostics=[Diagnostic(level="error", message=f"Cannot read: {exc}")],
             )
 
+        if suffix == _ASC_SUFFIX:
+            return self._lint_asc(text)
+        return self._lint_netlist(text)
+
+    def _lint_netlist(self, text: str) -> LintResult:
+        diagnostics: list[Diagnostic] = []
         if not text.strip():
             return LintResult(
                 ok=False,
@@ -128,6 +150,29 @@ class LTspiceDriver:
                 message="Looks like an LTspice .asc schematic, not a netlist",
             ))
 
+        ok = not any(d.level == "error" for d in diagnostics)
+        return LintResult(ok=ok, diagnostics=diagnostics)
+
+    def _lint_asc(self, text: str) -> LintResult:
+        diagnostics: list[Diagnostic] = []
+        if not text.strip():
+            return LintResult(
+                ok=False,
+                diagnostics=[Diagnostic(level="error", message="Schematic is empty")],
+            )
+        if not text.lstrip().startswith("Version "):
+            diagnostics.append(Diagnostic(
+                level="error",
+                message="Missing 'Version ' header — file is not an LTspice schematic",
+            ))
+        if not _ASC_ANALYSIS_RE.search(text):
+            diagnostics.append(Diagnostic(
+                level="error",
+                message=(
+                    "No SPICE analysis directive found in TEXT lines "
+                    "(.tran / .ac / .dc / .op / .noise / .tf / .four)"
+                ),
+            ))
         ok = not any(d.level == "error" for d in diagnostics)
         return LintResult(ok=ok, diagnostics=diagnostics)
 
@@ -167,9 +212,10 @@ class LTspiceDriver:
         return {}
 
     def run_file(self, script: Path) -> RunResult:
-        if script.suffix.lower() not in NETLIST_SUFFIXES:
+        suffix = script.suffix.lower()
+        if suffix not in _ACCEPTED_SUFFIXES:
             raise RuntimeError(
-                f"ltspice driver only accepts {NETLIST_SUFFIXES} "
+                f"ltspice driver only accepts {_ACCEPTED_SUFFIXES} "
                 f"(got {script.suffix})"
             )
         # Mirror the driver-protocol contract: raise RuntimeError if
@@ -181,11 +227,16 @@ class LTspiceDriver:
             )
 
         try:
-            lt: LtRunResult = run_net(script)
+            if suffix == _ASC_SUFFIX:
+                lt: LtRunResult = run_asc(script)
+            else:
+                lt = run_net(script)
         except LtspiceNotInstalled as exc:
             raise RuntimeError(str(exc)) from exc
         except UnsupportedInput as exc:
             raise RuntimeError(str(exc)) from exc
+        except FlattenError as exc:
+            raise RuntimeError(f"Cannot flatten schematic: {exc}") from exc
 
         # Fold sim_ltspice's structured log + trace list into the JSON
         # summary so parse_output() can pick it up from stdout.

--- a/tests/drivers/ltspice/test_ltspice_driver.py
+++ b/tests/drivers/ltspice/test_ltspice_driver.py
@@ -35,6 +35,11 @@ class TestDetect:
         p.write_text("* hi\nV1 1 0 1\n.end\n")
         assert self.driver.detect(p) is True
 
+    def test_asc_suffix(self, tmp_path):
+        p = tmp_path / "x.asc"
+        p.write_text("Version 4\nSHEET 1 880 680\n")
+        assert self.driver.detect(p) is True
+
     def test_wrong_suffix(self, tmp_path):
         p = tmp_path / "x.py"
         p.write_text("print('hi')\n")
@@ -70,6 +75,41 @@ class TestLint:
         p = tmp_path / "x.txt"
         p.write_text("* V1 1 0 1\n.tran 1m\n.end\n")
         assert self.driver.lint(p).ok is False
+
+
+class TestLintAsc:
+    def setup_method(self):
+        self.driver = LTspiceDriver()
+
+    def test_good_asc(self, tmp_path):
+        p = tmp_path / "rc.asc"
+        p.write_text(
+            "Version 4\nSHEET 1 880 680\n"
+            "SYMBOL res 0 0 R0\nSYMATTR InstName R1\n"
+            "TEXT 0 200 Left 2 !.tran 0 5m\n"
+        )
+        assert self.driver.lint(p).ok is True
+
+    def test_empty_asc(self, tmp_path):
+        p = tmp_path / "x.asc"
+        p.write_text("")
+        r = self.driver.lint(p)
+        assert r.ok is False
+        assert any("empty" in d.message.lower() for d in r.diagnostics)
+
+    def test_missing_version_header(self, tmp_path):
+        p = tmp_path / "x.asc"
+        p.write_text("not a real schematic\nTEXT 0 0 Left 2 !.tran 1m\n")
+        r = self.driver.lint(p)
+        assert r.ok is False
+        assert any("version" in d.message.lower() for d in r.diagnostics)
+
+    def test_no_analysis_directive(self, tmp_path):
+        p = tmp_path / "x.asc"
+        p.write_text("Version 4\nSHEET 1 880 680\nSYMBOL res 0 0 R0\n")
+        r = self.driver.lint(p)
+        assert r.ok is False
+        assert any("analysis" in d.message.lower() for d in r.diagnostics)
 
 
 class TestConnect:
@@ -234,3 +274,66 @@ class TestRunFile:
         result = d.run_file(script)
         assert result.exit_code == 1
         assert any("convergence" in e.lower() for e in result.errors)
+
+    def test_asc_dispatches_to_run_asc(self, monkeypatch, tmp_path):
+        """A `.asc` input must reach run_asc, not run_net."""
+        from sim_ltspice import RunResult as LtRunResult
+        from sim_ltspice.log import LogResult
+
+        d = LTspiceDriver()
+        monkeypatch.setattr(
+            d, "detect_installed",
+            lambda: [SolverInstall(
+                name="ltspice", version="17.2.4", path="/x", source="test",
+                extra={"exe": "/x/LTspice"},
+            )],
+        )
+
+        asc = tmp_path / "rc.asc"
+        asc.write_text("Version 4\nSHEET 1 880 680\n")
+
+        called: dict[str, object] = {}
+
+        def fake_asc(script):
+            called["asc"] = Path(script)
+            return LtRunResult(
+                exit_code=0, stdout="", stderr="",
+                duration_s=0.01, script=Path(script), started_at="",
+                log=LogResult(), log_path=None, raw_path=None, raw_traces=[],
+            )
+
+        def fake_net(_script):
+            called["net"] = True
+            raise AssertionError("run_net must not be called for .asc")
+
+        monkeypatch.setattr("sim.drivers.ltspice.driver.run_asc", fake_asc)
+        monkeypatch.setattr("sim.drivers.ltspice.driver.run_net", fake_net)
+
+        result = d.run_file(asc)
+        assert called["asc"] == asc
+        assert "net" not in called
+        assert result.exit_code == 0
+        assert result.solver == "ltspice"
+
+    def test_flatten_error_maps_to_runtime_error(self, monkeypatch, tmp_path):
+        """A FlattenError from sim_ltspice must surface as RuntimeError."""
+        from sim_ltspice.netlist import FlattenError as LtFlattenError
+
+        d = LTspiceDriver()
+        monkeypatch.setattr(
+            d, "detect_installed",
+            lambda: [SolverInstall(
+                name="ltspice", version="17.2.4", path="/x", source="test",
+                extra={"exe": "/x/LTspice"},
+            )],
+        )
+
+        asc = tmp_path / "x.asc"
+        asc.write_text("Version 4\nSHEET 1 880 680\n")
+
+        def boom(_script):
+            raise LtFlattenError("symbol 'no_such' not found in catalog")
+
+        monkeypatch.setattr("sim.drivers.ltspice.driver.run_asc", boom)
+        with pytest.raises(RuntimeError, match="(?i)flatten"):
+            d.run_file(asc)

--- a/uv.lock
+++ b/uv.lock
@@ -1936,15 +1936,15 @@ wheels = [
 
 [[package]]
 name = "sim-ltspice"
-version = "0.2.0"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/5f/52/73416f7afa64c579f6c41e813746219dd5f882f811fc322eac493cb6cf63/sim_ltspice-0.2.0.tar.gz", hash = "sha256:868dbe4f45bb3c292e1698943c6f2de1ac4ffe8c3b642864b41789b70f0475b1", size = 171494 }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/fc/888eb1b6cab101663944fd74c16b3b42552b913a5a0e657432727f9a46cf/sim_ltspice-0.2.2.tar.gz", hash = "sha256:dd01409560b717fd7938e28a41335cb3b82dfc947a4413972e5fda963c590f92", size = 179553 }
 wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/06/34/8c5630f602c682ec5a3fad07ae794a882652fcb5f1f148dfc909661d241f/sim_ltspice-0.2.0-py3-none-any.whl", hash = "sha256:14d5c459ec246546005d82473a82a9c7c2d1db3e14a6c5d89769056ffc8424da", size = 42838 },
+    { url = "https://files.pythonhosted.org/packages/5c/35/1e7aa4a4d9ba6324facb21f311b0f0d6591c089f47f436663e3d7dc44104/sim_ltspice-0.2.2-py3-none-any.whl", hash = "sha256:98269dc1964da4741e5b299257e1e25391b90cf7d30bd64cc91b54a5c345855d", size = 45837 },
 ]
 
 [[package]]
@@ -1997,7 +1997,7 @@ requires-dist = [
     { name = "pywinauto", marker = "sys_platform == 'win32'", specifier = ">=0.6.8" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
-    { name = "sim-ltspice", specifier = ">=0.2" },
+    { name = "sim-ltspice", specifier = ">=0.2.2" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "uvicorn", specifier = ">=0.34" },
 ]


### PR DESCRIPTION
## Summary

- LTspice driver now accepts \`.asc\` schematics on top of the existing \`.net\` / \`.cir\` / \`.sp\` netlists.
- \`detect\`, \`lint\`, and \`run_file\` all branch on suffix; \`.asc\` routes through the new \`sim_ltspice.run_asc\` helper, which flattens the schematic to a sibling \`.net\` via the pure-Python \`schematic_to_netlist\` path before invoking LTspice.
- Lint for \`.asc\` validates the \`Version \` header and the presence of at least one \`TEXT … !.<analysis>\` directive.
- \`FlattenError\` from the flattener surfaces as \`RuntimeError\` per the driver-protocol convention.
- Bumps \`sim-ltspice\` floor to \`>=0.2.2\` where \`run_asc\` lands.

## Why

Closes the LTspice slice of svd-ai-lab/sim-proj#48 — the GUI-free \"author → solve → read\" loop. \`sim-ltspice\` already had every primitive (\`read_asc\`, \`schematic_to_netlist\`, \`write_net\`, \`run_net\`, \`SymbolCatalog\`); the wrapper landed in svd-ai-lab/sim-ltspice#18. This PR exposes it through the sim-cli driver protocol so callers don't need to know which path they're on.

## Blocked on

- svd-ai-lab/sim-ltspice#18 — adds \`run_asc\` (must merge + 0.2.2 release before this lands).

## Test plan

- [x] \`pytest tests/drivers/ltspice/\` — 27 pass on macOS (was 22 + 5 new + e2e), with \`sim-ltspice 0.2.2\` editable-installed locally
- [x] Unit: \`detect\` accepts \`.asc\`
- [x] Unit: \`.asc\` lint catches missing \`Version \` header and missing analysis directive
- [x] Unit: \`run_file\` on \`.asc\` reaches \`run_asc\`, never \`run_net\`
- [x] Unit: \`FlattenError\` from the flattener maps to \`RuntimeError\`
- [ ] End-to-end with real LTspice on a schematic fixture (deferred to integration on Windows test host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)