### PR TITLE
feat(drivers): discover external drivers via entry_points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sim-runtime"
-version = "0.2.3"
+version = "0.2.4"
 description = "Make every engineering tool agent-native — a CLI runtime that lets LLM agents launch, drive, and observe CAD/CAE software"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sim/drivers/__init__.py
+++ b/src/sim/drivers/__init__.py
@@ -5,18 +5,39 @@ A broken import in one driver no longer crashes the entire CLI: callers that
 walk the registry (`iter_drivers`) get a per-driver error; callers that ask
 for a specific driver (`get_driver`) get the original ImportError raised so
 they can present it directly.
+
+Plugin discovery
+----------------
+External drivers register themselves via the ``sim.drivers`` entry-point group:
+
+    [project.entry-points."sim.drivers"]
+    myname = "my_pkg.module:MyDriver"
+
+These are discovered at import time, validated, sorted by name, and **appended
+after** the built-in registry. This ordering is contract: built-ins always
+take precedence in `lint` first-match resolution and `solvers list` output;
+externals cannot override a built-in name (collisions are logged and skipped).
+External `module:Class` strings are stored as-is and resolved lazily by
+`_resolve` — discovery never imports the plugin module.
 """
 from __future__ import annotations
 
 import importlib
+import logging
+from importlib.metadata import entry_points
 from typing import Iterator
 
 from sim.driver import DriverProtocol
 
 
+log = logging.getLogger(__name__)
+
+_ENTRY_POINT_GROUP = "sim.drivers"
+
+
 # (driver_name, "module:Class") — order controls `solvers list` output order
 # and `lint` first-match priority.
-_REGISTRY: list[tuple[str, str]] = [
+_BUILTIN_REGISTRY: list[tuple[str, str]] = [
     ("pybamm", "sim.drivers.pybamm:PyBaMMLDriver"),
     ("fluent", "sim.drivers.fluent:PyFluentDriver"),
     ("matlab", "sim.drivers.matlab:MatlabDriver"),
@@ -60,6 +81,62 @@ _REGISTRY: list[tuple[str, str]] = [
     ("hypermesh", "sim.drivers.hypermesh:HyperMeshDriver"),
     ("ltspice", "sim.drivers.ltspice:LTspiceDriver"),
 ]
+
+
+def _is_valid_spec(spec: str) -> bool:
+    """Cheap shape check for ``"module.path:ClassName"`` — no import."""
+    if not isinstance(spec, str) or ":" not in spec:
+        return False
+    module_path, _, cls_name = spec.rpartition(":")
+    if not module_path or not cls_name:
+        return False
+    if not all(p.isidentifier() for p in module_path.split(".")):
+        return False
+    return cls_name.isidentifier()
+
+
+def _discover_external() -> list[tuple[str, str]]:
+    """Find external drivers registered via the ``sim.drivers`` entry-point group.
+
+    Validation rules (all violations are logged + skipped, never raised):
+      * ``ep.value`` must look like ``"module.path:ClassName"``.
+      * Names already in ``_BUILTIN_REGISTRY`` are ignored — built-in wins.
+      * Duplicate external names: first-seen wins; rest skipped.
+
+    Returns a list sorted by driver name for deterministic ordering.
+    """
+    builtin_names = {n for n, _ in _BUILTIN_REGISTRY}
+    found: dict[str, str] = {}
+    try:
+        eps = entry_points(group=_ENTRY_POINT_GROUP)
+    except Exception as e:  # noqa: BLE001 — entry-point machinery itself failed; degrade gracefully
+        log.warning("entry_points(%s) lookup failed: %s", _ENTRY_POINT_GROUP, e)
+        return []
+    for ep in eps:
+        name, spec = ep.name, ep.value
+        if name in builtin_names:
+            log.warning(
+                "external driver %r (from %s) shadows a built-in; skipping",
+                name, spec,
+            )
+            continue
+        if name in found:
+            log.warning(
+                "duplicate external driver %r (from %s); keeping first-seen %r",
+                name, spec, found[name],
+            )
+            continue
+        if not _is_valid_spec(spec):
+            log.warning(
+                "external driver %r has malformed entry-point value %r; skipping",
+                name, spec,
+            )
+            continue
+        found[name] = spec
+    return sorted(found.items())
+
+
+_REGISTRY: list[tuple[str, str]] = _BUILTIN_REGISTRY + _discover_external()
 
 # Cache: name -> instance. Populated on first successful resolve.
 _INSTANCE_CACHE: dict[str, DriverProtocol] = {}

--- a/tests/base/test_driver_discovery.py
+++ b/tests/base/test_driver_discovery.py
@@ -1,0 +1,135 @@
+"""Tests for external driver discovery via entry_points.
+
+Covers `sim.drivers._discover_external` in isolation: validation rules,
+conflict policy with built-ins, deterministic ordering, and graceful
+degradation when the entry-point machinery itself fails.
+
+These tests do NOT install fake distributions — they monkey-patch the
+`entry_points` symbol imported into `sim.drivers`. Real-distribution
+end-to-end coverage belongs to the plugin packages themselves.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from sim import drivers as drivers_mod
+
+
+class _FakeEP:
+    """Minimal stand-in for importlib.metadata.EntryPoint."""
+    def __init__(self, name: str, value: str) -> None:
+        self.name = name
+        self.value = value
+
+
+def _patch_eps(eps: list[_FakeEP]):
+    """Patch the entry_points symbol in sim.drivers to yield `eps`."""
+    return patch.object(
+        drivers_mod, "entry_points",
+        lambda group: eps if group == drivers_mod._ENTRY_POINT_GROUP else [],
+    )
+
+
+class TestSpecValidation(unittest.TestCase):
+    def test_accepts_well_formed(self):
+        self.assertTrue(drivers_mod._is_valid_spec("pkg.mod:Cls"))
+        self.assertTrue(drivers_mod._is_valid_spec("a:B"))
+        self.assertTrue(drivers_mod._is_valid_spec("a.b.c.d:E"))
+
+    def test_rejects_malformed(self):
+        for bad in [
+            "",
+            "no_colon",
+            ":NoModule",
+            "no_class:",
+            "pkg.mod:Cls.extra",   # multi-segment class name not allowed
+            "pkg-with-dash:Cls",   # not a valid identifier segment
+            "pkg.mod:Cls Extra",   # space in class name
+            "1pkg:Cls",            # leading digit in module
+            None,                  # type: ignore[arg-type]
+            123,                   # type: ignore[arg-type]
+        ]:
+            with self.subTest(spec=bad):
+                self.assertFalse(drivers_mod._is_valid_spec(bad))
+
+
+class TestDiscoverExternal(unittest.TestCase):
+    def test_no_entry_points_returns_empty(self):
+        with _patch_eps([]):
+            self.assertEqual(drivers_mod._discover_external(), [])
+
+    def test_valid_external_passes_through(self):
+        eps = [_FakeEP("zzz_custom", "my_pkg.mod:MyDriver")]
+        with _patch_eps(eps):
+            result = drivers_mod._discover_external()
+        self.assertEqual(result, [("zzz_custom", "my_pkg.mod:MyDriver")])
+
+    def test_externals_sorted_by_name(self):
+        eps = [
+            _FakeEP("zeta", "p:Z"),
+            _FakeEP("alpha", "p:A"),
+            _FakeEP("mu", "p:M"),
+        ]
+        with _patch_eps(eps):
+            result = drivers_mod._discover_external()
+        self.assertEqual([n for n, _ in result], ["alpha", "mu", "zeta"])
+
+    def test_conflict_with_builtin_skipped(self):
+        # Pick a name guaranteed to be in _BUILTIN_REGISTRY.
+        builtin_name = drivers_mod._BUILTIN_REGISTRY[0][0]
+        eps = [_FakeEP(builtin_name, "evil_pkg:Hijacker")]
+        with self.assertLogs("sim.drivers", level="WARNING") as logs:
+            with _patch_eps(eps):
+                result = drivers_mod._discover_external()
+        self.assertEqual(result, [])
+        self.assertTrue(any("shadows a built-in" in m for m in logs.output))
+
+    def test_duplicate_external_names_first_wins(self):
+        eps = [
+            _FakeEP("dup", "first:A"),
+            _FakeEP("dup", "second:B"),
+        ]
+        with self.assertLogs("sim.drivers", level="WARNING") as logs:
+            with _patch_eps(eps):
+                result = drivers_mod._discover_external()
+        self.assertEqual(result, [("dup", "first:A")])
+        self.assertTrue(any("duplicate external driver" in m for m in logs.output))
+
+    def test_malformed_spec_skipped(self):
+        eps = [
+            _FakeEP("good", "ok.mod:Good"),
+            _FakeEP("bad", "this is not a spec"),
+        ]
+        with self.assertLogs("sim.drivers", level="WARNING") as logs:
+            with _patch_eps(eps):
+                result = drivers_mod._discover_external()
+        self.assertEqual(result, [("good", "ok.mod:Good")])
+        self.assertTrue(any("malformed entry-point value" in m for m in logs.output))
+
+    def test_entry_points_failure_returns_empty(self):
+        def boom(group):
+            raise RuntimeError("metadata corrupted")
+        with self.assertLogs("sim.drivers", level="WARNING") as logs:
+            with patch.object(drivers_mod, "entry_points", boom):
+                result = drivers_mod._discover_external()
+        self.assertEqual(result, [])
+        self.assertTrue(any("lookup failed" in m for m in logs.output))
+
+
+class TestRegistryComposition(unittest.TestCase):
+    """Sanity checks on the actually-loaded _REGISTRY."""
+
+    def test_contains_all_builtins(self):
+        registry_names = [n for n, _ in drivers_mod._REGISTRY]
+        for name, _ in drivers_mod._BUILTIN_REGISTRY:
+            self.assertIn(name, registry_names)
+
+    def test_builtins_appear_first(self):
+        builtin_count = len(drivers_mod._BUILTIN_REGISTRY)
+        prefix = drivers_mod._REGISTRY[:builtin_count]
+        self.assertEqual(prefix, drivers_mod._BUILTIN_REGISTRY)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Drivers can now register themselves via the \`sim.drivers\` entry-point group. This is the foundation for an out-of-tree driver plugin ecosystem; in this PR no driver behavior changes.

\`\`\`toml
# in a plugin package's pyproject.toml
[project.entry-points."sim.drivers"]
mydriver = "my_pkg.module:MyDriver"
\`\`\`

## How it works

- Discovery runs at \`sim.drivers\` module import; results are cached for the process lifetime.
- The built-in registry is unchanged. Externals are validated, sorted by name, and **appended after** the built-in list. Ordering is contract: built-ins always win in \`lint\` first-match resolution and \`solvers list\` output.
- Externals **cannot shadow** a built-in driver name — collisions are logged and skipped (defense against accidental or malicious name capture).
- Duplicate external names: first-seen wins, rest logged and skipped.
- Malformed \`module:Class\` strings are validated (cheap shape check, no import) and logged + skipped at discovery — a broken plugin never crashes the CLI.
- **Lazy resolution preserved**: discovery records the entry-point's \`value\` string verbatim and lets the existing \`_resolve\` import the module on first use. Discovery never imports plugin modules — protects the property from #52.

## Test plan

- [x] \`tests/base/test_driver_discovery.py\` — 11 new tests covering spec validation, conflict policy, duplicate handling, ordering determinism, and graceful degradation when \`entry_points()\` itself fails
- [x] \`tests/base/\` regression sweep — 90 passed, 0 new failures (2 pre-existing failures in \`test_cli.py\` unrelated to this change, reproduce on \`main\`)
- [x] Runtime smoke: \`from sim import drivers; len(drivers._REGISTRY)\` → 42 (matches pre-change), first/last names unchanged
- [ ] Manual: publish a real out-of-tree driver plugin and verify end-to-end discovery (deferred to follow-up PR — this PR is the mechanism only)