### PR TITLE
feat(driver): tail XML log helper for GUI sessions

### DIFF
--- a/src/sim/drivers/flotherm/_helpers.py
+++ b/src/sim/drivers/flotherm/_helpers.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from sim.drivers.flotherm.lib.error_log import (
     parse_error_log,
+    parse_logfile_xml,
     read_floerror_log,
 )
 
@@ -94,6 +95,64 @@ def default_flouser(install_root: str) -> str:
     if env:
         return env
     return os.path.join(install_root, "flouser")
+
+
+# ---------------------------------------------------------------------------
+# GUI session log discovery (<install>/WinXP/bin/LogFiles/logFile*.xml)
+# ---------------------------------------------------------------------------
+
+def list_logfile_xmls(install_root: str) -> list[str]:
+    """Return Flotherm GUI session log paths, newest first.
+
+    Flotherm writes one `logFile<timestamp>.xml` per GUI session under
+    `<install>/WinXP/bin/LogFiles/`, retaining up to 5. Sorted by file
+    mtime descending so the first entry is the most recent session.
+    Returns ``[]`` when the directory doesn't exist.
+    """
+    log_dir = os.path.join(install_root, "WinXP", "bin", "LogFiles")
+    if not os.path.isdir(log_dir):
+        return []
+    candidates = []
+    for name in os.listdir(log_dir):
+        if name.startswith("logFile") and name.endswith(".xml"):
+            full = os.path.join(log_dir, name)
+            with suppress(OSError):
+                candidates.append((os.path.getmtime(full), full))
+    candidates.sort(reverse=True)
+    return [path for _, path in candidates]
+
+
+def tail_logfile_xml(
+    install_root: str,
+    *,
+    most_recent_only: bool = True,
+) -> list[dict]:
+    """Return structured GUI-log entries under `<install>/WinXP/bin/LogFiles/`.
+
+    Each entry is a plain dict ``{code, severity, message, suggested_action,
+    raw}`` from :func:`sim.drivers.flotherm.lib.error_log.parse_logfile_xml`.
+
+    With ``most_recent_only=True`` (default) reads only the most recently
+    modified `logFile*.xml` — the typical "what just happened in this GUI
+    session" use case. With ``most_recent_only=False`` merges every retained
+    log file in newest-first order.
+
+    Callers that want "only entries since a baseline" should pass the result
+    through their own diff (the parser doesn't expose per-entry timestamps —
+    use the same baseline-list approach the driver uses for `floerror.log`).
+    """
+    from dataclasses import asdict
+
+    paths = list_logfile_xmls(install_root)
+    if not paths:
+        return []
+    if most_recent_only:
+        paths = paths[:1]
+    out: list[dict] = []
+    for p in paths:
+        for entry in parse_logfile_xml(p):
+            out.append(asdict(entry))
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/drivers/flotherm/test_logfile_xml_helpers.py
+++ b/tests/drivers/flotherm/test_logfile_xml_helpers.py
@@ -1,0 +1,105 @@
+"""Unit tests for Flotherm GUI-log discovery + tailing helpers.
+
+These exercise the install-relative `WinXP/bin/LogFiles/` lookup that
+parses each retained `logFile*.xml` GUI session log into structured
+:class:`ErrorEntry` records.
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from sim.drivers.flotherm._helpers import list_logfile_xmls, tail_logfile_xml
+
+
+def _write_logfile(path: Path, messages: list[str]) -> None:
+    """Write a minimal Flotherm-style GUI session XML at *path*."""
+    body = "\n".join(f'  <message text="{m}"/>' for m in messages)
+    path.write_text(
+        f'<?xml version="1.0"?>\n<log>\n{body}\n</log>\n',
+        encoding="utf-8",
+    )
+
+
+def _make_install(root: Path) -> Path:
+    """Materialise the `WinXP/bin/LogFiles/` skeleton under *root*."""
+    log_dir = root / "WinXP" / "bin" / "LogFiles"
+    log_dir.mkdir(parents=True)
+    return log_dir
+
+
+def test_list_logfile_xmls_empty_when_dir_missing(tmp_path: Path) -> None:
+    assert list_logfile_xmls(str(tmp_path)) == []
+
+
+def test_list_logfile_xmls_returns_only_logfile_xmls(tmp_path: Path) -> None:
+    log_dir = _make_install(tmp_path)
+    _write_logfile(log_dir / "logFile_20260427_120000.xml", ["INFO    I/9001 - x"])
+    _write_logfile(log_dir / "logFile_20260427_130000.xml", ["INFO    I/9001 - x"])
+    # Non-matching files should be ignored.
+    (log_dir / "README.txt").write_text("not a log", encoding="utf-8")
+    (log_dir / "other.xml").write_text("<x/>", encoding="utf-8")
+
+    out = list_logfile_xmls(str(tmp_path))
+    assert len(out) == 2
+    assert all(p.endswith(".xml") and "logFile" in os.path.basename(p) for p in out)
+
+
+def test_list_logfile_xmls_sorts_newest_first(tmp_path: Path) -> None:
+    log_dir = _make_install(tmp_path)
+    older = log_dir / "logFile_old.xml"
+    newer = log_dir / "logFile_new.xml"
+    _write_logfile(older, ["INFO    I/9001 - first"])
+    # Force older mtime so the second file is genuinely newer.
+    os.utime(older, (time.time() - 60, time.time() - 60))
+    _write_logfile(newer, ["INFO    I/9001 - second"])
+
+    out = list_logfile_xmls(str(tmp_path))
+    assert out[0] == str(newer)
+    assert out[1] == str(older)
+
+
+def test_tail_logfile_xml_empty_when_no_logs(tmp_path: Path) -> None:
+    assert tail_logfile_xml(str(tmp_path)) == []
+
+
+def test_tail_logfile_xml_default_reads_only_most_recent(tmp_path: Path) -> None:
+    log_dir = _make_install(tmp_path)
+    older = log_dir / "logFile_old.xml"
+    newer = log_dir / "logFile_new.xml"
+    _write_logfile(older, ["ERROR   E/11013 - older session lock"])
+    os.utime(older, (time.time() - 60, time.time() - 60))
+    _write_logfile(newer, ["ERROR   E/15002 - newer session prop fail"])
+
+    out = tail_logfile_xml(str(tmp_path))
+    assert isinstance(out, list)
+    assert all(isinstance(item, dict) for item in out)
+    codes = [item["code"] for item in out]
+    assert codes == ["E/15002"]  # only the newer file contributed
+
+
+def test_tail_logfile_xml_merge_all_returns_newest_first_entries(tmp_path: Path) -> None:
+    log_dir = _make_install(tmp_path)
+    older = log_dir / "logFile_old.xml"
+    newer = log_dir / "logFile_new.xml"
+    _write_logfile(older, ["ERROR   E/11013 - older"])
+    os.utime(older, (time.time() - 60, time.time() - 60))
+    _write_logfile(newer, ["ERROR   E/15002 - newer"])
+
+    out = tail_logfile_xml(str(tmp_path), most_recent_only=False)
+    codes = [item["code"] for item in out]
+    # Newer file's entries come first; older follows.
+    assert codes == ["E/15002", "E/11013"]
+
+
+def test_tail_logfile_xml_propagates_suggested_action(tmp_path: Path) -> None:
+    log_dir = _make_install(tmp_path)
+    _write_logfile(
+        log_dir / "logFile_x.xml",
+        ["ERROR   E/11029 - Failed unknown file type No reader for this file type"],
+    )
+    out = tail_logfile_xml(str(tmp_path))
+    assert len(out) == 1
+    assert out[0]["code"] == "E/11029"
+    assert "translator.exe" in out[0]["suggested_action"]


### PR DESCRIPTION
## Summary
Adds discovery + tail helpers in `_helpers.py` over the install-relative XML log channel — the second of two log sources documented in the driver's error-code catalogue. (The first, a plain-text log, landed in [#48](https://github.com/svd-ai-lab/sim-cli/pull/48).)

This replaces the original [#49](https://github.com/svd-ai-lab/sim-cli/pull/49), which was auto-closed when its base branch was deleted as part of the `--delete-branch` squash-merge of #48. Branch has been rebased onto current `main`; the diff is now scoped to only the #49 net changes.

**API:**
- `list_logfile_xmls(install_root) -> list[str]` — returns XML log paths under the install's log directory, sorted newest-first by mtime. `[]` when missing.
- `tail_logfile_xml(install_root, *, most_recent_only=True) -> list[dict]` — plain-dict `ErrorEntry` records from the most recent GUI session (default) or from every retained log file.

The parser stays in `lib/`; the install-path orchestration sits in `_helpers.py`.

## Test plan
- [x] 7 new unit tests cover the empty-dir case, mtime sort, extension filter, merge mode, and `suggested_action` propagation.
- [x] Full driver suite still passes — **85 passed, 5 skipped**.
- [ ] On-host: run a session that produces a known error code, then call the tail helper from a Python REPL — confirm the entry appears with the catalogued action. (verification in flight)

Supersedes #49.
