### PR TITLE
fix(driver): plumb workspace env var through GUI launch subprocess

### DIFF
--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -459,8 +459,10 @@ def _print_followup_hints(run_id, stdout_path, stderr_path, delta):
 @click.option("--mode", default="meshing", type=click.Choice(["meshing", "solver"]))
 @click.option("--ui-mode", default="no_gui", type=click.Choice(["no_gui", "gui"]))
 @click.option("--processors", default=1, type=int)
+@click.option("--workspace", default=None,
+              help="Solver-specific working dir (e.g. flotherm FLOUSERDIR).")
 @click.pass_context
-def connect(ctx, solver, mode, ui_mode, processors):
+def connect(ctx, solver, mode, ui_mode, processors, workspace):
     """Launch a solver and hold a persistent session."""
     from sim.session import SessionClient
 
@@ -471,6 +473,7 @@ def connect(ctx, solver, mode, ui_mode, processors):
         mode=mode,
         ui_mode=ui_mode,
         processors=processors,
+        workspace=workspace,
     )
 
     if ctx.obj["json"]:

--- a/src/sim/drivers/comsol/driver.py
+++ b/src/sim/drivers/comsol/driver.py
@@ -563,6 +563,7 @@ class ComsolDriver:
         comsol_root: str | None = None,
         user: str | None = None,
         password: str | None = None,
+        **kwargs,
     ) -> dict:
         """Launch comsolmphserver + optional GUI client, connect via JPype.
 

--- a/src/sim/drivers/flotherm/driver.py
+++ b/src/sim/drivers/flotherm/driver.py
@@ -739,7 +739,15 @@ class FlothermDriver:
                     self._process.kill()
 
     def _launch_gui(self, workspace: str) -> int | None:
-        """Launch Flotherm GUI via flotherm.exe."""
+        """Launch Flotherm GUI via flotherm.exe.
+
+        Injects ``FLOUSERDIR=<workspace>`` into the subprocess env so the
+        spawned GUI looks at the session's workspace, not the inherited
+        process-wide default. Without this, calling ``launch(workspace=...)``
+        sets the field on the session metadata but the GUI itself opens the
+        wrong project root — projects created in our workspace are invisible
+        in Project Manager.
+        """
         if self._install is None:
             return None
 
@@ -752,8 +760,10 @@ class FlothermDriver:
 
         try:
             self._ensure_license_env()
+            env = os.environ.copy()
+            env["FLOUSERDIR"] = workspace
             self._process = subprocess.Popen(
-                [exe_path], cwd=bin_dir,
+                [exe_path], cwd=bin_dir, env=env,
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
                 creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
             )

--- a/src/sim/server.py
+++ b/src/sim/server.py
@@ -76,6 +76,7 @@ class ConnectRequest(BaseModel):
     mode: str = "meshing"
     ui_mode: str = "gui"
     processors: int = 2
+    workspace: str | None = None  # passed through to driver.launch(workspace=...)
 
 
 class ExecRequest(BaseModel):
@@ -271,12 +272,15 @@ def connect(req: ConnectRequest):
                     "two concurrent sessions on the same driver aren't supported yet",
                 )
 
+    launch_kwargs: dict = {
+        "mode": req.mode,
+        "ui_mode": req.ui_mode,
+        "processors": req.processors,
+    }
+    if req.workspace is not None:
+        launch_kwargs["workspace"] = req.workspace
     try:
-        info = driver.launch(
-            mode=req.mode,
-            ui_mode=req.ui_mode,
-            processors=req.processors,
-        )
+        info = driver.launch(**launch_kwargs)
     except HTTPException:
         raise
     except Exception as e:

--- a/src/sim/session.py
+++ b/src/sim/session.py
@@ -151,16 +151,19 @@ class SessionClient:
             return {"ok": False, "error": str(e)}
 
     def connect(self, solver: str, mode: str = "meshing",
-                ui_mode: str = "no_gui", processors: int = 1) -> dict:
+                ui_mode: str = "no_gui", processors: int = 1,
+                workspace: str | None = None) -> dict:
         # Auto-start local server if needed
         if self._is_local() and not self._server_reachable():
             if not self._auto_start_server():
                 return {"ok": False, "error": "failed to auto-start sim-server locally"}
 
-        body = {
+        body: dict = {
             "solver": solver, "mode": mode,
             "ui_mode": ui_mode, "processors": processors,
         }
+        if workspace is not None:
+            body["workspace"] = workspace
         resp = self._request("post", "/connect", timeout=CONNECT_TIMEOUT_S, json=body)
         # Remember the new session_id so subsequent calls on this client
         # route to it even if another session shows up later.


### PR DESCRIPTION
## Summary

- The driver's `launch(workspace=...)` was storing the workspace in session metadata but not propagating it to the spawned GUI subprocess.
- Result: the GUI always opened the inherited (default-install) workspace — making the `workspace` parameter effectively a lie for GUI sessions.
- Fix: copy `os.environ`, overwrite the workspace env var, pass to `subprocess.Popen(..., env=env)`.

## Why

Needed for headless authoring experiments where the agent creates a fresh project shell under a sandbox path and wants to drive the GUI bootstrap step against *that* workspace. Without the fix, the GUI ignores the sandbox.

## Test plan

- [x] All 87 driver unit tests pass on Mac (1.7 s)
- [ ] On-host smoke test on a Windows runner: `sim <driver> connect --workspace <sandbox>` → confirm the project manager shows projects from the sandbox, not the default install root
