### PR TITLE
fix(driver): handle truncated XML log without closing tag

### DIFF
--- a/src/sim/drivers/flotherm/lib/error_log.py
+++ b/src/sim/drivers/flotherm/lib/error_log.py
@@ -112,18 +112,32 @@ def parse_logfile_xml(path: str) -> list[ErrorEntry]:
 
     Flotherm writes `<install>\\WinXP\\bin\\LogFiles\\logFile<ts>.xml` per
     GUI session (5 retained). Each diagnostic appears as
-    `<message text="ERROR …"/>`.
+    `<message text="ERROR …"/>`. Flotherm leaves these files without a
+    closing `</xml_log_file>` tag — both during a live session and (often)
+    after exit — so a strict ``ET.parse`` raises
+    ``ParseError: no element found``. Try the strict parse first; on
+    failure, append a synthetic close tag and retry.
     """
     from xml.etree import ElementTree as ET
 
     if not os.path.isfile(path):
         return []
     try:
-        tree = ET.parse(path)
-    except ET.ParseError:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except OSError:
         return []
+    if not text.strip():
+        return []
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError:
+        try:
+            root = ET.fromstring(text + "\n</xml_log_file>")
+        except ET.ParseError:
+            return []
     entries: list[ErrorEntry] = []
-    for el in tree.getroot().iter("message"):
+    for el in root.iter("message"):
         entry = parse_error_line(el.get("text") or "")
         if entry is not None:
             entries.append(entry)

--- a/tests/drivers/flotherm/lib/test_error_log.py
+++ b/tests/drivers/flotherm/lib/test_error_log.py
@@ -148,6 +148,35 @@ def test_parse_logfile_xml_malformed_xml_returns_empty(tmp_path: Path) -> None:
     assert parse_logfile_xml(str(p)) == []
 
 
+def test_parse_logfile_xml_handles_unterminated_log(tmp_path: Path) -> None:
+    """Flotherm leaves logFile*.xml without a closing </xml_log_file> — both
+    while the session is live and (often) after exit. We must still parse
+    the messages that are present."""
+    open_xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<xml_log_file version="1.0">\n'
+        '    <!--Unpublished work. Copyright 2025 Siemens-->\n'
+        '    <message text="ERROR   E/15002 - '
+        'Command failed to find property: foo"/>\n'
+        '    <message text="WARN    W/15000 - '
+        'Aborting XML due to previous error"/>\n'
+        # No closing </xml_log_file> on purpose.
+    )
+    p = tmp_path / "logFile_truncated.xml"
+    p.write_text(open_xml, encoding="utf-8")
+    out = parse_logfile_xml(str(p))
+    assert [e.code for e in out] == ["E/15002", "W/15000"]
+    assert out[0].suggested_action  # action propagates after the wrap-and-retry
+
+
+def test_parse_logfile_xml_empty_file_returns_empty(tmp_path: Path) -> None:
+    p = tmp_path / "empty.xml"
+    p.write_text("", encoding="utf-8")
+    assert parse_logfile_xml(str(p)) == []
+    p.write_text("   \n  \n", encoding="utf-8")
+    assert parse_logfile_xml(str(p)) == []
+
+
 # --- catalogue invariants -------------------------------------------------
 
 def test_fatal_codes_are_in_catalogue() -> None:


### PR DESCRIPTION
## Summary
Follow-up fix for [#50](https://github.com/svd-ai-lab/sim-cli/pull/50). An on-host probe discovered that the XML log-tail helper returns 0 entries against any real install — even when a fresh log XML clearly contains an error code from the session that just ran.

**Root cause:** the GUI writes the session log incrementally and **never** writes the closing root tag — not while the session is live, and (in the cases observed) not on exit either. `ET.parse` raises `ParseError: no element found`, the helper hits its silent-fallback `except`, and returns `[]`.

**Fix:** read the file as text, try strict parse first, fall back to appending a synthetic closing root tag and retrying. If both fail, return `[]` (preserves the empty-on-corrupt contract).

Verified against a real truncated on-host fixture (1 entry, with the catalogued `suggested_action` propagated) — strict parse returned `0`, the fix returns `1`.

## Test plan
- [x] 2 new regression tests — one for the unterminated-XML shape the GUI actually writes, one for an empty file.
- [x] Full driver suite: **87 passed, 5 skipped** (was 85 before).
- [x] Real on-host fixture parses to 1 entry under the new code; previously returned 0.

Refs: #50 (the helper this fixes).
