### PR TITLE
chore: trim solver registry + intro + demo to abstract framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 ## 🤔 Why sim?
 
-LLM agents already know how to write PyFluent, MATLAB, COMSOL, and OpenFOAM scripts — training data is full of them. What they *don't* have is a standard way to **launch a solver, drive it step by step, and observe what happened** before deciding the next move.
+LLM agents already know how to write simulation scripts — training data is full of them. What they *don't* have is a standard way to **launch a solver, drive it step by step, and observe what happened** before deciding the next move.
 
 Today, the choices are awful:
 
@@ -110,29 +110,9 @@ That's the full loop: **detect → bootstrap → launch → drive → observe �
 
 ## 🧪 Solver registry
 
-The driver registry is **open and intentionally growing** — adding a new backend is a ~200-LOC `DriverProtocol` implementation plus one line in `drivers/__init__.py`. Below is a snapshot of what currently ships in `main`:
+The driver registry is **open and intentionally growing** — adding a new backend is a ~200-LOC `DriverProtocol` implementation plus one line in `drivers/__init__.py`, or an out-of-tree plugin package registered through the `sim.drivers` entry-point group.
 
-| Domain | Example backends shipping today | Sessions | Status |
-|---|---|---|---|
-| Electronics thermal | Simcenter Flotherm | persistent (GUI) | ✅ Working — model generation from natural language, XSD-validated FloSCRIPT, step-by-step build with checkpoints |
-| CFD | Ansys Fluent, OpenFOAM, Simcenter STAR-CCM+, Ansys CFX | persistent / one-shot | ✅ Working |
-| Multiphysics | COMSOL Multiphysics | one-shot | ✅ Working |
-| CAE | Ansys Workbench, Ansys Mechanical, Abaqus | persistent / one-shot | ✅ Working |
-| Explicit FEA | Ansys LS-DYNA | one-shot | ✅ Working |
-| Pre-processing | BETA CAE ANSA | persistent / one-shot | ✅ Working (Phase 1) |
-| Numerical / scripting | MATLAB | one-shot | ✅ Working (v0) |
-| Battery modeling | PyBaMM | one-shot | ✅ Working |
-| Implicit FEA | Ansys MAPDL, CalculiX, Elmer FEM, PyMFEM, scikit-fem, SfePy, OpenSeesPy | persistent / one-shot | ✅ Working |
-| Pre/post-processing | Gmsh, meshio, pyvista, ParaView, HyperMesh, Trimesh | one-shot | ✅ Working |
-| Embodied-AI / GPU physics | NVIDIA Isaac Sim, NVIDIA Newton (Warp) | one-shot | ✅ Working — Newton: Route A recipe JSON + Route B run-script; Isaac: SimulationApp bootstrap + AST lint |
-| Open-source CFD | OpenFOAM, SU2 | one-shot / remote | ✅ Working |
-| Molecular dynamics | LAMMPS | one-shot | ✅ Working |
-| FD codegen / seismic | Devito | one-shot | ✅ Working |
-| Thermo properties / combustion | CoolProp, Cantera | one-shot | ✅ Working |
-| Optimization / MDAO | OpenMDAO, pymoo, Pyomo | one-shot | ✅ Working |
-| Discrete-event simulation | SimPy | one-shot | ✅ Working |
-| Power systems / RF | pandapower, scikit-rf | one-shot | ✅ Working |
-| **+ your solver** | open a PR — see [Adding a driver](#-development) | — | 🛠 |
+Built-in coverage spans CFD, multiphysics, electronics thermal, implicit and explicit structural FEA, pre/post-processing, mesh generation, embodied-AI / GPU physics, molecular dynamics, optimization / MDAO, battery modeling, thermo properties, power-systems and RF simulation, and discrete-event modeling. Specific solvers are reached through either the built-in registry or out-of-tree plugin packages — see [`sim-plugin-cantera`](https://github.com/svd-ai-lab/sim-plugin-cantera) for a reference plugin.
 
 Per-solver protocols, snippets, and demo workflows live in [`sim-skills`](https://github.com/svd-ai-lab/sim-skills), which is **also designed to grow** alongside the driver registry — one new agent skill per new backend.
 
@@ -142,18 +122,7 @@ Per-solver protocols, snippets, and demo workflows live in [`sim-skills`](https:
 
 > 📺 **Early preview:** [first walkthrough on YouTube](https://www.youtube.com/watch?v=3Fg6Oph44Ik) — rough cut, a polished recording is still wanted (see below).
 
-> **Recording in progress.** A short terminal capture of `sim connect → exec → inspect → screenshot` against a real Fluent session will land here. The exact sequence to record:
->
-> ```bash
-> sim serve --host 0.0.0.0
-> sim --host <ip> connect --solver fluent --mode solver --ui-mode gui --auto-install
-> sim --host <ip> inspect session.versions    # ← step 0: which profile am I in?
-> sim --host <ip> exec "solver.settings.file.read_case(file_name='mixing_elbow.cas.h5')"
-> sim --host <ip> exec "solver.settings.solution.initialization.hybrid_initialize()"
-> sim --host <ip> exec "solver.settings.solution.run_calculation.iterate(iter_count=20)"
-> sim --host <ip> inspect session.summary
-> sim --host <ip> disconnect
-> ```
+> **Recording in progress.** A short terminal capture of `sim connect → exec → inspect → screenshot` against a live solver session will land here.
 >
 > Want to contribute the recording? Use [`vhs`](https://github.com/charmbracelet/vhs) or [`asciinema`](https://asciinema.org/) and open a PR against `assets/demo.gif`.
 

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -34,7 +34,7 @@
 
 ## 🤔 Warum sim?
 
-LLM-Agenten wissen längst, wie man PyFluent-, MATLAB-, COMSOL- und OpenFOAM-Skripte schreibt — die Trainingsdaten sind voll davon. Was ihnen fehlt, ist eine standardisierte Möglichkeit, **einen Solver zu starten, ihn schrittweise zu steuern und zwischen jedem Schritt zu beobachten**, was passiert ist, bevor sie den nächsten Zug entscheiden.
+LLM-Agenten wissen längst, wie man Simulationsskripte schreibt — die Trainingsdaten sind voll davon. Was ihnen fehlt, ist eine standardisierte Möglichkeit, **einen Solver zu starten, ihn schrittweise zu steuern und zwischen jedem Schritt zu beobachten**, was passiert ist, bevor sie den nächsten Zug entscheiden.
 
 Heutige Optionen sind unzureichend:
 
@@ -113,18 +113,7 @@ Das ist die volle Schleife: **erkennen → bootstrappen → starten → steuern 
 
 > 📺 **Frühe Vorschau:** [erster Walkthrough auf YouTube](https://www.youtube.com/watch?v=3Fg6Oph44Ik) — Rohschnitt, eine überarbeitete Aufnahme ist weiterhin willkommen (siehe unten).
 
-> **Aufnahme in Arbeit.** Ein kurzer Terminal-Capture von `sim connect → exec → inspect → screenshot` gegen eine echte Fluent-Session landet hier. Die exakte Sequenz:
->
-> ```bash
-> sim serve --host 0.0.0.0
-> sim --host <ip> connect --solver fluent --mode solver --ui-mode gui --auto-install
-> sim --host <ip> inspect session.versions    # ← Schritt 0: in welchem Profil bin ich?
-> sim --host <ip> exec "solver.settings.file.read_case(file_name='mixing_elbow.cas.h5')"
-> sim --host <ip> exec "solver.settings.solution.initialization.hybrid_initialize()"
-> sim --host <ip> exec "solver.settings.solution.run_calculation.iterate(iter_count=20)"
-> sim --host <ip> inspect session.summary
-> sim --host <ip> disconnect
-> ```
+> **Aufnahme in Arbeit.** Ein kurzer Terminal-Capture von `sim connect → exec → inspect → screenshot` gegen eine echte Solver-Session landet hier.
 >
 > Aufnahme beitragen? [`vhs`](https://github.com/charmbracelet/vhs) oder [`asciinema`](https://asciinema.org/) verwenden und einen PR auf `assets/demo.gif` öffnen.
 
@@ -201,18 +190,9 @@ Vollständiges Design: [`docs/architecture/version-compat.md`](architecture/vers
 
 ## 🧪 Solver Registry
 
-Die Driver-Registry ist **offen und absichtlich wachsend** — ein neuer Backend ist eine ~200 LOC `DriverProtocol`-Implementierung plus eine Zeile in `drivers/__init__.py`. Hier ein Snapshot dessen, was aktuell in `main` ausgeliefert wird:
+Die Driver-Registry ist **offen und absichtlich wachsend** — ein neuer Backend ist eine ~200 LOC `DriverProtocol`-Implementierung plus eine Zeile in `drivers/__init__.py`, oder ein Out-of-tree-Plugin-Paket, das über die `sim.drivers`-Entry-point-Gruppe registriert wird.
 
-| Domäne | Beispiel-Backends, die heute funktionieren | Sessions | Status |
-|---|---|---|---|
-| Elektronik-Thermik | Simcenter Flotherm | persistent (GUI) | ✅ Working — Modellgenerierung aus natürlicher Sprache, XSD-validiertes FloSCRIPT, schrittweiser Aufbau mit Checkpoints |
-| CFD | Ansys Fluent, OpenFOAM, Simcenter STAR-CCM+ | persistent / one-shot | ✅ Working |
-| Multiphysik | COMSOL Multiphysics | one-shot | ✅ Working |
-| CAE | Ansys Workbench, Ansys Mechanical, Abaqus | persistent / one-shot | ✅ Working |
-| Vorverarbeitung | BETA CAE ANSA | persistent / one-shot | ✅ Working (Phase 1) |
-| Numerik / Scripting | MATLAB | one-shot | ✅ Working (v0) |
-| Batteriemodellierung | PyBaMM | one-shot | ✅ Working |
-| **+ dein Solver** | PR öffnen — siehe [Entwicklung](#-entwicklung) | — | 🛠 |
+Die mitgelieferte Abdeckung umfasst CFD, Multiphysik, Elektronik-Thermik, implizite und explizite strukturelle FEA, Vor- und Nachverarbeitung, Mesh-Generierung, Embodied-AI / GPU-Physik, Molekulardynamik, Optimierung / MDAO, Batteriemodellierung, thermodynamische Stoffdaten, Energienetze und HF-Simulation sowie ereignisdiskrete Modellierung. Konkrete Solver werden entweder über die eingebaute Registry oder über Out-of-tree-Plugin-Pakete erreicht — siehe [`sim-plugin-cantera`](https://github.com/svd-ai-lab/sim-plugin-cantera) als Referenz-Plugin.
 
 Per-Solver-Protokolle, Snippets und Demo-Workflows leben in [`sim-skills`](https://github.com/svd-ai-lab/sim-skills), das **ebenfalls so entworfen ist, dass es mitwächst** — ein neuer Agent-Skill pro neuem Backend.
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -34,7 +34,7 @@
 
 ## 🤔 sim が存在する理由
 
-LLM エージェントは PyFluent、MATLAB、COMSOL、OpenFOAM のスクリプトの書き方を既に知っています ── トレーニングデータに満ちています。彼らに欠けているのは、**ソルバーを起動し、一歩ずつ駆動し、各ステップの間に結果を観察してから**次の手を決めるための標準的な方法です。
+LLM エージェントはシミュレーションスクリプトの書き方を既に知っています ── トレーニングデータに満ちています。彼らに欠けているのは、**ソルバーを起動し、一歩ずつ駆動し、各ステップの間に結果を観察してから**次の手を決めるための標準的な方法です。
 
 今日の選択肢はどれも不十分です：
 
@@ -112,18 +112,7 @@ sim --host <server-ip> disconnect
 
 > 📺 **早期プレビュー:** [YouTube の初回ウォークスルー](https://www.youtube.com/watch?v=3Fg6Oph44Ik) — 粗編集です。よりブラッシュアップした録画の投稿を歓迎します（下記参照）。
 
-> **録画準備中。** 実際の Fluent セッションに対する `sim connect → exec → inspect → screenshot` の短いターミナルキャプチャがここに入ります。録画する正確なシーケンス：
->
-> ```bash
-> sim serve --host 0.0.0.0
-> sim --host <ip> connect --solver fluent --mode solver --ui-mode gui --auto-install
-> sim --host <ip> inspect session.versions    # ← step 0: 今どの profile？
-> sim --host <ip> exec "solver.settings.file.read_case(file_name='mixing_elbow.cas.h5')"
-> sim --host <ip> exec "solver.settings.solution.initialization.hybrid_initialize()"
-> sim --host <ip> exec "solver.settings.solution.run_calculation.iterate(iter_count=20)"
-> sim --host <ip> inspect session.summary
-> sim --host <ip> disconnect
-> ```
+> **録画準備中。** ライブソルバーセッションに対する `sim connect → exec → inspect → screenshot` の短いターミナルキャプチャがここに入ります。
 >
 > 録画を貢献したい？ [`vhs`](https://github.com/charmbracelet/vhs) か [`asciinema`](https://asciinema.org/) を使って `assets/demo.gif` に PR をどうぞ。
 
@@ -200,18 +189,9 @@ sim --host <server-ip> disconnect
 
 ## 🧪 ソルバーレジストリ
 
-ドライバーレジストリは**オープンで、意図的に成長する設計** ── 新しいバックエンドの追加は ~200 LOC の `DriverProtocol` 実装と `drivers/__init__.py` の 1 行の登録だけ。下記は現在 `main` に入っているスナップショットです：
+ドライバーレジストリは**オープンで、意図的に成長する設計** ── 新しいバックエンドの追加は ~200 LOC の `DriverProtocol` 実装と `drivers/__init__.py` の 1 行の登録、または `sim.drivers` エントリポイントグループ経由で登録するアウトオブツリーのプラグインパッケージで済みます。
 
-| ドメイン | 今日動く例示バックエンド | セッション | ステータス |
-|---|---|---|---|
-| 電子機器熱解析 | Simcenter Flotherm | 持続 (GUI) | ✅ Working ── 自然言語からのモデル生成、XSD 検証付き FloSCRIPT、チェックポイント付き段階構築 |
-| CFD | Ansys Fluent、OpenFOAM、Simcenter STAR-CCM+ | 持続 / ワンショット | ✅ Working |
-| マルチフィジックス | COMSOL Multiphysics | ワンショット | ✅ Working |
-| CAE | Ansys Workbench、Ansys Mechanical、Abaqus | 持続 / ワンショット | ✅ Working |
-| 前処理 | BETA CAE ANSA | 持続 / ワンショット | ✅ Working (Phase 1) |
-| 数値 / スクリプト | MATLAB | ワンショット | ✅ Working (v0) |
-| 電池モデリング | PyBaMM | ワンショット | ✅ Working |
-| **+ あなたのソルバー** | PR をどうぞ ── [開発](#-開発) を参照 | — | 🛠 |
+ビルトインのカバー範囲は CFD、マルチフィジックス、電子機器熱解析、陰的・陽的構造 FEA、前処理 / 後処理、メッシュ生成、エンボディド AI / GPU 物理、分子動力学、最適化 / MDAO、電池モデリング、熱物性、電力系統・RF シミュレーション、離散イベントモデリングに及びます。具体的なソルバーはビルトインレジストリ、またはアウトオブツリーのプラグインパッケージから利用できます ── リファレンスプラグインは [`sim-plugin-cantera`](https://github.com/svd-ai-lab/sim-plugin-cantera) を参照。
 
 ソルバーごとのプロトコル、スニペット、デモワークフローは [`sim-skills`](https://github.com/svd-ai-lab/sim-skills) にあります。これも**同様に成長するよう設計されており** ── 新しいバックエンドごとに 1 つの新しいエージェントスキルを追加します。
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -34,7 +34,7 @@
 
 ## 🤔 为什么是 sim？
 
-LLM 智能体早已知道怎么写 PyFluent、MATLAB、COMSOL、OpenFOAM 脚本 —— 训练数据里到处都是。它们真正缺的，是一个标准化的方式去**启动一个求解器、一步一步地驱动它、并在每一步之间观察结果**，再决定下一步怎么走。
+LLM 智能体早已知道怎么写仿真脚本 —— 训练数据里到处都是。它们真正缺的，是一个标准化的方式去**启动一个求解器、一步一步地驱动它、并在每一步之间观察结果**，再决定下一步怎么走。
 
 今天的选项都很糟糕：
 
@@ -111,18 +111,7 @@ sim --host <server-ip> disconnect
 
 > 📺 **早期预览：** [【agent驱动 ansys fluent 进行芯片热仿真】](https://www.bilibili.com/video/BV15RD7BTE21/) —— 粗剪版本（B 站），仍欢迎贡献更精致的录制（见下文）。
 
-> **录制中。** 即将放置一段终端 capture：`sim connect → exec → inspect → screenshot` 驱动一个真实的 Fluent 会话。计划录制的命令序列：
->
-> ```bash
-> sim serve --host 0.0.0.0
-> sim --host <ip> connect --solver fluent --mode solver --ui-mode gui --auto-install
-> sim --host <ip> inspect session.versions    # ← step 0: 当前在哪个 profile？
-> sim --host <ip> exec "solver.settings.file.read_case(file_name='mixing_elbow.cas.h5')"
-> sim --host <ip> exec "solver.settings.solution.initialization.hybrid_initialize()"
-> sim --host <ip> exec "solver.settings.solution.run_calculation.iterate(iter_count=20)"
-> sim --host <ip> inspect session.summary
-> sim --host <ip> disconnect
-> ```
+> **录制中。** 即将放置一段终端 capture：`sim connect → exec → inspect → screenshot` 驱动一个真实的求解器会话。
 >
 > 想贡献录制？欢迎使用 [`vhs`](https://github.com/charmbracelet/vhs) 或 [`asciinema`](https://asciinema.org/)，向 `assets/demo.gif` 提 PR。
 
@@ -199,18 +188,9 @@ sim --host <server-ip> disconnect
 
 ## 🧪 求解器注册表
 
-驱动注册表是**开放的、有意为之的成长式设计** —— 新增一个后端只需一份 ~200 LOC 的 `DriverProtocol` 实现，加上 `drivers/__init__.py` 里的一行注册。下面是 `main` 当前的快照：
+驱动注册表是**开放的、有意为之的成长式设计** —— 新增一个后端只需一份 ~200 LOC 的 `DriverProtocol` 实现，加上 `drivers/__init__.py` 里的一行注册，或者作为独立插件包通过 `sim.drivers` entry-point 注册。
 
-| 领域 | 当前已支持的示例后端 | 会话模式 | 状态 |
-|---|---|---|---|
-| 电子热分析 | Simcenter Flotherm | 持久（GUI）| ✅ 可用 —— 自然语言驱动的模型生成、XSD 校验的 FloSCRIPT、带检查点的分步构建 |
-| CFD | Ansys Fluent、OpenFOAM、Simcenter STAR-CCM+ | 持久 / 一次性 | ✅ 可用 |
-| 多物理场 | COMSOL Multiphysics | 一次性 | ✅ 可用 |
-| CAE | Ansys Workbench、Ansys Mechanical、Abaqus | 持久 / 一次性 | ✅ 可用 |
-| 前处理 | BETA CAE ANSA | 持久 / 一次性 | ✅ 可用（Phase 1）|
-| 数值 / 脚本 | MATLAB | 一次性 | ✅ 可用（v0）|
-| 电池建模 | PyBaMM | 一次性 | ✅ 可用 |
-| **+ 你的求解器** | 提 PR —— 见 [Adding a driver](#-开发) | — | 🛠 |
+内置覆盖范围横跨 CFD、多物理场、电子热分析、隐式与显式结构 FEA、前后处理、网格生成、具身 AI / GPU 物理、分子动力学、优化 / MDAO、电池建模、热物性、电力系统与射频仿真、以及离散事件建模。具体的求解器既可通过内置注册表抵达，也可通过外置插件包接入 —— 参考插件实现见 [`sim-plugin-cantera`](https://github.com/svd-ai-lab/sim-plugin-cantera)。
 
 每个求解器的协议、片段、演示工作流都住在 [`sim-skills`](https://github.com/svd-ai-lab/sim-skills)，它**同样在持续扩展** —— 每加一个新后端就配一份 agent skill。
 


### PR DESCRIPTION
## Summary

Round-2 of the README sanitization. Replaces specific-solver enumerations with abstract domain coverage in three sections of all four README files (en / de / ja / zh):

1. **Intro paragraph** — \"LLM agents already know how to write PyFluent, MATLAB, COMSOL, and OpenFOAM scripts\" → \"LLM agents already know how to write simulation scripts\".
2. **Solver registry section** — replace the 17-row vendor-by-domain table with a two-paragraph abstract summary of built-in coverage areas + a pointer to [\`sim-plugin-cantera\`](https://github.com/svd-ai-lab/sim-plugin-cantera) as the reference plugin.
3. **Demo section** — drop the solver-specific demo recipe (file load / initialize / iterate / inspect sequence) in favor of a generic \"live solver session\" placeholder. Kept all surrounding links (YouTube, Bilibili, vhs / asciinema).

## Diff

| File | Lines |
|---|---|
| \`README.md\` | -38 / +5 |
| \`docs/README.de.md\` | -25 / +5 |
| \`docs/README.ja.md\` | -25 / +5 |
| \`docs/README.zh.md\` | -25 / +5 |

Total: -111 / +20.

## Test plan

- [x] grep for the original phrases in all 4 READMEs → 0 hits
- [x] grep for vendor-name combos like \`PyFluent.*MATLAB.*COMSOL\`, \`real Fluent session\`, \`echte Fluent-Session\`, \`真实的 Fluent\` → 0 hits
- [x] Round-1 carve-outs preserved: Quick Start \`sim check fluent\` literal, version-compat \"Fluent 24R1 / PyFluent 0.37.x\" engineering callout, \`pip install 'sim-runtime[fluent]'\` example
- [x] No trademark or third-party-SDK sections exist in the translated READMEs (verified by per-language grep)
- [x] No CHANGELOG or News stragglers (those went in PR #55)