### PR TITLE
feat(driver): describe(model) — typed walk over the physics tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ changes at milestone boundaries.
 
 ### Added
 
+- **`sim.drivers.comsol.lib.describe(model, what="physics")`** — typed
+  walk over the COMSOL Java model tree returning a structured Python
+  dict (and a compact `format_text()` plain-text rendering) of all
+  physics interfaces and their features. Replaces hand-rolled tree
+  introspection in `sim exec` snippets — agents can now answer "what's
+  in this model" with one helper call. Pure-Python; lives in
+  `comsol/lib/` mirroring the `flotherm/lib/` deferred-package
+  convention. 18 unit tests on macOS use a hand-rolled stand-in for
+  the JPype tree; live verification gate at
+  `tests/inspect/probe_describe_physics.py`.
+
 - **LTspice driver accepts `.asc` schematics.** `LTspiceDriver.detect`,
   `lint`, and `run_file` now route `.asc` inputs through
   `sim_ltspice.run_asc`, which flattens the schematic to a sibling `.net`

--- a/src/sim/drivers/comsol/lib/__init__.py
+++ b/src/sim/drivers/comsol/lib/__init__.py
@@ -1,0 +1,14 @@
+"""Cross-platform COMSOL helpers — pure-Python utilities that walk a live
+COMSOL Java model tree to produce human-readable summaries.
+
+Like `flotherm/lib/`, this subpackage holds code that can be exercised
+on macOS / Linux without COMSOL installed (the live-tree code paths are
+mocked in unit tests). The boundary mirrors the deferred-package
+convention: when this grows past ~1500 LOC or a second consumer wants
+the API, it migrates to `sim-comsol` on PyPI.
+"""
+from __future__ import annotations
+
+from sim.drivers.comsol.lib.describe import describe, format_text
+
+__all__ = ["describe", "format_text"]

--- a/src/sim/drivers/comsol/lib/describe.py
+++ b/src/sim/drivers/comsol/lib/describe.py
@@ -1,0 +1,203 @@
+"""Walk a COMSOL Java model tree and produce a structured summary.
+
+The COMSOL Java API is a near-1:1 mirror of the GUI tree — thousands
+of nodes, undocumented type strings, default features auto-created
+beside user-created ones. `describe()` reduces that to a typed Python
+dict (and a compact text format) so an agent can answer "what's in
+this model" without walking the tree by hand each time.
+
+Scope: physics interfaces and their features. Selections, materials,
+mesh, and study layers land in follow-up slices.
+
+Read-side API observed against COMSOL 6.4 + Heat Transfer in Solids
+(see `tests/inspect/verify_describe_physics.py`):
+  - `model.physics().tags()`            → Java string array of physics tags
+  - `model.physics(tag).name()`         → display name
+  - `model.physics(tag).getType()`      → type string ("HeatTransfer")
+  - `phy.feature().tags()`              → all features (user + defaults)
+  - `feat.getType()`                    → feature type string
+  - `feat.name()`                       → display name
+  - `feat.selection().entities()`       → int[] of geometric entity ids
+  - `feat.selection().named()`          → named-selection tag, or ""
+  - `feat.properties()`                 → string[] of property names
+  - `feat.getString(name)`              → property value as string
+
+Selection dimension is intentionally not surfaced: COMSOL's Java
+`Selection.dimension()` returned a 4-byte little-endian buffer through
+JPype rather than a Python int during probing, so we drop that field
+until a reliable accessor is found. Callers can infer dimension from
+the feature type ("...Boundary" → 2D in 3D models, "Solid..." → 3D).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+# Curated highlight properties per feature type — values shown inline in
+# `format_text()`. Other properties remain available in the full dict.
+_HIGHLIGHT_PROPS: dict[str, tuple[str, ...]] = {
+    "TemperatureBoundary": ("T0",),
+    "HeatFluxBoundary": ("HeatFluxType", "q0_input", "h", "Text"),
+    "HeatSource": ("Q0",),
+    "ThinLayer": ("ThinLayerType", "ds", "k_mat"),
+    "ThermalInsulation": (),  # default — no useful highlight
+    "SolidHeatTransferModel": ("Solid_material", "k", "rho", "Cp"),
+    "init": ("Tinit",),
+}
+
+
+def describe(model: Any, what: str = "physics") -> dict[str, Any]:
+    """Return a structured summary of the live COMSOL model.
+
+    Parameters
+    ----------
+    model
+        Live COMSOL Java model (the object injected as `model` into a
+        `sim exec` snippet). Anything responding to the read-side API
+        above will work — unit tests pass a Python stub.
+    what
+        Currently only ``"physics"`` is implemented. Future scopes:
+        ``"selections"``, ``"materials"``, ``"mesh"``, ``"study"``,
+        ``"all"``.
+
+    Returns
+    -------
+    dict
+        ``{"what": "physics", "physics": [<interface dict>, ...]}``
+        where each interface dict has ``tag`` / ``type`` / ``name`` /
+        ``features`` (a list of feature dicts).
+    """
+    if what != "physics":
+        raise ValueError(
+            f"describe(): only what='physics' is implemented "
+            f"(got {what!r}). Selections / materials / mesh / study "
+            f"land in follow-up slices."
+        )
+    return {"what": "physics", "physics": _walk_physics(model)}
+
+
+def _walk_physics(model: Any) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for tag in _str_list(model.physics().tags()):
+        phy = model.physics(tag)
+        out.append({
+            "tag": tag,
+            "type": _safe_str(lambda: phy.getType()),
+            "name": _safe_str(lambda: phy.name()),
+            "features": _walk_features(phy),
+        })
+    return out
+
+
+def _walk_features(phy: Any) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for tag in _str_list(phy.feature().tags()):
+        feat = phy.feature(tag)
+        out.append({
+            "tag": tag,
+            "type": _safe_str(lambda: feat.getType()),
+            "name": _safe_str(lambda: feat.name()),
+            "selection_entities": _safe_int_list(lambda: feat.selection().entities()),
+            "selection_named": _safe_str(lambda: feat.selection().named()) or None,
+            "properties": _read_properties(feat),
+        })
+    return out
+
+
+def _read_properties(feat: Any) -> dict[str, str]:
+    """Read every property of a feature as a string. Errors are dropped
+    silently — a busted property shouldn't sink the whole summary."""
+    try:
+        names = _str_list(feat.properties())
+    except Exception:
+        return {}
+    out: dict[str, str] = {}
+    for n in names:
+        try:
+            out[n] = str(feat.getString(n))
+        except Exception:
+            continue
+    return out
+
+
+def _str_list(java_array: Any) -> list[str]:
+    """Coerce a Java string array (JPype) to a Python ``list[str]``."""
+    return [str(x) for x in java_array]
+
+
+def _safe_int_list(thunk: Any) -> list[int]:
+    """Run ``thunk`` and coerce its iterable result to ``list[int]``,
+    or return ``[]`` on failure."""
+    try:
+        return [int(x) for x in thunk()]
+    except Exception:
+        return []
+
+
+def _safe_str(thunk: Any) -> str:
+    try:
+        return str(thunk())
+    except Exception:
+        return ""
+
+
+# ----------------------------------------------------------------------
+# Text rendering
+# ----------------------------------------------------------------------
+
+
+def format_text(summary: dict[str, Any]) -> str:
+    """Render a `describe()` summary as a compact human-readable block.
+
+    Layout::
+
+        Physics: <tag> (<type>) — "<name>"
+          features (<n>):
+            <tag>      <type>           "<name>"            entities=[...]    <highlights>
+    """
+    if summary.get("what") != "physics":
+        raise ValueError("format_text(): only physics summaries are supported")
+
+    interfaces = summary.get("physics") or []
+    if not interfaces:
+        return "(no physics interfaces in model)"
+
+    lines: list[str] = []
+    for i, ifc in enumerate(interfaces):
+        if i > 0:
+            lines.append("")
+        lines.append(
+            f'Physics: {ifc["tag"]} ({ifc["type"]}) — "{ifc["name"]}"'
+        )
+        feats = ifc.get("features") or []
+        lines.append(f"  features ({len(feats)}):")
+        for f in feats:
+            lines.append("    " + _format_feature_line(f))
+    return "\n".join(lines)
+
+
+def _format_feature_line(f: dict[str, Any]) -> str:
+    tag = f["tag"]
+    ftype = f["type"]
+    name = f["name"]
+    ents = f.get("selection_entities") or []
+    sel_named = f.get("selection_named")
+
+    sel_str = ""
+    if sel_named:
+        sel_str = f'sel="{sel_named}"'
+    elif ents:
+        sel_str = f"entities={list(ents)}"
+
+    highlights: list[str] = []
+    props = f.get("properties") or {}
+    for hp in _HIGHLIGHT_PROPS.get(ftype, ()):
+        if hp in props:
+            highlights.append(f"{hp}={props[hp]}")
+    hl_str = " ".join(highlights)
+
+    head = f'{tag:<10} {ftype:<28} "{name}"'
+    tail_parts = [p for p in (sel_str, hl_str) if p]
+    if not tail_parts:
+        return head
+    return head + "  " + "  ".join(tail_parts)

--- a/tests/drivers/comsol/test_describe.py
+++ b/tests/drivers/comsol/test_describe.py
@@ -1,0 +1,326 @@
+"""Unit tests for `sim.drivers.comsol.lib.describe`.
+
+These tests build a hand-rolled stand-in for a COMSOL Java model — a
+plain Python object that responds to the read-side API observed during
+the win1 probe (see PR description). Acceptance against a real COMSOL
+session is covered by `tests/inspect/probe_describe_physics.py`.
+
+The fixture data mirrors the real `block_with_hole` solve verbatim
+where it matters (feature tags, types, T0 values, selection entities,
+the full set of auto-created defaults). That way the formatter is
+exercised against real-shaped data without needing JPype on the test
+host.
+"""
+from __future__ import annotations
+
+import pytest
+
+from sim.drivers.comsol.lib import describe, format_text
+from sim.drivers.comsol.lib.describe import _format_feature_line
+
+
+# ----------------------------------------------------------------------
+# Stand-in for the COMSOL Java model — duck-typed against the read API.
+# ----------------------------------------------------------------------
+
+
+class _Selection:
+    def __init__(self, entities: list[int], named: str = ""):
+        self._entities = entities
+        self._named = named
+
+    def entities(self):
+        return list(self._entities)
+
+    def named(self):
+        return self._named
+
+
+class _Feature:
+    def __init__(
+        self,
+        tag: str,
+        ftype: str,
+        name: str,
+        entities: list[int],
+        properties: dict[str, str] | None = None,
+        named: str = "",
+    ):
+        self.tag = tag
+        self._ftype = ftype
+        self._name = name
+        self._sel = _Selection(entities, named=named)
+        self._props = dict(properties or {})
+
+    def getType(self):
+        return self._ftype
+
+    def name(self):
+        return self._name
+
+    def selection(self):
+        return self._sel
+
+    def properties(self):
+        return list(self._props.keys())
+
+    def getString(self, name: str):
+        if name not in self._props:
+            raise KeyError(name)
+        return self._props[name]
+
+
+class _PhysicsFeatureSet:
+    def __init__(self, features: list[_Feature]):
+        self._features = {f.tag: f for f in features}
+
+    def tags(self):
+        return list(self._features.keys())
+
+    def __call__(self, tag: str | None = None):
+        # phy.feature() with no args → set; phy.feature(tag) → feature
+        if tag is None:
+            return self
+        return self._features[tag]
+
+
+class _Physics:
+    def __init__(self, tag: str, ptype: str, name: str, features: list[_Feature]):
+        self.tag = tag
+        self._ptype = ptype
+        self._name = name
+        self._fset = _PhysicsFeatureSet(features)
+
+    def getType(self):
+        return self._ptype
+
+    def name(self):
+        return self._name
+
+    def feature(self, tag: str | None = None):
+        if tag is None:
+            return self._fset
+        return self._fset(tag)
+
+
+class _PhysicsSet:
+    def __init__(self, interfaces: list[_Physics]):
+        self._physics = {p.tag: p for p in interfaces}
+
+    def tags(self):
+        return list(self._physics.keys())
+
+    def __call__(self, tag: str | None = None):
+        if tag is None:
+            return self
+        return self._physics[tag]
+
+
+class _Model:
+    """Quacks like the live COMSOL Java model for `describe()` purposes."""
+
+    def __init__(self, interfaces: list[_Physics]):
+        self._pset = _PhysicsSet(interfaces)
+
+    def physics(self, tag: str | None = None):
+        if tag is None:
+            return self._pset
+        return self._pset(tag)
+
+
+# ----------------------------------------------------------------------
+# Block-with-hole physics tree — verbatim from the win1 probe.
+# ----------------------------------------------------------------------
+
+
+def _block_with_hole_model() -> _Model:
+    """Heat Transfer in Solids with 3 user BCs and 8 default features.
+
+    Entity ids and T0 values match the win1 probe output exactly so the
+    formatter is exercised against real shapes.
+    """
+    ht = _Physics(
+        tag="ht",
+        ptype="HeatTransfer",
+        name="Heat Transfer in Solids",
+        features=[
+            _Feature("solid1", "SolidHeatTransferModel", "Solid 1", [1],
+                     properties={"Solid_material": "dommat", "k": "0",
+                                 "rho_mat": "from_mat"}),
+            _Feature("init1", "init", "Initial Values 1", [1],
+                     properties={"Tinit": "293.15[K]", "Tinit_src": "userdef"}),
+            _Feature("ins1", "ThermalInsulation", "Thermal Insulation 1",
+                     [2, 3, 4, 5, 10]),
+            _Feature("idi1", "IsothermalDomainInterface",
+                     "Isothermal Domain Interface 1", []),
+            _Feature("ltneb1", "LocalThermalNonequilibriumBoundary",
+                     "Local Thermal Nonequilibrium Boundary 1", []),
+            _Feature("os1", "OpaqueSurface", "Opaque Surface 1", []),
+            _Feature("cib1", "ContinuityOnInteriorBoundary",
+                     "Continuity on Interior Boundary 1", []),
+            _Feature("dcont1", "Continuity", "Continuity 1", []),
+            _Feature("temp1", "TemperatureBoundary", "Temperature 1", [1],
+                     properties={"T0": "373[K]", "T0_src": "userdef"}),
+            _Feature("temp2", "TemperatureBoundary", "Temperature 2", [6],
+                     properties={"T0": "293[K]", "T0_src": "userdef"}),
+            _Feature("hf1", "HeatFluxBoundary", "Heat Flux 1", [7, 8, 9],
+                     properties={"HeatFluxType": "ConvectiveHeatFlux",
+                                 "h": "50[W/(m^2*K)]", "Text": "293[K]",
+                                 "q0_input": "0"}),
+        ],
+    )
+    return _Model([ht])
+
+
+# ----------------------------------------------------------------------
+# describe() shape
+# ----------------------------------------------------------------------
+
+
+class TestDescribePhysics:
+    def test_returns_one_interface_for_block_with_hole(self):
+        summary = describe(_block_with_hole_model())
+        assert summary["what"] == "physics"
+        assert len(summary["physics"]) == 1
+
+    def test_interface_top_level_fields(self):
+        ifc = describe(_block_with_hole_model())["physics"][0]
+        assert ifc["tag"] == "ht"
+        assert ifc["type"] == "HeatTransfer"
+        assert ifc["name"] == "Heat Transfer in Solids"
+
+    def test_walks_all_features_user_and_default(self):
+        ifc = describe(_block_with_hole_model())["physics"][0]
+        tags = [f["tag"] for f in ifc["features"]]
+        # 3 user-created BCs + 8 auto-created defaults
+        assert tags == [
+            "solid1", "init1", "ins1", "idi1", "ltneb1", "os1", "cib1",
+            "dcont1", "temp1", "temp2", "hf1",
+        ]
+
+    def test_temperature_boundary_carries_T0(self):
+        ifc = describe(_block_with_hole_model())["physics"][0]
+        temp1 = next(f for f in ifc["features"] if f["tag"] == "temp1")
+        assert temp1["type"] == "TemperatureBoundary"
+        assert temp1["selection_entities"] == [1]
+        assert temp1["properties"]["T0"] == "373[K]"
+
+    def test_heat_flux_boundary_carries_h(self):
+        ifc = describe(_block_with_hole_model())["physics"][0]
+        hf = next(f for f in ifc["features"] if f["tag"] == "hf1")
+        assert hf["type"] == "HeatFluxBoundary"
+        assert hf["selection_entities"] == [7, 8, 9]
+        assert hf["properties"]["h"] == "50[W/(m^2*K)]"
+
+    def test_default_features_have_empty_or_present_selections(self):
+        """Auto-created features may have empty selection lists; no exceptions."""
+        ifc = describe(_block_with_hole_model())["physics"][0]
+        for tag in ("idi1", "ltneb1", "os1", "cib1", "dcont1"):
+            f = next(x for x in ifc["features"] if x["tag"] == tag)
+            assert f["selection_entities"] == []
+
+    def test_named_selection_default_is_none(self):
+        ifc = describe(_block_with_hole_model())["physics"][0]
+        for f in ifc["features"]:
+            assert f["selection_named"] is None
+
+    def test_unsupported_what_raises(self):
+        with pytest.raises(ValueError, match="only what='physics' is implemented"):
+            describe(_block_with_hole_model(), what="materials")
+
+
+# ----------------------------------------------------------------------
+# Exception robustness — describe() must not crash on misbehaved fields.
+# ----------------------------------------------------------------------
+
+
+class TestDescribeRobustness:
+    def test_property_read_failure_is_dropped(self):
+        class BrokenFeat(_Feature):
+            def getString(self, name):
+                if name == "T0":
+                    raise RuntimeError("Java exploded")
+                return super().getString(name)
+
+        feat = BrokenFeat(
+            "temp_x", "TemperatureBoundary", "Temperature X", [1],
+            properties={"T0": "373[K]", "T0_src": "userdef"},
+        )
+        ifc = _Physics("ht", "HeatTransfer", "Heat Transfer in Solids", [feat])
+        summary = describe(_Model([ifc]))
+        props = summary["physics"][0]["features"][0]["properties"]
+        # Broken key dropped, other keys survive
+        assert "T0" not in props
+        assert props["T0_src"] == "userdef"
+
+    def test_selection_entities_failure_yields_empty_list(self):
+        class BrokenSel(_Selection):
+            def entities(self):
+                raise RuntimeError("kaboom")
+
+        class BrokenFeat(_Feature):
+            def selection(self):
+                return BrokenSel([])
+
+        feat = BrokenFeat("x", "TemperatureBoundary", "X", [])
+        ifc = _Physics("ht", "HeatTransfer", "HT", [feat])
+        summary = describe(_Model([ifc]))
+        assert summary["physics"][0]["features"][0]["selection_entities"] == []
+
+    def test_no_physics_interfaces(self):
+        summary = describe(_Model([]))
+        assert summary == {"what": "physics", "physics": []}
+
+
+# ----------------------------------------------------------------------
+# Text formatter
+# ----------------------------------------------------------------------
+
+
+class TestFormatText:
+    def test_block_with_hole_has_three_lines_per_user_bc(self):
+        summary = describe(_block_with_hole_model())
+        out = format_text(summary)
+        # One header + 11 features + section title
+        assert 'Physics: ht (HeatTransfer) — "Heat Transfer in Solids"' in out
+        assert "features (11):" in out
+
+    def test_temperature_boundary_shows_T0_highlight(self):
+        summary = describe(_block_with_hole_model())
+        out = format_text(summary)
+        assert "T0=373[K]" in out
+        assert "T0=293[K]" in out
+
+    def test_heat_flux_shows_convection_highlights(self):
+        summary = describe(_block_with_hole_model())
+        out = format_text(summary)
+        assert "HeatFluxType=ConvectiveHeatFlux" in out
+        assert "h=50[W/(m^2*K)]" in out
+
+    def test_named_selection_overrides_entities(self):
+        line = _format_feature_line({
+            "tag": "x", "type": "TemperatureBoundary", "name": "X",
+            "selection_entities": [1, 2, 3], "selection_named": "left_face",
+            "properties": {"T0": "300[K]"},
+        })
+        assert 'sel="left_face"' in line
+        assert "entities=[1, 2, 3]" not in line
+
+    def test_no_selection_no_highlights(self):
+        line = _format_feature_line({
+            "tag": "idi1", "type": "IsothermalDomainInterface",
+            "name": "Isothermal Domain Interface 1",
+            "selection_entities": [], "selection_named": None, "properties": {},
+        })
+        assert "idi1" in line
+        assert "IsothermalDomainInterface" in line
+        # No trailing junk
+        assert line.rstrip() == line
+
+    def test_empty_summary(self):
+        out = format_text({"what": "physics", "physics": []})
+        assert out == "(no physics interfaces in model)"
+
+    def test_rejects_non_physics_summary(self):
+        with pytest.raises(ValueError):
+            format_text({"what": "materials", "materials": []})

--- a/tests/inspect/probe_describe_physics.py
+++ b/tests/inspect/probe_describe_physics.py
@@ -27,10 +27,23 @@ import urllib.request
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-SKILLS_ROOT = (
-    REPO_ROOT.parent / "sim-skills" / "comsol" / "base" / "workflows"
-    / "block_with_hole"
-)
+
+
+def _resolve_skills_root() -> Path:
+    """The sim-skills layout differs across hosts. Probe both known shapes."""
+    candidates = [
+        REPO_ROOT.parent / "sim-skills" / "comsol" / "base" / "workflows" / "block_with_hole",
+        REPO_ROOT.parent / "sim-skills" / "comsol" / "workflows" / "block_with_hole",
+    ]
+    for c in candidates:
+        if c.is_dir():
+            return c
+    raise FileNotFoundError(
+        f"block_with_hole workflow not found in any of: {[str(c) for c in candidates]}"
+    )
+
+
+SKILLS_ROOT = _resolve_skills_root()
 OUT_DIR = REPO_ROOT / "tests" / "inspect" / "_run_outputs"
 OUT_DIR.mkdir(parents=True, exist_ok=True)
 OUT_FILE = OUT_DIR / "probe_describe_physics.json"
@@ -87,7 +100,7 @@ def main() -> int:
     if not r.get("ok", True):
         print(f"  CONNECT FAILED: {r}")
         return 1
-    print(f"  ok — model_tag={data.get('model_tag')}")
+    print(f"  ok -- model_tag={data.get('model_tag')}")
 
     rc = 0
     try:
@@ -135,12 +148,12 @@ def main() -> int:
 
         OUT_FILE.write_text(json.dumps(summary, indent=2))
         print(f"\n[saved] {OUT_FILE}")
-        print("\nPASS — describe(model) matches unit-test fixture against live model.")
+        print("\nPASS -- describe(model) matches unit-test fixture against live model.")
     except AssertionError as exc:
-        print(f"\nFAIL — assertion: {exc}")
+        print(f"\nFAIL -- assertion: {exc}")
         rc = 1
     except Exception as exc:
-        print(f"\nFAIL — {type(exc).__name__}: {exc}")
+        print(f"\nFAIL -- {type(exc).__name__}: {exc}")
         rc = 1
     finally:
         print("\n[disconnect]")

--- a/tests/inspect/probe_describe_physics.py
+++ b/tests/inspect/probe_describe_physics.py
@@ -1,0 +1,156 @@
+"""Win1 verification gate for `sim.drivers.comsol.lib.describe(model)`.
+
+Builds the `block_with_hole` physics tree in a fresh COMSOL session,
+calls `describe(model)` and `format_text(summary)` from inside the
+session, and asserts the structural shape of the output matches what
+the unit-test fixture in `tests/drivers/comsol/test_describe.py`
+expects.
+
+The unit tests run on macOS against a hand-rolled Python stand-in, so
+they verify the formatter logic but cannot catch JPype/Java contract
+drift (e.g., a method renamed in COMSOL 6.x). This probe closes that
+gap on a host with COMSOL installed.
+
+Run:
+    cd C:/Users/<user>/Documents/GitHub/sim-cli
+    .venv/Scripts/python.exe tests/inspect/probe_describe_physics.py
+
+Output:
+    tests/inspect/_run_outputs/probe_describe_physics.json
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SKILLS_ROOT = (
+    REPO_ROOT.parent / "sim-skills" / "comsol" / "base" / "workflows"
+    / "block_with_hole"
+)
+OUT_DIR = REPO_ROOT / "tests" / "inspect" / "_run_outputs"
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+OUT_FILE = OUT_DIR / "probe_describe_physics.json"
+
+BASE = os.environ.get("SIM_BASE", "http://localhost:7600")
+
+
+def post(path: str, body: dict, timeout: float = 180) -> dict:
+    req = urllib.request.Request(
+        f"{BASE}{path}",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode())
+
+
+def exec_snippet(code: str, label: str) -> dict:
+    print(f"[exec] {label} ({len(code)} bytes)")
+    resp = post("/exec", {"code": code, "label": label})
+    data = resp.get("data") or resp
+    if not data.get("ok"):
+        print(f"  FAILED: {data.get('error') or data.get('stderr', '')[:500]}")
+        sys.exit(1)
+    return data
+
+
+PROBE = r"""
+import json
+from sim.drivers.comsol.lib import describe, format_text
+
+summary = describe(model, what="physics")
+text = format_text(summary)
+
+print("=== format_text() ===")
+print(text)
+print()
+print("=== summary JSON ===")
+print("DESCRIBE_BEGIN")
+print(json.dumps(summary, indent=2, default=str))
+print("DESCRIBE_END")
+_result = {"summary": summary, "text": text}
+"""
+
+
+def main() -> int:
+    print(f"[connect] {BASE}/connect → comsol server-only")
+    r = post(
+        "/connect",
+        {"solver": "comsol", "mode": "solver", "ui_mode": "server", "processors": 2},
+        timeout=120,
+    )
+    data = r.get("data") or r
+    if not r.get("ok", True):
+        print(f"  CONNECT FAILED: {r}")
+        return 1
+    print(f"  ok — model_tag={data.get('model_tag')}")
+
+    rc = 0
+    try:
+        for fname in (
+            "00_create_geometry.py",
+            "01_assign_material.py",
+            "02_setup_physics.py",
+        ):
+            code = (SKILLS_ROOT / fname).read_text(encoding="utf-8")
+            exec_snippet(code, fname)
+
+        out = exec_snippet(PROBE, "describe_physics_probe")
+        stdout = out.get("stdout", "")
+        if "DESCRIBE_BEGIN" in stdout:
+            block = stdout.split("DESCRIBE_BEGIN", 1)[1].split("DESCRIBE_END")[0].strip()
+            summary = json.loads(block)
+        else:
+            print("[fail] no DESCRIBE block in stdout")
+            print(stdout[:2000])
+            return 1
+
+        # Acceptance: same structural assertions as the unit tests, against
+        # the live JPype tree.
+        assert summary["what"] == "physics", summary
+        ifcs = summary["physics"]
+        assert len(ifcs) == 1, f"expected 1 physics interface, got {len(ifcs)}"
+        ht = ifcs[0]
+        assert ht["tag"] == "ht", ht["tag"]
+        assert ht["type"] == "HeatTransfer", ht["type"]
+        assert ht["name"] == "Heat Transfer in Solids", ht["name"]
+
+        feat_tags = [f["tag"] for f in ht["features"]]
+        for required in ("solid1", "init1", "ins1", "temp1", "temp2", "hf1"):
+            assert required in feat_tags, f"missing feature {required} in {feat_tags}"
+
+        temp1 = next(f for f in ht["features"] if f["tag"] == "temp1")
+        assert temp1["type"] == "TemperatureBoundary", temp1["type"]
+        assert temp1["selection_entities"] == [1], temp1["selection_entities"]
+        assert temp1["properties"].get("T0") == "373[K]", temp1["properties"].get("T0")
+
+        hf1 = next(f for f in ht["features"] if f["tag"] == "hf1")
+        assert hf1["type"] == "HeatFluxBoundary", hf1["type"]
+        assert hf1["selection_entities"] == [7, 8, 9], hf1["selection_entities"]
+        assert hf1["properties"].get("h") == "50[W/(m^2*K)]", hf1["properties"].get("h")
+
+        OUT_FILE.write_text(json.dumps(summary, indent=2))
+        print(f"\n[saved] {OUT_FILE}")
+        print("\nPASS — describe(model) matches unit-test fixture against live model.")
+    except AssertionError as exc:
+        print(f"\nFAIL — assertion: {exc}")
+        rc = 1
+    except Exception as exc:
+        print(f"\nFAIL — {type(exc).__name__}: {exc}")
+        rc = 1
+    finally:
+        print("\n[disconnect]")
+        try:
+            post("/disconnect", {}, timeout=30)
+        except Exception as e:
+            print(f"  disconnect failed: {e}")
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/inspect/probe_describe_physics.py
+++ b/tests/inspect/probe_describe_physics.py
@@ -77,7 +77,7 @@ _result = {"summary": summary, "text": text}
 
 
 def main() -> int:
-    print(f"[connect] {BASE}/connect → comsol server-only")
+    print(f"[connect] {BASE}/connect -> comsol server-only")
     r = post(
         "/connect",
         {"solver": "comsol", "mode": "solver", "ui_mode": "server", "processors": 2},


### PR DESCRIPTION
## Summary

First slice of a companion sim-proj line item: a "semantic layer over the Java tree". Replaces hand-rolled Java-bridge tree introspection in `sim exec` snippets with a single helper:

```python
from sim.drivers.<driver>.lib import describe, format_text
summary = describe(model, what="physics")
print(format_text(summary))
```

`describe()` returns a structured dict listing every physics interface (tag/type/name) and every feature inside it (tag/type/name + selection entities + the full property→value map). `format_text()` renders that dict as a compact human-readable block with curated highlights for common BC types.

## Why this slice first

Per advisor input on the slice plan: scope to ONE category (physics) before designing the semantic recipe layer. Physics is the most opaque to the GUI tree and the highest leverage for an introspector — the Java tree mixes user-created BCs with auto-created defaults, with no natural way for an agent to tell what's there. `describe()` makes that one call.

Selections, materials, mesh, and study scopes land in follow-ups once this format proves out.

## What's in here

| File | Purpose |
|---|---|
| `lib/__init__.py` | New subpackage, mirrors the deferred-package convention used by another driver |
| `lib/describe.py` | `describe()` + `format_text()` + curated highlight property table per BC type |
| `tests/.../test_describe.py` | 18 unit tests on macOS using a hand-rolled stand-in for the Java-bridge tree, fixture data verbatim from an on-host probe |
| `tests/inspect/probe_describe_physics.py` | Live verification gate — runs a reference model against a real session, calls `describe()`, asserts same shape |
| `CHANGELOG.md` | Unreleased entry |

## Read-side API observed

Documented in the `describe.py` module docstring. One gotcha: `Selection.dimension()` returns a 4-byte little-endian buffer through Java-bridge rather than a Python int. We drop dimension from the output until a reliable accessor is found; callers can infer from the feature type.

## Test plan

- [x] `uv run pytest tests/.../test_describe.py` — 18/18 pass on macOS
- [x] `uvx ruff check` — clean
- [x] Live probe on a Windows test host — **PASS**, all assertions hold against the live Java-bridge tree
- [x] Saved live output matches the unit-test fixture verbatim

