### PR TITLE
feat(driver): structured error-code parsing for log files

### DIFF
--- a/src/sim/drivers/flotherm/_helpers.py
+++ b/src/sim/drivers/flotherm/_helpers.py
@@ -16,7 +16,10 @@ import subprocess
 from contextlib import suppress
 from pathlib import Path
 
-from sim.drivers.flotherm.lib.error_log import read_floerror_log
+from sim.drivers.flotherm.lib.error_log import (
+    parse_error_log,
+    read_floerror_log,
+)
 
 # ---------------------------------------------------------------------------
 # Installation detection
@@ -187,7 +190,17 @@ def detect_job_state(
     has_fatal = len(new_fatals) > 0
 
     if has_fatal:
-        reasons.append(f"New fatal errors: {new_fatals[0][:80]}")
+        # Surface the code + suggested action when we recognise the line.
+        first = new_fatals[0]
+        entries = parse_error_log(workspace)
+        match = next((e for e in entries if e["raw"] == first), None)
+        if match and match["suggested_action"]:
+            reasons.append(
+                f"New fatal: {match['code']} — {match['message'][:60]} "
+                f"(action: {match['suggested_action'][:80]})"
+            )
+        else:
+            reasons.append(f"New fatal errors: {first[:80]}")
     elif all_fatals and not has_fatal:
         reasons.append(f"Historical errors (ignored): {len(all_fatals)}")
 
@@ -237,6 +250,7 @@ def collect_artifacts(
         log_files = sorted(os.listdir(log_dir))
 
     error_content, _, _ = read_floerror_log(workspace)
+    structured_errors = parse_error_log(workspace)
 
     return {
         "project_path": proj_path,
@@ -245,4 +259,5 @@ def collect_artifacts(
         "log_files": log_files,
         "generated_scripts": generated_scripts or [],
         "error_log_summary": error_content[:300] if error_content else "",
+        "errors": structured_errors,
     }

--- a/src/sim/drivers/flotherm/lib/__init__.py
+++ b/src/sim/drivers/flotherm/lib/__init__.py
@@ -14,7 +14,16 @@ here.
 """
 from __future__ import annotations
 
-from sim.drivers.flotherm.lib.error_log import read_floerror_log
+from sim.drivers.flotherm.lib.error_log import (
+    CODE_CATALOGUE,
+    FATAL_CODES,
+    ErrorEntry,
+    parse_error_line,
+    parse_error_log,
+    parse_error_log_text,
+    parse_logfile_xml,
+    read_floerror_log,
+)
 from sim.drivers.flotherm.lib.floscript import (
     build_custom,
     build_solve_and_save,
@@ -46,7 +55,10 @@ from sim.drivers.flotherm.lib.pack import (
 
 __all__ = [
     "Ambient",
+    "CODE_CATALOGUE",
     "Cuboid",
+    "ErrorEntry",
+    "FATAL_CODES",
     "FixedTemperature",
     "Fluid",
     "HeatSource",
@@ -63,6 +75,10 @@ __all__ = [
     "list_fields",
     "pack_project_dir",
     "pack_project_name",
+    "parse_error_line",
+    "parse_error_log",
+    "parse_error_log_text",
+    "parse_logfile_xml",
     "read_floerror_log",
     "read_mesh_dims",
     "read_msp_field",

--- a/src/sim/drivers/flotherm/lib/error_log.py
+++ b/src/sim/drivers/flotherm/lib/error_log.py
@@ -1,23 +1,171 @@
-"""`floerror.log` parsing — fatal + warning extraction."""
+"""`floerror.log` and `WinXP\\bin\\LogFiles\\logFile*.xml` parsing.
+
+The error code catalogue (E/6xxx, E/9xxx, E/11xxx, E/15xxx and friends) is
+documented in
+`sim-skills/flotherm/base/reference/error_codes.md` — that doc is the
+authoritative source for the severity / message / driver-action columns
+encoded in :data:`CODE_CATALOGUE` below. Provenance: Flotherm 2504.
+"""
 from __future__ import annotations
 
 import os
+import re
 from contextlib import suppress
+from dataclasses import asdict, dataclass
 
-_FATAL_PATTERNS = ("E/11029", "E/9012")
-_WARNING_PATTERNS = ("registerStart runTable exception",)
+# Line shape: "ERROR   E/15002 - Command failed to find property: foo".
+# Severity prefix has variable whitespace; strip before matching.
+_LINE_RE = re.compile(r"\b([EWI])/(\d+)\s*-?\s*(.*)")
+_SEVERITY = {"E": "error", "W": "warning", "I": "info"}
+
+
+@dataclass(frozen=True)
+class ErrorEntry:
+    """One parsed diagnostic line."""
+
+    code: str               # "E/15002"
+    severity: str           # "error" | "warning" | "info"
+    message: str            # remainder of the line after the code
+    suggested_action: str   # short driver-side recommendation; "" if unknown
+    raw: str                # original line, stripped
+
+
+# Code → suggested driver action. Sourced from
+# sim-skills/flotherm/base/reference/error_codes.md (Flotherm 2504).
+# Codes not listed here parse as ErrorEntry with suggested_action="".
+CODE_CATALOGUE: dict[str, str] = {
+    # Table / CSV export
+    "E/6000": "Surface to caller; do not retry without changing inputs.",
+    # Mesher / grid
+    "E/9012": "Treat as fatal; correlate with preceding E/11029. Don't retry without a successful translator pass.",
+    "I/9001": "Solver converged — positive signal.",
+    "I/9033": "Pre-flight grid count; value of 1 is diagnostic of E/9012.",
+    # Project lifecycle
+    "E/11008": "Validate import_type ∈ {'Pack File','FloXML','PDML',…} before re-emit.",
+    "E/11013": "Run <project_unlock project_name=…/> first, retry <project_load>. If repeated, fall back to flounlock.exe -d <project>.",
+    "E/11029": "Don't go through flotherm.bat -b; use direct translator.exe + solexe.exe. Treat as fatal.",
+    "E/15105": "If preceded by E/11013, retry after <project_unlock>. Otherwise fatal — verify project dir and PDProject/group.",
+    # FloSCRIPT runtime
+    "E/15000": "Surface; do not retry. Caller can verify with <find> + <commonStringQueryConstraint>.",
+    "E/15001": "Surface; do not retry. Workaround: build attributes by hand (see ISSUE-006).",
+    "E/15002": "Surface; do not retry. Always pair with the immediately following W/15000. Suggest the recording-oracle workflow.",
+    "E/15013": "Driver bug — should have been caught by lib.floscript._validate_xsd before dispatch.",
+    "W/15000": "Companion warning that always follows a fatal E/15xxx.",
+}
+
+# Codes that should flip the job state to failed when freshly observed.
+FATAL_CODES: frozenset[str] = frozenset({
+    "E/6000",
+    "E/9012",
+    "E/11008",
+    "E/11013",
+    "E/11029",
+    "E/15000",
+    "E/15001",
+    "E/15002",
+    "E/15013",
+    "E/15105",
+})
+
+# Legacy non-coded patterns kept for the floserv RunTable bug.
+_LEGACY_WARNING_PATTERNS = ("registerStart runTable exception",)
+
+
+def parse_error_line(line: str) -> ErrorEntry | None:
+    """Extract one :class:`ErrorEntry` from a single log line.
+
+    Returns ``None`` if the line carries no recognised severity-coded token.
+    """
+    text = line.strip()
+    if not text:
+        return None
+    for token in text.split():
+        m = _LINE_RE.match(token)
+        if not m:
+            continue
+        sev_prefix, code_digits, _ = m.groups()
+        code = f"{sev_prefix}/{code_digits}"
+        # Trim everything up to and including the code token.
+        rest = text.split(token, 1)[1].lstrip(" -")
+        return ErrorEntry(
+            code=code,
+            severity=_SEVERITY[sev_prefix],
+            message=rest,
+            suggested_action=CODE_CATALOGUE.get(code, ""),
+            raw=text,
+        )
+    return None
+
+
+def parse_error_log_text(content: str) -> list[ErrorEntry]:
+    """Parse a `floerror.log` body into structured entries."""
+    entries: list[ErrorEntry] = []
+    for line in content.splitlines():
+        entry = parse_error_line(line)
+        if entry is not None:
+            entries.append(entry)
+    return entries
+
+
+def parse_logfile_xml(path: str) -> list[ErrorEntry]:
+    """Parse a Flotherm GUI session log XML into structured entries.
+
+    Flotherm writes `<install>\\WinXP\\bin\\LogFiles\\logFile<ts>.xml` per
+    GUI session (5 retained). Each diagnostic appears as
+    `<message text="ERROR …"/>`.
+    """
+    from xml.etree import ElementTree as ET
+
+    if not os.path.isfile(path):
+        return []
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError:
+        return []
+    entries: list[ErrorEntry] = []
+    for el in tree.getroot().iter("message"):
+        entry = parse_error_line(el.get("text") or "")
+        if entry is not None:
+            entries.append(entry)
+    return entries
 
 
 def read_floerror_log(workspace: str) -> tuple[str, list[str], list[str]]:
-    """Read floerror.log; return (full_content, fatal_errors, warnings)."""
+    """Read `floerror.log`; return (full_content, fatal_lines, warning_lines).
+
+    Backward-compatible signature. Fatal/warning lists carry raw lines whose
+    parsed entry maps to a fatal code (see :data:`FATAL_CODES`) or a legacy
+    floserv RunTable warning pattern.
+    """
     logpath = os.path.join(workspace, "floerror.log")
     if not os.path.isfile(logpath):
         return "", [], []
     with suppress(OSError):
         content = open(logpath, encoding="utf-8", errors="replace").read()
-        fatals = [l.strip() for l in content.splitlines()
-                  if any(p in l for p in _FATAL_PATTERNS)]
-        warns = [l.strip() for l in content.splitlines()
-                 if any(p in l for p in _WARNING_PATTERNS)]
+        entries = parse_error_log_text(content)
+        fatals = [e.raw for e in entries if e.code in FATAL_CODES]
+        warns = [
+            line.strip()
+            for line in content.splitlines()
+            if any(p in line for p in _LEGACY_WARNING_PATTERNS)
+        ]
         return content, fatals, warns
     return "", [], []
+
+
+def parse_error_log(workspace: str) -> list[dict]:
+    """Read `floerror.log` and return structured entries as plain dicts.
+
+    Plain dicts (rather than dataclass instances) so the result can flow
+    straight into JSON / IPC payloads. Each item carries
+    ``{code, severity, message, suggested_action, raw}``.
+    """
+    logpath = os.path.join(workspace, "floerror.log")
+    if not os.path.isfile(logpath):
+        return []
+    try:
+        with open(logpath, encoding="utf-8", errors="replace") as f:
+            content = f.read()
+    except OSError:
+        return []
+    return [asdict(e) for e in parse_error_log_text(content)]

--- a/tests/drivers/flotherm/lib/test_error_log.py
+++ b/tests/drivers/flotherm/lib/test_error_log.py
@@ -1,0 +1,164 @@
+"""Unit tests for the structured `floerror.log` parser."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from sim.drivers.flotherm.lib.error_log import (
+    CODE_CATALOGUE,
+    FATAL_CODES,
+    ErrorEntry,
+    parse_error_line,
+    parse_error_log,
+    parse_error_log_text,
+    parse_logfile_xml,
+    read_floerror_log,
+)
+
+
+# --- parse_error_line ------------------------------------------------------
+
+def test_parse_error_line_property_not_found() -> None:
+    line = "ERROR   E/15002 - Command failed to find property: power"
+    e = parse_error_line(line)
+    assert e is not None
+    assert e.code == "E/15002"
+    assert e.severity == "error"
+    assert "find property" in e.message
+    assert e.suggested_action  # non-empty — it's catalogued
+    assert e.raw == line
+
+
+def test_parse_error_line_warning() -> None:
+    e = parse_error_line("WARN    W/15000 - Aborting XML due to previous error")
+    assert e is not None
+    assert e.code == "W/15000"
+    assert e.severity == "warning"
+
+
+def test_parse_error_line_info_solver_converged() -> None:
+    e = parse_error_line("INFO    I/9001 - Solver stopped: steady solution converged")
+    assert e is not None
+    assert e.code == "I/9001"
+    assert e.severity == "info"
+    assert "converged" in e.suggested_action
+
+
+def test_parse_error_line_unknown_code_no_action() -> None:
+    e = parse_error_line("ERROR   E/99999 - Made-up code we do not catalogue")
+    assert e is not None
+    assert e.code == "E/99999"
+    assert e.severity == "error"
+    assert e.suggested_action == ""  # unknown codes still parse, just no action
+
+
+def test_parse_error_line_blank_returns_none() -> None:
+    assert parse_error_line("") is None
+    assert parse_error_line("   \n") is None
+
+
+def test_parse_error_line_no_code_returns_none() -> None:
+    assert parse_error_line("plain log line with no severity code") is None
+
+
+# --- parse_error_log_text -------------------------------------------------
+
+_FIXTURE = """
+INFO    I/9033 - Total number of Grid Cells are: 1
+ERROR   E/9012 - Too few grid-cells to be solved NX = 1 and NY = 1
+ERROR   E/11029 - Failed unknown file type No reader for this file type - C:\\foo
+WARN    W/15000 - Aborting XML due to previous error
+random unparseable line that should be skipped
+""".strip()
+
+
+def test_parse_error_log_text_picks_up_all_codes() -> None:
+    entries = parse_error_log_text(_FIXTURE)
+    codes = [e.code for e in entries]
+    assert codes == ["I/9033", "E/9012", "E/11029", "W/15000"]
+
+
+def test_parse_error_log_text_skips_blank_and_unparseable_lines() -> None:
+    entries = parse_error_log_text(_FIXTURE)
+    # 4 codes from 5 candidate lines (the random one is skipped).
+    assert len(entries) == 4
+    assert all(isinstance(e, ErrorEntry) for e in entries)
+
+
+# --- parse_error_log (workspace path) -------------------------------------
+
+def test_parse_error_log_reads_workspace_file(tmp_path: Path) -> None:
+    (tmp_path / "floerror.log").write_text(_FIXTURE, encoding="utf-8")
+    out = parse_error_log(str(tmp_path))
+    assert isinstance(out, list)
+    assert all(isinstance(item, dict) for item in out)
+    codes = [item["code"] for item in out]
+    assert "E/11029" in codes
+    # Catalogued action is propagated.
+    e11029 = next(item for item in out if item["code"] == "E/11029")
+    assert "translator.exe" in e11029["suggested_action"]
+
+
+def test_parse_error_log_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert parse_error_log(str(tmp_path)) == []
+
+
+# --- read_floerror_log backward compat -----------------------------------
+
+def test_read_floerror_log_returns_legacy_tuple(tmp_path: Path) -> None:
+    log = (
+        "registerStart runTable exception: invalid map<K, T> key\n"
+        "ERROR   E/11029 - Failed unknown file type\n"
+        "ERROR   E/9012 - Too few grid-cells to be solved\n"
+    )
+    (tmp_path / "floerror.log").write_text(log, encoding="utf-8")
+    content, fatals, warns = read_floerror_log(str(tmp_path))
+    assert content == log
+    assert any("E/11029" in f for f in fatals)
+    assert any("E/9012" in f for f in fatals)
+    assert any("runTable" in w for w in warns)
+
+
+def test_read_floerror_log_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert read_floerror_log(str(tmp_path)) == ("", [], [])
+
+
+# --- parse_logfile_xml ----------------------------------------------------
+
+def test_parse_logfile_xml_extracts_messages(tmp_path: Path) -> None:
+    xml = """<?xml version="1.0"?>
+<log>
+  <message text="ERROR   E/15002 - Command failed to find property: foo"/>
+  <message text="WARN    W/15000 - Aborting XML due to previous error"/>
+  <message text="non-coded message ignored"/>
+</log>
+"""
+    p = tmp_path / "logFile_2026.xml"
+    p.write_text(xml, encoding="utf-8")
+    out = parse_logfile_xml(str(p))
+    assert [e.code for e in out] == ["E/15002", "W/15000"]
+
+
+def test_parse_logfile_xml_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert parse_logfile_xml(str(tmp_path / "nonexistent.xml")) == []
+
+
+def test_parse_logfile_xml_malformed_xml_returns_empty(tmp_path: Path) -> None:
+    p = tmp_path / "bad.xml"
+    p.write_text("<not></balanced>", encoding="utf-8")
+    assert parse_logfile_xml(str(p)) == []
+
+
+# --- catalogue invariants -------------------------------------------------
+
+def test_fatal_codes_are_in_catalogue() -> None:
+    """Every FATAL_CODES entry should have a catalogued suggested_action."""
+    for code in FATAL_CODES:
+        assert code in CODE_CATALOGUE, f"{code} listed as fatal but no action"
+        assert CODE_CATALOGUE[code], f"{code} has empty action"
+
+
+def test_catalogue_codes_are_well_formed() -> None:
+    for code in CODE_CATALOGUE:
+        prefix, _, digits = code.partition("/")
+        assert prefix in {"E", "W", "I"}
+        assert digits.isdigit()

--- a/tests/drivers/flotherm/lib/test_lib_imports.py
+++ b/tests/drivers/flotherm/lib/test_lib_imports.py
@@ -28,10 +28,15 @@ def test_public_surface():
         lint_pack,
         pack_project_dir,
         pack_project_name,
+        parse_error_line,
+        parse_error_log,
+        parse_error_log_text,
+        parse_logfile_xml,
         read_floerror_log,
     )
 
     for fn in (build_custom, build_solve_and_save, build_solve_scenario,
                lint_floscript, lint_floxml, lint_pack, pack_project_dir,
-               pack_project_name, read_floerror_log):
+               pack_project_name, parse_error_line, parse_error_log,
+               parse_error_log_text, parse_logfile_xml, read_floerror_log):
         assert callable(fn)


### PR DESCRIPTION
## Summary
Expands `lib/error_log.py` from a 4-line legacy parser (string-match for two specific codes) into a **code-aware parser** sourced from the catalogue distilled in companion sim-proj/sim-skills issues.

**Module surface (new):**
- `ErrorEntry` dataclass — `(code, severity, message, suggested_action, raw)`
- `parse_error_line(line)` / `parse_error_log_text(content)` / `parse_error_log(workspace)` / `parse_logfile_xml(path)`
- `CODE_CATALOGUE: dict[str, str]` — code → suggested driver action
- `FATAL_CODES: frozenset[str]`
- `read_error_log()` — **unchanged signature** (back-compat for existing callers)

**Catalogue covers** roughly a dozen error codes plus a few warnings and informational entries. Unknown codes still parse cleanly with `suggested_action=""`.

**Driver wiring:**
- `_helpers.detect_job_state` — fresh fatals now produce a structured "New fatal: <code> — <message> (action: <suggested_action>)" instead of just the raw line slice.
- `_helpers.collect_artifacts` — adds `errors` field to the artifact dict with structured entries; legacy `error_log_summary` stays for back-compat.

## Test plan
- [x] 17 new unit tests: parser surface, legacy tuple compat, XML log path, catalogue invariants.
- [x] Full driver suite passes — **78 passed, 5 skipped** (skips need a real solver install, unrelated).
- [x] On a Windows test host, ran a deliberately-broken script via `sim exec`. `inspect last.result` surfaces both a structured GUI error and warning entry. Note: the artifact-dict `errors` field requires the `submit_job` flow (not the `sim exec` shortcut), but the GUI structured-error block already exposes the error code/severity in the live result.
