### PR TITLE
refactor(drivers): lazy-load registry — broken driver no longer crashes CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ changes at milestone boundaries.
 
 ## [Unreleased]
 
+### Changed
+
+- **`sim.drivers` is now lazy-loaded.** `import sim.drivers` no longer
+  pulls every driver module at startup; each driver is resolved on
+  demand via `importlib`. A broken import in one driver no longer
+  crashes the whole CLI — `solvers list` shows the broken driver as
+  `status="error"` while other drivers continue to work. New API:
+  - `get_driver(name)` — returns the instance (cached), raises the
+    underlying `ImportError` if `name` is registered but its module
+    fails to import, returns `None` for unknown names.
+  - `iter_drivers()` — yields `(name, instance, error)` tuples,
+    tolerating per-driver failure. Used by `solvers list` and `lint`
+    auto-detection.
+  - `driver_names()` — stable list of all registered names.
+
+  The old `DRIVERS` list constant is removed. The two internal
+  callers (`cli.py:_check_all_local`, `cli.py:lint`) migrated to
+  `iter_drivers`. External code that imported `DRIVERS` should switch
+  to `iter_drivers()` or call `get_driver(name)` for a specific
+  driver.
+
 ### Added
 
 - **`sim.drivers.comsol.lib.MphArchive` / `inspect_mph` / `mph_diff`** —

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -80,7 +80,10 @@ def _check_local(solver: str) -> dict:
 
     from sim.compat import load_compatibility, safe_detect_installed
 
-    driver = get_driver(solver)
+    try:
+        driver = get_driver(solver)
+    except Exception as e:  # noqa: BLE001 — surface lazy-import failures distinctly
+        return {"ok": False, "error": f"driver '{solver}' failed to load: {type(e).__name__}: {e}"}
     if driver is None:
         return {"ok": False, "error": f"unknown solver: {solver}"}
 
@@ -184,10 +187,16 @@ def _check_all_local() -> dict:
     with status="not_installed". Driver errors are captured as status="error".
     """
     from sim.compat import safe_detect_installed
-    from sim.drivers import DRIVERS
+    from sim.drivers import iter_drivers
 
     rows: list[dict] = []
-    for driver in DRIVERS:
+    for reg_name, driver, import_error in iter_drivers():
+        if import_error is not None:
+            rows.append({
+                "name": reg_name, "status": "error",
+                "message": f"{type(import_error).__name__}: {import_error}",
+            })
+            continue
         name = getattr(driver, "name", driver.__class__.__name__)
         try:
             installs = safe_detect_installed(driver)
@@ -296,10 +305,12 @@ def check(ctx, solver, check_all):
 def lint(ctx, script):
     """Validate a simulation script before execution."""
     script_path = Path(script)
-    from sim.drivers import DRIVERS
+    from sim.drivers import iter_drivers
 
     driver = None
-    for d in DRIVERS:
+    for _name, d, import_error in iter_drivers():
+        if import_error is not None or d is None:
+            continue
         if d.detect(script_path):
             driver = d
             break
@@ -327,7 +338,11 @@ def lint(ctx, script):
 @click.pass_context
 def run(ctx, script, solver):
     """Execute a simulation script in a subprocess (one-shot)."""
-    driver = get_driver(solver)
+    try:
+        driver = get_driver(solver)
+    except Exception as e:  # noqa: BLE001 — surface lazy-import failures distinctly
+        click.echo(f"[sim] error: driver '{solver}' failed to load: {type(e).__name__}: {e}", err=True)
+        sys.exit(1)
     if driver is None:
         click.echo(f"[sim] error: no driver for '{solver}'", err=True)
         sys.exit(1)

--- a/src/sim/drivers/__init__.py
+++ b/src/sim/drivers/__init__.py
@@ -29,7 +29,7 @@ _REGISTRY: list[tuple[str, str]] = [
     ("abaqus", "sim.drivers.abaqus:AbaqusDriver"),
     ("starccm", "sim.drivers.starccm:StarccmDriver"),
     ("cfx", "sim.drivers.cfx:CfxDriver"),
-    ("lsdyna", "sim.drivers.lsdyna:LsDynaDriver"),
+    ("ls_dyna", "sim.drivers.lsdyna:LsDynaDriver"),
     ("mapdl", "sim.drivers.mapdl:MapdlDriver"),
     ("icem", "sim.drivers.icem:IcemDriver"),
     ("isaac", "sim.drivers.isaac:IsaacDriver"),
@@ -54,7 +54,7 @@ _REGISTRY: list[tuple[str, str]] = [
     ("trimesh", "sim.drivers.trimesh:TrimeshDriver"),
     ("devito", "sim.drivers.devito:DevitoDriver"),
     ("coolprop", "sim.drivers.coolprop:CoolPropDriver"),
-    ("scikitrf", "sim.drivers.scikitrf:ScikitRfDriver"),
+    ("scikit_rf", "sim.drivers.scikitrf:ScikitRfDriver"),
     ("pandapower", "sim.drivers.pandapower:PandapowerDriver"),
     ("paraview", "sim.drivers.paraview:ParaViewDriver"),
     ("hypermesh", "sim.drivers.hypermesh:HyperMeshDriver"),
@@ -111,5 +111,5 @@ def iter_drivers() -> Iterator[tuple[str, DriverProtocol | None, BaseException |
     for name, _ in _REGISTRY:
         try:
             yield name, _resolve(name), None
-        except BaseException as e:  # noqa: BLE001 — intentional: any import-time failure
+        except Exception as e:  # noqa: BLE001 — any import-time failure; KeyboardInterrupt/SystemExit propagate
             yield name, None, e

--- a/src/sim/drivers/__init__.py
+++ b/src/sim/drivers/__init__.py
@@ -1,99 +1,115 @@
-"""Driver registry for sim."""
+"""Driver registry for sim — lazy-loaded.
+
+Each driver is identified by a stable name and resolved lazily via importlib.
+A broken import in one driver no longer crashes the entire CLI: callers that
+walk the registry (`iter_drivers`) get a per-driver error; callers that ask
+for a specific driver (`get_driver`) get the original ImportError raised so
+they can present it directly.
+"""
 from __future__ import annotations
 
-from sim.driver import DriverProtocol
-from sim.drivers.pybamm import PyBaMMLDriver
-from sim.drivers.fluent import PyFluentDriver
-from sim.drivers.matlab import MatlabDriver
-from sim.drivers.comsol import ComsolDriver
-from sim.drivers.flotherm import FlothermDriver
-from sim.drivers.ansa import AnsaDriver
-from sim.drivers.openfoam import OpenFOAMDriver
-from sim.drivers.workbench import WorkbenchDriver
-from sim.drivers.mechanical import MechanicalDriver
-from sim.drivers.abaqus import AbaqusDriver
-from sim.drivers.starccm import StarccmDriver
-from sim.drivers.cfx import CfxDriver
-from sim.drivers.lsdyna import LsDynaDriver
-from sim.drivers.mapdl import MapdlDriver
-from sim.drivers.icem import IcemDriver
-from sim.drivers.isaac import IsaacDriver
-from sim.drivers.newton import NewtonDriver
-from sim.drivers.calculix import CalculixDriver
-from sim.drivers.gmsh import GmshDriver
-from sim.drivers.su2 import Su2Driver
-from sim.drivers.lammps import LammpsDriver
-from sim.drivers.scikit_fem import ScikitFemDriver
-from sim.drivers.elmer import ElmerDriver
-from sim.drivers.meshio import MeshioDriver
-from sim.drivers.pyvista import PyvistaDriver
-from sim.drivers.pymfem import PymfemDriver
-from sim.drivers.openseespy import OpenSeesPyDriver
-from sim.drivers.sfepy import SfepyDriver
-from sim.drivers.cantera import CanteraDriver
-from sim.drivers.openmdao import OpenMDAODriver
-from sim.drivers.fipy import FipyDriver
-from sim.drivers.pymoo import PymooDriver
-from sim.drivers.pyomo import PyomoDriver
-from sim.drivers.simpy import SimpyDriver
-from sim.drivers.trimesh import TrimeshDriver
-from sim.drivers.devito import DevitoDriver
-from sim.drivers.coolprop import CoolPropDriver
-from sim.drivers.scikitrf import ScikitRfDriver
-from sim.drivers.pandapower import PandapowerDriver
-from sim.drivers.paraview import ParaViewDriver
-from sim.drivers.hypermesh import HyperMeshDriver
-from sim.drivers.ltspice import LTspiceDriver
+import importlib
+from typing import Iterator
 
-DRIVERS: list[DriverProtocol] = [
-    PyBaMMLDriver(),
-    PyFluentDriver(),
-    MatlabDriver(),
-    ComsolDriver(),
-    FlothermDriver(),
-    AnsaDriver(),
-    OpenFOAMDriver(),
-    WorkbenchDriver(),
-    MechanicalDriver(),
-    AbaqusDriver(),
-    StarccmDriver(),
-    CfxDriver(),
-    LsDynaDriver(),
-    MapdlDriver(),
-    IcemDriver(),
-    IsaacDriver(),
-    NewtonDriver(),
-    CalculixDriver(),
-    GmshDriver(),
-    Su2Driver(),
-    LammpsDriver(),
-    ScikitFemDriver(),
-    ElmerDriver(),
-    MeshioDriver(),
-    PyvistaDriver(),
-    PymfemDriver(),
-    OpenSeesPyDriver(),
-    SfepyDriver(),
-    CanteraDriver(),
-    OpenMDAODriver(),
-    FipyDriver(),
-    PymooDriver(),
-    PyomoDriver(),
-    SimpyDriver(),
-    TrimeshDriver(),
-    DevitoDriver(),
-    CoolPropDriver(),
-    ScikitRfDriver(),
-    PandapowerDriver(),
-    ParaViewDriver(),
-    HyperMeshDriver(),
-    LTspiceDriver(),
+from sim.driver import DriverProtocol
+
+
+# (driver_name, "module:Class") — order controls `solvers list` output order
+# and `lint` first-match priority.
+_REGISTRY: list[tuple[str, str]] = [
+    ("pybamm", "sim.drivers.pybamm:PyBaMMLDriver"),
+    ("fluent", "sim.drivers.fluent:PyFluentDriver"),
+    ("matlab", "sim.drivers.matlab:MatlabDriver"),
+    ("comsol", "sim.drivers.comsol:ComsolDriver"),
+    ("flotherm", "sim.drivers.flotherm:FlothermDriver"),
+    ("ansa", "sim.drivers.ansa:AnsaDriver"),
+    ("openfoam", "sim.drivers.openfoam:OpenFOAMDriver"),
+    ("workbench", "sim.drivers.workbench:WorkbenchDriver"),
+    ("mechanical", "sim.drivers.mechanical:MechanicalDriver"),
+    ("abaqus", "sim.drivers.abaqus:AbaqusDriver"),
+    ("starccm", "sim.drivers.starccm:StarccmDriver"),
+    ("cfx", "sim.drivers.cfx:CfxDriver"),
+    ("lsdyna", "sim.drivers.lsdyna:LsDynaDriver"),
+    ("mapdl", "sim.drivers.mapdl:MapdlDriver"),
+    ("icem", "sim.drivers.icem:IcemDriver"),
+    ("isaac", "sim.drivers.isaac:IsaacDriver"),
+    ("newton", "sim.drivers.newton:NewtonDriver"),
+    ("calculix", "sim.drivers.calculix:CalculixDriver"),
+    ("gmsh", "sim.drivers.gmsh:GmshDriver"),
+    ("su2", "sim.drivers.su2:Su2Driver"),
+    ("lammps", "sim.drivers.lammps:LammpsDriver"),
+    ("scikit_fem", "sim.drivers.scikit_fem:ScikitFemDriver"),
+    ("elmer", "sim.drivers.elmer:ElmerDriver"),
+    ("meshio", "sim.drivers.meshio:MeshioDriver"),
+    ("pyvista", "sim.drivers.pyvista:PyvistaDriver"),
+    ("pymfem", "sim.drivers.pymfem:PymfemDriver"),
+    ("openseespy", "sim.drivers.openseespy:OpenSeesPyDriver"),
+    ("sfepy", "sim.drivers.sfepy:SfepyDriver"),
+    ("cantera", "sim.drivers.cantera:CanteraDriver"),
+    ("openmdao", "sim.drivers.openmdao:OpenMDAODriver"),
+    ("fipy", "sim.drivers.fipy:FipyDriver"),
+    ("pymoo", "sim.drivers.pymoo:PymooDriver"),
+    ("pyomo", "sim.drivers.pyomo:PyomoDriver"),
+    ("simpy", "sim.drivers.simpy:SimpyDriver"),
+    ("trimesh", "sim.drivers.trimesh:TrimeshDriver"),
+    ("devito", "sim.drivers.devito:DevitoDriver"),
+    ("coolprop", "sim.drivers.coolprop:CoolPropDriver"),
+    ("scikitrf", "sim.drivers.scikitrf:ScikitRfDriver"),
+    ("pandapower", "sim.drivers.pandapower:PandapowerDriver"),
+    ("paraview", "sim.drivers.paraview:ParaViewDriver"),
+    ("hypermesh", "sim.drivers.hypermesh:HyperMeshDriver"),
+    ("ltspice", "sim.drivers.ltspice:LTspiceDriver"),
 ]
+
+# Cache: name -> instance. Populated on first successful resolve.
+_INSTANCE_CACHE: dict[str, DriverProtocol] = {}
+
+
+def driver_names() -> list[str]:
+    """Stable list of all registered driver names."""
+    return [n for n, _ in _REGISTRY]
+
+
+def _resolve(name: str) -> DriverProtocol:
+    """Import + instantiate the driver, caching the result. Raises on failure."""
+    if name in _INSTANCE_CACHE:
+        return _INSTANCE_CACHE[name]
+    spec = next((s for n, s in _REGISTRY if n == name), None)
+    if spec is None:
+        raise KeyError(name)
+    module_path, cls_name = spec.split(":", 1)
+    mod = importlib.import_module(module_path)
+    cls = getattr(mod, cls_name)
+    instance = cls()
+    _INSTANCE_CACHE[name] = instance
+    return instance
 
 
 def get_driver(name: str) -> DriverProtocol | None:
-    """Get a driver by name."""
-    for d in DRIVERS:
-        if d.name == name:
-            return d
-    return None
+    """Lazily resolve a driver by name.
+
+    Returns None if `name` is not a registered driver.
+    Raises ImportError (or whatever the driver's import raises) if `name` is
+    registered but the underlying module fails to import — callers that asked
+    for a specific driver should see the real failure, not a misleading
+    "no driver named X".
+    """
+    try:
+        return _resolve(name)
+    except KeyError:
+        return None
+
+
+def iter_drivers() -> Iterator[tuple[str, DriverProtocol | None, BaseException | None]]:
+    """Walk all registered drivers, tolerating per-driver import failure.
+
+    Yields (name, instance, error). When import fails, instance is None and
+    error holds the exception. Use this for `solvers list`, `lint`
+    auto-detection, or anywhere you need to enumerate without a single broken
+    driver killing the walk.
+    """
+    for name, _ in _REGISTRY:
+        try:
+            yield name, _resolve(name), None
+        except BaseException as e:  # noqa: BLE001 — intentional: any import-time failure
+            yield name, None, e

--- a/src/sim/server.py
+++ b/src/sim/server.py
@@ -175,7 +175,10 @@ def detect_solver(solver: str):
     from sim.compat import load_compatibility, safe_detect_installed
     from sim.drivers import get_driver
 
-    driver = get_driver(solver)
+    try:
+        driver = get_driver(solver)
+    except Exception as e:  # noqa: BLE001 — surface lazy-import failures distinctly
+        raise HTTPException(500, f"driver '{solver}' failed to load: {type(e).__name__}: {e}")
     if driver is None:
         raise HTTPException(404, f"unknown solver: {solver}")
 
@@ -246,7 +249,10 @@ def connect(req: ConnectRequest):
     """
     from sim.drivers import get_driver
 
-    driver = get_driver(req.solver)
+    try:
+        driver = get_driver(req.solver)
+    except Exception as e:  # noqa: BLE001 — surface lazy-import failures distinctly
+        raise HTTPException(500, f"driver '{req.solver}' failed to load: {type(e).__name__}: {e}")
     if driver is None:
         raise HTTPException(400, f"unknown solver: {req.solver}")
 
@@ -356,7 +362,10 @@ def run_script(req: RunRequest):
     if not script_path.is_file():
         raise HTTPException(400, f"script not found: {req.script}")
 
-    driver = get_driver(req.solver)
+    try:
+        driver = get_driver(req.solver)
+    except Exception as e:  # noqa: BLE001 — surface lazy-import failures distinctly
+        raise HTTPException(500, f"driver '{req.solver}' failed to load: {type(e).__name__}: {e}")
     if driver is None:
         raise HTTPException(400, f"unknown solver: {req.solver}")
 


### PR DESCRIPTION
## Summary

- Replaces eager `from sim.drivers.X import XDriver` with an importlib-backed registry. `import sim.drivers` now imports zero driver modules.
- A broken driver import (e.g. a stale third-party SDK) is contained: `solvers list` shows it as `status=error` while other drivers continue working.
- Public API: `get_driver(name)` (raises on broken-registered, None on unknown), `iter_drivers()` (yields `(name, instance, error)` for tolerant walks), `driver_names()` for the stable list. The old `DRIVERS` constant is removed; the two internal callers in `cli.py` migrated to `iter_drivers`.

## Why

A stale `sim_ltspice` install on a dev host crashed every `sim` invocation at startup, even for solvers unrelated to LTspice — because `sim/drivers/__init__.py` eagerly imported all 42 drivers. One bad import shouldn't break the whole CLI.

## Test plan

- [x] `python -c "import sim.drivers; assert no 'sim.drivers.' in sys.modules"` — confirms zero eager imports
- [x] All 42 drivers resolve via `iter_drivers()` on Mac, zero errors
- [x] Simulated broken driver: `iter_drivers` yields error row; `get_driver` re-raises
- [x] `tests/base/test_multi_session.py` (the test that monkeypatches `sim.drivers.get_driver`) — 10 passed
- [x] `tests/drivers/{newton,icem,mapdl}` — 59 passed
- [x] Broader pytest run (skip GUI-dependent solvers) — 831 passed; 4 failures pre-existing on main, unrelated

## Notes

- Draft per repo workflow (`feedback_draft_pr_first`); flip to ready after on-host smoke test on win1.
- No CHANGELOG version bump — added under `[Unreleased]` since this is a non-breaking change for end users; the `DRIVERS` constant removal is a minor API change for any external code that imported it (none found in `sim-cli` / `sim-skills` / `sim-proj` greps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)