### PR TITLE
chore(docs): scrub product names + stale in-tree refs after the recent driver removals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ ruff check --fix src/sim tests
 
 # CLI
 sim serve --host 0.0.0.0             # start HTTP server (default port 7600)
-sim --host <ip> connect --solver fluent --mode solver --ui-mode gui
+sim --host <ip> connect --solver <name> --mode solver --ui-mode gui
 sim --host <ip> exec "solver.settings.mesh.check()"
 sim --host <ip> inspect session.summary
 sim --host <ip> screenshot -o shot.png
@@ -39,7 +39,7 @@ sim --host <ip> disconnect
 sim run script.py --solver pybamm    # one-shot mode
 sim logs                              # list runs
 sim logs last --field voltage_V      # extract a parsed field
-sim check fluent                      # solver availability
+sim check <name>                      # solver availability
 sim lint script.py                    # validate before running
 ```
 
@@ -65,11 +65,11 @@ FastAPI app exposing:
 
 The server supports multiple concurrent sessions keyed by session_id. Each `SessionState` carries its own `threading.Lock` so exec/inspect against different sessions can run in parallel. A single solver name can only be live once (driver instances are module-level singletons).
 
-**`sim serve --reload` drops all sessions on any source change under the watched tree.** uvicorn's reload watchdog observes file mtimes in `src/sim/**`; any edit (git pull, scp of a modified driver, even touching an unrelated module) restarts the worker, wiping `_sessions`. Child solver processes (Flotherm GUI, Fluent, etc.) survive the reload because they're spawned separately, but the session handles to them are gone — you have to `connect` again. Driver temp files (written to the solver's workspace, e.g. `flouser/_sim_*.xml`) live outside `src/` so they don't retrigger. Practical rules:
+**`sim serve --reload` drops all sessions on any source change under the watched tree.** uvicorn's reload watchdog observes file mtimes in `src/sim/**`; any edit (git pull, scp of a modified driver, even touching an unrelated module) restarts the worker, wiping `_sessions`. Child solver processes (out-of-process GUIs, separately spawned solver binaries) survive the reload because they're spawned separately, but the session handles to them are gone — you have to `connect` again. Driver temp files written into the solver's workspace live outside `src/` so they don't retrigger. Practical rules:
 
 - Don't edit driver code mid-experiment; finish the run, then edit.
 - For long autonomous experiments where you're editing driver code iteratively, launch **without** `--reload` and restart manually when you want the new code picked up.
-- Reconnecting after a reload takes ~20s for GUI-mode Flotherm (the existing GUI process is re-adopted; no re-launch needed).
+- Reconnecting after a reload can take tens of seconds for GUI-mode drivers that re-adopt the existing window rather than relaunching it.
 
 ### Driver protocol (`src/sim/driver.py`)
 `DriverProtocol` (a `runtime_checkable` `Protocol`):
@@ -83,33 +83,13 @@ The server supports multiple concurrent sessions keyed by session_id. Each `Sess
 `LintResult`, `Diagnostic`, `RunResult`, `ConnectionInfo` are dataclasses with `to_dict()` for JSON serialization.
 
 ### Driver registry (`src/sim/drivers/__init__.py`)
-`DRIVERS` — module-level list of instantiated driver objects:
 
-| Name | Class | Layout |
-|---|---|---|
-| `pybamm` | `PyBaMMLDriver` | `pybamm/driver.py` |
-| `fluent` | `PyFluentDriver` | `fluent/driver.py` + `runtime.py` + `queries.py` |
-| `matlab` | `MatlabDriver` | `matlab/driver.py` |
-| `comsol` | `ComsolDriver` | `comsol/driver.py` |
-| `flotherm` | `FlothermDriver` | `flotherm/driver.py` + `_helpers.py` |
-| `ansa` | `AnsaDriver` | `ansa/driver.py` + `runtime.py` + `schemas.py` |
-| `openfoam` | `OpenFOAMDriver` | `openfoam/driver.py` |
-| `workbench` | `WorkbenchDriver` | `workbench/driver.py` + `compatibility.yaml` |
-| `mechanical` | `MechanicalDriver` | `mechanical/driver.py` + `compatibility.yaml` |
-| `abaqus` | `AbaqusDriver` | `abaqus/driver.py` |
-| `starccm` | `StarccmDriver` | `starccm/driver.py` + `compatibility.yaml` |
-| `cfx` | `CfxDriver` | `cfx/driver.py` + `compatibility.yaml` |
-| `ls_dyna` | `LsDynaDriver` | `lsdyna/driver.py` + `compatibility.yaml` |
-| `mapdl` | `MapdlDriver` | `mapdl/driver.py` + `compatibility.yaml` |
-| `icem` | `IcemDriver` | `icem/driver.py` + `compatibility.yaml` |
-| `paraview` | `ParaViewDriver` | `paraview/driver.py` + `compatibility.yaml` |
-| `hypermesh` | `HyperMeshDriver` | `hypermesh/driver.py` + `compatibility.yaml` |
+Drivers are resolved lazily through two channels:
 
-Drivers with `supports_session = True` (fluent, ansa, flotherm, matlab, workbench, mechanical, cfx, ls_dyna, mapdl) implement persistent-session lifecycle (`launch`/`run`/`query`/`disconnect`). The rest are one-shot only.
+- **`_BUILTIN_REGISTRY`** — an ordered list of `(name, "module:Class")` tuples for the open-source drivers that ship with `sim-runtime` itself (PyBaMM, OpenFOAM, CalculiX, gmsh, SU2, LAMMPS, Elmer, scikit-fem, MFEM, OpenSeesPy, SfePy, OpenMDAO, FiPy, pymoo, Pyomo, SimPy, Trimesh, Devito, CoolProp, scikit-rf, pandapower, ParaView, meshio, PyVista, Newton, Isaac Sim, LTspice). The canonical list lives in `src/sim/drivers/__init__.py`.
+- **`sim.drivers` entry-point group** — external/closed-source drivers register themselves via standard Python entry points and are discovered at import time, validated, and appended after the built-ins. Built-ins win on name collisions. This is the path used by every commercial-solver plugin (each lives in its own out-of-tree package with its own `compatibility.yaml`).
 
-LS-DYNA is a special case: the *solver* is one-shot (no live process to connect to), but the session holds a persistent Python namespace with PyDyna `Deck`/`run_dyna` and a DPF `Model` so deck-building and post-processing can be driven incrementally via `sim exec`.
-
-`get_driver(name)` looks up by `.name` attribute.
+A driver may set `supports_session = True` to implement the persistent-session lifecycle (`launch`/`run`/`query`/`disconnect`); the rest are one-shot only. `get_driver(name)` looks up by `.name` attribute and lazily imports the implementation module on first use, so a broken plugin does not crash the CLI.
 
 ### Execution pipeline — one-shot (`run`)
 1. `cli.run` → `runner.execute_script(script, solver, driver)` → subprocess, captures stdout/stderr/duration
@@ -132,66 +112,31 @@ Session routing rules: an explicit `X-Sim-Session` header wins (404 if unknown);
 3. Register in `src/sim/drivers/__init__.py`: import and append to `DRIVERS`
 4. If the driver needs server-side launch logic, extend `server.py`'s `/connect` handler accordingly
 
-See `pybamm/driver.py` for the smallest reference implementation; `fluent/` for a full persistent-session example.
+See `pybamm/driver.py` for the smallest reference implementation. Persistent-session examples live in the out-of-tree plugin packages.
 
 ## Test Layout
 
 ```
 tests/
   __init__.py
-  conftest.py                        shared FIXTURES / EXECUTION paths
+  conftest.py                        shared fixtures / execution paths
   base/                              core framework tests (no solver needed)
     test_cli.py                      smoke tests for click commands
     test_compat.py                   skills layering / profile resolution
+    test_config.py                   two-tier config resolution
     test_connect.py                  driver.connect() availability checks
+    test_driver_discovery.py         entry-point plugin discovery
+    test_history.py                  global run history persistence
     test_lint.py                     lint protocol coverage
-    test_run.py                      one-shot subprocess execution
-    test_store.py                    RunStore persistence
     test_logs.py                     sim logs CLI
-  drivers/                           per-driver unit + integration tests
-    abaqus/
-      test_abaqus_driver.py          protocol compliance
-      test_abaqus_e2e.py             cantilever beam E2E
-    comsol/
-      test_comsol_driver.py          unit tests
-    flotherm/
-      test_flotherm_lint.py          FloSCRIPT XSD validation
-    fluent/
-      test_fluent_mixing_elbow.py    mixing_elbow E2E
-    matlab/
-      test_matlab_driver.py          unit tests
-    cfx/
-      test_cfx_driver.py             unit tests (27 tests)
-      test_cfx_e2e.py                VMFL015 verification E2E
-    lsdyna/
-      test_lsdyna_driver.py          unit tests (24 tests)
-      test_lsdyna_e2e.py             single hex tension E2E
-    starccm/
-      test_starccm_driver.py         unit tests
-    workbench/
-      test_workbench_driver.py       unit tests (monkeypatched)
-      test_workbench_integration.py  real SDK integration
-  fixtures/                          mock solver scripts, organized by solver
-    abaqus/                          .py + .inp fixtures
-    comsol/                          .py fixtures
-    matlab/                          .m fixtures
-    pybamm/                          .py fixtures
-    cfx/                             .ccl + .def fixtures
-    lsdyna/                          .k fixtures
-    starccm/                         .java fixtures
-    workbench/                       .wbjn + .py fixtures
-    mock_solver.py                   shared mock scripts
-    mock_fail.py
-    not_simulation.py
-  execution/                         E2E scripts (per solver, manual runs)
-    abaqus/                          cantilever beam scripts
-    fluent/                          mixing_elbow snippets + PS1 runners
-    mechanical/                      static structural E2E + observation coupling
-    starccm/                         smoke test Java macro
-    workbench/                       SDK example runners
+    test_multi_session.py            session routing + concurrency
+    test_run.py                      one-shot subprocess execution
+  drivers/                           per-driver unit + integration tests for in-tree drivers
+  fixtures/                          mock solver scripts (one set per in-tree driver, plus shared mocks)
+  execution/                         optional end-to-end scripts for in-tree drivers
 ```
 
-Tests that need a real solver are gated by import-availability flags (e.g. `HAS_PYBAMM`) and skip gracefully when the package is missing.
+Tests for out-of-tree plugin drivers live in their own plugin repos. Tests in this repo that require a real solver are gated by import-availability flags (e.g. `HAS_PYBAMM`) and skip gracefully when the package is missing.
 
 ## Notes
 
@@ -218,9 +163,12 @@ machine or account. The two are easy to confuse.
 
 **Keep:**
 - The bug, the error message, the exit code, the reproducing input.
-- Version info that is a genuine reproduction prereq — *"this bug
-  reproduces on MATLAB R2024+ because `addpath` rejects `resources/`
-  in that release"*. The version is part of the engineering claim.
+- Version info that is a genuine reproduction prereq — when a behavior
+  is gated to a specific release of an open-source dependency, the
+  version is part of the engineering claim and stays. Use neutral
+  framing for closed-source dependencies ("a CFD solver release that
+  changed the boundary-condition API") rather than naming the vendor
+  and release.
 - Platform when behavior is platform-gated (Linux vs Windows
   filesystem casing, COM availability, etc.).
 
@@ -233,9 +181,9 @@ machine or account. The two are easy to confuse.
   `C:\Program Files\<Vendor>\<version>\...`) → "a local clone",
   "the editable install", or elide.
 - Specific commercial-software *versions tied to a personal machine*
-  — e.g. *"MATLAB R2025b on my Windows host at `C:\Program
-  Files\MATLAB\R2025b`"*. Vendor compliance teams use these as
-  license-audit signals even when the version alone would be fine.
+  — vendor compliance teams treat these as license-audit signals
+  even when the version alone would be fine. Replace with neutral
+  phrasing.
 - Tailscale tailnet names, OS account SIDs, MAC/serial numbers.
 
 Sanitize existing artifacts by editing PR/issue/comment bodies

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -14,7 +14,7 @@ ruff check src/sim tests
 
 ## Adding a new driver
 
-Drop a `DriverProtocol` implementation under `src/sim/drivers/<name>/driver.py`, register it in `drivers/__init__.py`, and you're done. See `pybamm/driver.py` for the smallest reference; `fluent/` for a full persistent-session driver.
+Drop a `DriverProtocol` implementation under `src/sim/drivers/<name>/driver.py` and register it in `_BUILTIN_REGISTRY` inside `drivers/__init__.py`. For an out-of-tree driver, expose it via the `sim.drivers` entry-point group from your own package. See `pybamm/driver.py` for the smallest reference. Persistent-session driver examples live in the out-of-tree plugin packages.
 
 The server routes all drivers through `DriverProtocol` — no `server.py` changes needed. Set `supports_session = True` for persistent-session drivers, `False` for one-shot only.
 
@@ -28,12 +28,13 @@ src/sim/
   driver.py        DriverProtocol + result dataclasses
   compat.py        Version-compat profiles + layered skill resolution
   drivers/
-    fluent/        Reference: persistent-session driver
-                   (driver.py + runtime.py + queries.py)
     pybamm/        Reference: smallest one-shot driver
-    flotherm/      GUI automation driver (Win32 + UIA backend)
-    …              one folder per registered backend
-    __init__.py    DRIVERS registry — register new backends here
+    openfoam/      Reference: SDK-less batch-CLI driver
+    …              one folder per built-in (open-source) backend
+    __init__.py    _BUILTIN_REGISTRY — register new built-in backends
+                   here; external plugins register via the
+                   `sim.drivers` entry-point group from their own
+                   package
 tests/             unit tests + fixtures (84 tests)
 assets/            logo · banner · architecture (SVG)
 docs/              translated READMEs (de · ja · zh) + architecture docs
@@ -77,9 +78,10 @@ sim disconnect --stop-server
 
 ### `SIM_DEV_MODE=1`
 
-Gates dangerous features behind an env var. Currently:
-
-- **Flotherm `#!python` exec** — raw Python execution through the Flotherm driver is blocked unless `SIM_DEV_MODE=1` is set.
+Gates dangerous features behind an env var. Plugins use this to gate
+raw-Python escape hatches inside script formats that would otherwise be
+declarative-only — without `SIM_DEV_MODE=1`, those code paths refuse to
+execute even when the directive is present in the input file.
 
 ## Layered skill composition
 

--- a/docs/architecture/multi-session-and-config.md
+++ b/docs/architecture/multi-session-and-config.md
@@ -34,7 +34,7 @@ empty string) so downstream tools can rely on column presence.
   "ts": "2025-04-24T07:21:14Z",
   "cwd": "/abs/path/to/project",
   "session_id": "s-8f3a",
-  "solver": "fluent",
+  "solver": "<driver>",
   "run_id": "r-0001",
   "kind": "exec",
   "label": "cli-snippet",
@@ -52,8 +52,8 @@ Field rules:
 - `session_id` — set when a session exists (`sim exec`, `sim run` when
   routed through a session). For `sim run <file>` one-shot (no server,
   no session), `session_id` is the empty string `""`. Never `null`.
-- `solver` — driver name (`fluent`, `mapdl`, `pybamm`, ...). For one-shot
-  `sim run`, this is the driver used.
+- `solver` — driver name (`pybamm`, `openfoam`, or any other registered
+  driver). For one-shot `sim run`, this is the driver used.
 - `run_id` — monotonic id, unique within a process. Opaque string.
 - `kind` — one of `exec`, `run`, `run_file`. (`run` = `sim run <file>`
   one-shot; `run_file` = server-side `/run` via a session; `exec` = code
@@ -68,7 +68,7 @@ record shape doesn't need to change for that.
 ## 3. `sim-serve.log` line format
 
 ```
-2025-04-24T07:21:14Z [session=s-8f3a] [solver=fluent] /exec cli-snippet ok (142 ms)
+2025-04-24T07:21:14Z [session=s-8f3a] [solver=<driver>] /exec cli-snippet ok (142 ms)
 ```
 
 Prefix rules:
@@ -92,10 +92,11 @@ env var  >  project .sim/config.toml  >  global ~/.sim/config.toml  >  auto-dete
 Under multi-session, the schema is unchanged but two UX rules apply:
 
 1. **Solver pins are advisory, not gating.** If
-   `.sim/config.toml` pins `[solvers.fluent]` but the user runs
-   `sim connect --solver mapdl`, the connect proceeds; the pin is
+   `.sim/config.toml` pins `[solvers.<name>]` but the user runs
+   `sim connect --solver <other-name>`, the connect proceeds; the pin is
    ignored for that session and a one-line warning is printed. Rationale:
-   a project may legitimately run Mechanical + Flotherm side by side.
+   a project may legitimately run two solvers (e.g. a structural FEA
+   driver alongside a thermal driver) side by side.
 2. **`sim connect` with no `--solver` picks the one pinned default if
    present; otherwise errors with the available driver list.** No
    guessing across multiple pins.
@@ -109,13 +110,13 @@ Breaking change — migrate once, don't carry two shapes.
   "sessions": [
     {
       "session_id": "s-8f3a",
-      "solver": "fluent",
-      "mode": "meshing",
+      "solver": "<driver>",
+      "mode": "<driver-mode>",
       "ui_mode": "no_gui",
       "processors": 1,
       "connected_at": "2025-04-24T07:18:02Z",
       "run_count": 3,
-      "profile": "pyfluent-0.38"
+      "profile": "<profile-name>"
     }
   ],
   "default_session": "s-8f3a",

--- a/docs/architecture/skills-layering-plan.md
+++ b/docs/architecture/skills-layering-plan.md
@@ -18,17 +18,17 @@
 ## 1. Problem (one paragraph)
 
 Each driver currently ships a flat `sim-skills/<driver>/` tree. As we
-add more SDK and solver versions, the API-specific bits (pyfluent 0.37
-vs 0.38) and solver-specific bits (Fluent 25R2 vs 24R1) start fighting
-the cross-cutting bits (concepts, file formats, license tips). We need
-a way to say "this reference is generic; this snippet is 0.38-only;
-this known-issue is 25R2-only" *without* duplicating the whole tree per
-profile.
+add more SDK and solver versions, the API-specific bits (one SDK
+release vs the next) and solver-specific bits (one solver release vs
+the next) start fighting the cross-cutting bits (concepts, file
+formats, license tips). We need a way to say "this reference is
+generic; this snippet is SDK-rev-only; this known-issue is
+solver-rev-only" *without* duplicating the whole tree per profile.
 
 ## 2. Layout
 
 ```
-sim-skills/fluent/
+sim-skills/<driver>/
     SKILL.md            ← single entry point. Hand-written index that
                           tells the LLM where to look. Does NOT contain
                           actual knowledge — only pointers like
@@ -41,18 +41,19 @@ sim-skills/fluent/
         snippets/
         workflows/
     sdk/
-        pyfluent-0.37/
-        pyfluent-0.38/
+        <sdk-rev-a>/
+        <sdk-rev-b>/
     solver/
-        25.2/
-        24.1/
+        <solver-rev-a>/
+        <solver-rev-b>/
 ```
 
 `base/` is always relevant. `sdk/<slug>/` and `solver/<slug>/` carry
 deltas that apply only to specific profiles.
 
-The same template applies to every driver. SDK-less drivers (openfoam,
-flotherm, ansa) just have an empty or absent `sdk/` directory.
+The same template applies to every driver. SDK-less drivers (e.g. those
+that drive a solver purely through its scripting interface or a CLI
+batch mode) just have an empty or absent `sdk/` directory.
 
 ## 3. compat.yaml change
 
@@ -60,12 +61,12 @@ Each profile gains two optional string fields:
 
 ```yaml
 profiles:
-  - name: pyfluent_0_38_modern
-    sdk: ">=0.38,<0.39"
-    solver_versions: ["25.2", "25.1"]
-    runner_module: sim._runners.fluent.modern_runner
-    active_sdk_layer: pyfluent-0.38         # ← new
-    active_solver_layer: "25.2"             # ← new
+  - name: <profile-name>
+    sdk: ">=X.Y,<Z.W"
+    solver_versions: ["<solver-rev-a>", "<solver-rev-b>"]
+    runner_module: sim._runners.<driver>.<runner>
+    active_sdk_layer: <sdk-slug>            # ← new
+    active_solver_layer: "<solver-slug>"    # ← new
 ```
 
 `base/` is implicit and always active — no field for it.
@@ -82,7 +83,7 @@ content leave `active_solver_layer` unset). The current
 
 The only runtime requirement: when an LLM connects, it needs to know
 which sdk/solver layers are active for its profile. Otherwise it can't
-tell whether to read `sdk/pyfluent-0.37/` or `sdk/pyfluent-0.38/`.
+tell which `sdk/<slug>/` directory to read.
 
 Wire it through the existing `/connect` response. After a successful
 connect, sim-server returns:
@@ -92,12 +93,12 @@ connect, sim-server returns:
   "ok": true,
   "data": {
     "session_id": "...",
-    "profile": "pyfluent_0_38_modern",
+    "profile": "<profile-name>",
     "skills": {
-      "root": "/path/to/sim-skills/fluent",
-      "index": "/path/to/sim-skills/fluent/SKILL.md",
-      "active_sdk_layer": "sdk/pyfluent-0.38",
-      "active_solver_layer": "solver/25.2"
+      "root": "/path/to/sim-skills/<driver>",
+      "index": "/path/to/sim-skills/<driver>/SKILL.md",
+      "active_sdk_layer": "sdk/<sdk-slug>",
+      "active_solver_layer": "solver/<solver-slug>"
     },
     ...
   }
@@ -153,31 +154,28 @@ skipping.)
 
 ## 6. sim-skills migration
 
-Per-driver, in this order. Each driver is a separate sim-skills PR.
+Per-driver, in dependency order. Each driver is a separate sim-skills PR.
 
 1. **pybamm** — currently has only `SKILL.md`. Create `base/` with the
    existing content, write a fresh top-level `SKILL.md` index.
    Validates the loader/contract end-to-end on minimal content.
 2. **openfoam** — SDK-less. Move existing `reference/`, `docs/`,
-   `tests/` into `base/`. Create `solver/v2206/`, `solver/v2312/`,
-   `solver/v2406/` (initially empty `.gitkeep`). Hand-write SKILL.md
+   `tests/` into `base/`. Create `solver/<rev>/` directories per
+   supported release (initially empty `.gitkeep`). Hand-write SKILL.md
    index. compat.yaml profiles get `active_solver_layer`.
-3. **fluent** — the actual reason this exists. Move bulk content into
-   `base/`. Create `sdk/pyfluent-0.37/` and `sdk/pyfluent-0.38/` and
-   triage which existing snippets/reference files are version-specific.
-   Create `solver/25.2/`, `solver/24.1/` (probably mostly empty at
-   first). Hand-write SKILL.md index.
-4. **comsol** — same recipe; mostly `solver/<ver>/` layers, single
-   `sdk/mph-1.x/`.
-5. **matlab** — three engine versions, three release years; mostly
-   `sdk/<engine>/` layers.
-6. **flotherm**, **ansa** — SDK-less, smallest deltas; do last.
+3. Drivers with both SDK and solver-version sensitivity — move bulk
+   content into `base/`. Create one `sdk/<rev>/` per supported SDK
+   release and triage which existing snippets/reference files are
+   version-specific. Create `solver/<rev>/` directories (probably
+   mostly empty at first). Hand-write SKILL.md index.
+4. SDK-less drivers and drivers with smallest deltas — do last.
 
 After each driver's PR lands, the corresponding `compatibility.yaml` in
-sim-cli is updated in the same commit (the schema change in §3 must be
-additive and backward compatible *for unmigrated drivers*: profiles
-without the two new fields just get None for both, which means "no
-sdk/solver overlay, base only").
+sim-cli (or the plugin package, for out-of-tree drivers) is updated in
+the same commit. The schema change in §3 must be additive and backward
+compatible *for unmigrated drivers*: profiles without the two new
+fields just get None for both, which means "no sdk/solver overlay,
+base only".
 
 ## 7. SKILL.md content (template)
 
@@ -198,15 +196,16 @@ which active layers apply (`active_sdk_layer`, `active_solver_layer`).
 
 ## SDK-version-specific — sdk/<your-active-sdk-layer>/
 
-If your active_sdk_layer is `pyfluent-0.38`, look in
-`sdk/pyfluent-0.38/` for:
+For example, if your active_sdk_layer is `<sdk-slug>`, look in
+`sdk/<sdk-slug>/` for:
 - the API surface (method names, kwargs)
 - migration notes from earlier SDKs
 - known SDK-version bugs
 
 ## Solver-version-specific — solver/<your-active-solver-layer>/
 
-If your active_solver_layer is `25.2`, look in `solver/25.2/` for:
+For example, if your active_solver_layer is `<solver-slug>`, look in
+`solver/<solver-slug>/` for:
 - features added/removed in this release
 - license syntax quirks
 - known issues
@@ -233,10 +232,10 @@ Tests live alongside `compat.py`. Create `tests/test_compat_skills.py`
 |---|------|---------|
 | 1 | `profile_loads_active_layer_fields` | Synthetic compat.yaml with `active_sdk_layer` / `active_solver_layer` round-trips into `Profile` correctly. |
 | 2 | `profile_active_layers_default_to_none` | A profile that omits both fields gets `None` / `None` and still loads. |
-| 3 | `verify_skills_layout_passes_on_complete_tree` | Build a synthetic sim-skills tree with `fluent/SKILL.md`, `fluent/base/`, `fluent/sdk/pyfluent-0.38/`, `fluent/solver/25.2/`. Pretend compat.yaml declares those active layers. `verify_skills_layout()` returns `[]`. |
-| 4 | `verify_skills_layout_flags_missing_skill_md` | Drop `fluent/SKILL.md` → mismatch entry. |
-| 5 | `verify_skills_layout_flags_missing_base` | Drop `fluent/base/` → mismatch entry. |
-| 6 | `verify_skills_layout_flags_missing_sdk_layer` | compat.yaml says `active_sdk_layer: pyfluent-0.99`, no such dir → mismatch entry. |
+| 3 | `verify_skills_layout_passes_on_complete_tree` | Build a synthetic sim-skills tree with `<driver>/SKILL.md`, `<driver>/base/`, `<driver>/sdk/<sdk-slug>/`, `<driver>/solver/<solver-slug>/`. Pretend compat.yaml declares those active layers. `verify_skills_layout()` returns `[]`. |
+| 4 | `verify_skills_layout_flags_missing_skill_md` | Drop `<driver>/SKILL.md` → mismatch entry. |
+| 5 | `verify_skills_layout_flags_missing_base` | Drop `<driver>/base/` → mismatch entry. |
+| 6 | `verify_skills_layout_flags_missing_sdk_layer` | compat.yaml declares an `active_sdk_layer` slug for which no directory exists → mismatch entry. |
 | 7 | `verify_skills_layout_flags_missing_solver_layer` | symmetric. |
 | 8 | `verify_skills_layout_skips_unset_layers` | A profile with `active_sdk_layer: None` doesn't trigger any sdk-related check. |
 | 9 | `connect_response_includes_skills_block` | (server-side, async test) `/connect` against a fake driver returns a response whose `data.skills` block has `root`, `index`, `active_sdk_layer`, `active_solver_layer`. |
@@ -253,8 +252,8 @@ sim-skills repo.
 4. Per-driver sim-skills migration PRs in the order from §6. Each PR
    updates that driver's `compatibility.yaml` to set the two active
    layer fields and removes `skill_revision`.
-5. Once all 7 drivers are migrated, delete the back-compat tolerance
-   for `skill_revision` (a one-line removal — until then the loader
+5. Once every driver is migrated, delete the back-compat tolerance for
+   `skill_revision` (a one-line removal — until then the loader
    accepts and ignores it with a warning).
 
 ## 10. What this plan deliberately does NOT do
@@ -289,12 +288,11 @@ works with the same Read/Glob/Grep tools it already has.
 
 ## 12. Open questions for review
 
-1. **Layer slug convention.** I've been writing `sdk/pyfluent-0.38/`
-   and `solver/25.2/`. Are those the slugs you want, or do you prefer
-   something tighter like `sdk/0.38/` (driver name dropped because the
-   parent dir already says `fluent`)?
+1. **Layer slug convention.** Should the slug repeat the SDK package
+   name (e.g. `sdk/<sdk-package>-<rev>/`) or stay terse (e.g.
+   `sdk/<rev>/`, since the parent dir already names the driver)?
 2. **`active_sdk_layer` value format.** Same question — does the yaml
-   value include the `pyfluent-` prefix, or just `0.38`?
+   value include the SDK-package prefix, or just the rev?
 3. **Should `verify_skills_layout()` be wired into a CI step now**, or
    only added as a function for later use? (I lean: add the function,
    no CI hook yet — wiring it into CI requires both repos to migrate

--- a/docs/architecture/version-compat.md
+++ b/docs/architecture/version-compat.md
@@ -1,502 +1,130 @@
-# Version Compatibility & Environment Bootstrapping
+# Version Compatibility & Plugin Discovery
 
-> **Status:** design accepted, M1 in progress
-> **Audience:** sim-cli maintainers, sim-skills maintainers, new driver authors
-> **Last reviewed:** 2026-04-08
+> **Status:** stub.
+> **Audience:** sim-cli maintainers, plugin authors.
+> **Last reviewed:** 2026-04-27.
 
-This document defines how `sim-cli` handles the fact that **every supported solver has its own version sprawl**, each with its own SDK that pins to a narrow window of solver versions, with skill content that is implicitly tied to a specific SDK API surface. It is the contract for the M1 work and the mental model every new driver author must follow.
+This document used to carry a long, driver-specific compatibility-matrix design. Most of that material now lives **inside individual plugin packages** — every commercial-solver driver ships as its own out-of-tree plugin, and each plugin owns the version-compat data for its own SDK and solver releases. The design intent is preserved here in summary form so the public `sim-runtime` repo still describes the contract that plugins implement.
 
-If you only read one section, read **§3 (Three first-principles axioms)** and **§4 (The detect-then-bootstrap model)**.
-
----
-
-## 1. The problem, in one paragraph
-
-Ansys Fluent has multiple versions in active use (24.1, 24.2, 25.1, 25.2, …). The Python binding `ansys-fluent-core` (PyFluent) advances on its own schedule and each PyFluent release supports a *window* of Fluent versions — for example, PyFluent 0.38 dropped Fluent 24.1 entirely; PyFluent 0.37 has a different API surface than 0.38 for boundary conditions and cell zones. The driver code in `sim-cli` calls into PyFluent. The skill content in `sim-skills` (snippets, workflows, reference) implicitly assumes a specific PyFluent API. **Four different things need to line up before a single `sim exec` call can succeed**, and right now we encode none of those constraints anywhere — we just pin one SDK version in `pyproject.toml` and hope.
-
-This is the same shape of problem as: browser feature detection, database client/server compatibility, Kubernetes version skew, Linux distro packaging, PyTorch CUDA wheels, dbt adapters, Airflow providers. None of those projects solve it with a single dependency pin. Neither can we.
+If you are looking for the per-plugin compatibility data, read each plugin's own `compatibility.yaml` and its own architecture notes.
 
 ---
 
-## 2. The four version axes
+## 1. Why "compatibility" is plural
 
-```
-            ┌───────────────────────────────────────────┐
-            │         The compatibility surface         │
-            └───────────────────────────────────────────┘
-              ▲          ▲              ▲           ▲
-              │          │              │           │
-       (1) Solver   (2) SDK /      (3) Driver  (4) Skill
-           version       bindings        code        content
-                       (PyFluent,     (sim-cli/   (sim-skills/
-                        JPype,         drivers/    fluent/...)
-                        matlab-       fluent/)
-                        engine, ...)
-```
+Every supported solver has its own version sprawl, each with its own SDK or scripting interface that pins to a narrow window of solver versions, and each with skill content that is implicitly tied to a specific API surface. A single global pin in `pyproject.toml` cannot represent that. We solve it by:
 
-| Axis | Owner | Cadence | Typical drift |
-|---|---|---|---|
-| (1) Solver binary | The user's IT / license server | yearly | 24.1, 24.2, 25.1, 25.2 |
-| (2) SDK / language binding | Vendor or OSS upstream | monthly | PyFluent 0.36 → 0.37 → 0.38 |
-| (3) Driver code (`sim-cli/drivers/<solver>/`) | Us | weekly | API call shape changes per profile |
-| (4) Skill content (`sim-skills/<solver>/`) | Us | weekly | Snippets pinned to a specific API surface |
-
-These four axes constrain each other in **non-obvious** ways. Selecting Fluent 24.1 forbids PyFluent 0.38; selecting PyFluent 0.38 forces a different driver code path; that driver code path forces different snippet bodies. One choice cascades.
+- shipping a small **core** runtime (`sim-runtime`) that holds no solver SDK as a hard dependency,
+- letting each driver — built-in or external — carry its own `compatibility.yaml` next to its `driver.py`,
+- discovering external drivers at import time through a standard Python entry-point group.
 
 ---
 
-## 3. Three first-principles axioms
+## 2. Plugin discovery contract
 
-The whole design follows from these three.
+Two channels feed `get_driver(name)` in `src/sim/drivers/__init__.py`:
 
-> **Axiom A — Compatibility is data, not prose.**
-> The relationships between (solver, SDK, driver, skill) versions must live in a single machine-readable file per driver, consumed identically by sim-cli code, by CI, by users, and by LLM agents. Documentation drifts; data does not.
+1. **`_BUILTIN_REGISTRY`** — an ordered list of `(name, "module:Class")` tuples for the open-source drivers shipped in this repo (PyBaMM, OpenFOAM, CalculiX, gmsh, SU2, LAMMPS, Elmer, scikit-fem, MFEM, OpenSeesPy, SfePy, OpenMDAO, FiPy, pymoo, Pyomo, SimPy, Trimesh, Devito, CoolProp, scikit-rf, pandapower, ParaView, meshio, PyVista, Newton, Isaac Sim, LTspice, …).
+2. **`sim.drivers` entry-point group** — external packages register drivers via standard Python entry points:
 
-> **Axiom B — Detection happens at runtime, on demand, against the real environment.**
-> sim never assumes it knows the user's solver version. It detects when the user asks. Detection is per-solver and per-host (local or remote), never global "scan everything." This is the LLM equivalent of `caniuse` — feature detection, not design-time guessing.
+   ```toml
+   # in the plugin package's pyproject.toml
+   [project.entry-points."sim.drivers"]
+   myname = "my_pkg.module:MyDriver"
+   ```
 
-> **Axiom C — Each (solver, SDK) profile lives in an isolated environment, dispatched by the core process.**
-> The core `sim` process holds no SDK dependency. Each profile gets its own venv under `.sim/envs/`. The core spawns a subprocess into the right env when it needs to talk to a solver. Multi-version machines (Fluent 24R2 + 25R2 side by side) work natively; CI matrices fall out for free.
+   At import time, sim-cli enumerates the group, validates each spec shape, drops collisions with built-ins (built-ins always win), and appends the survivors after the built-in list. Resolution is lazy: a broken plugin module does not crash the CLI, and `get_driver` raises the original `ImportError` only if the user asks for that specific driver.
 
-Everything below is mechanism in service of these three axioms.
-
----
-
-## 4. The detect-then-bootstrap model
-
-The user's experience reduces to **three actions, all of them per-solver and lazy**:
-
-```
-                ┌────────────────────────┐
-                │  uv tool install sim-cli  (~10 MB, no SDKs)
-                └────────────┬───────────┘
-                             │
-                             ▼
-        ┌──────────────────────────────────────────┐
-        │  sim check fluent       (or any solver)  │
-        │   ─ scans THIS host for fluent installs  │
-        │   ─ resolves each to a profile           │
-        │   ─ reports + tells you what to bootstrap│
-        └────────────┬─────────────────────────────┘
-                     │
-                     ▼
-        ┌──────────────────────────────────────────┐
-        │  sim env install fluent-pyfluent-0-38    │
-        │   ─ uv venv .sim/envs/fluent-0-38/       │
-        │   ─ uv pip install ansys-fluent-core...  │
-        │   ─ installs the driver runner shim      │
-        └────────────┬─────────────────────────────┘
-                     │
-                     ▼
-        ┌──────────────────────────────────────────┐
-        │  sim connect --solver fluent             │
-        │   ─ picks env by detected version        │
-        │   ─ spawns runner subprocess in that env │
-        │   ─ ready                                │
-        └──────────────────────────────────────────┘
-```
-
-Two non-obvious commitments:
-
-- **`sim init` is NOT a global scanner.** There is no "scan all 7 drivers at once" command. The user always names a solver. Reasoning: detection has cost (registry hits, file walks, env probes); we don't pay that cost for tools the user isn't using; we don't want to confuse a Fluent user by listing the fact that they don't have COMSOL installed.
-- **Bootstrap is opt-in.** `sim check fluent` does NOT install anything. It reports. The actual env creation is `sim env install`. We ask before downloading 200 MB of SDK wheels.
-
-The single optional convenience subcommand `sim env install --auto-from-check` lets a confident user do detect+bootstrap in one shot for a named solver, but it still scopes to that one solver.
+The list of drivers a given install can see is therefore a function of `_BUILTIN_REGISTRY` plus whatever plugin packages are installed in the same venv. Run `sim solvers list` to see the resolved set.
 
 ---
 
-## 5. Two detection modes: local and remote
+## 3. `compatibility.yaml` — per-driver
 
-Detection runs **wherever the solver license and binaries actually live**. There are two cases:
-
-### 5.1 Local detection
-
-```
-[user laptop with sim-cli + license + solver installed]
-   $ sim check fluent
-   → driver.detect_installed() runs in the local sim process
-```
-
-Used when the user is on the workstation that has the solver.
-
-### 5.2 Remote detection (via `sim serve`)
-
-```
-[Mac]                                   [Windows workstation with Fluent]
-$ sim --host 100.90.110.79 check fluent ─────► sim serve (already running)
-                                                 │
-                                                 ▼
-                                              GET /detect/fluent
-                                                 │
-                                                 ▼
-                                       driver.detect_installed()
-                                       runs INSIDE the server process
-                                                 │
-                                                 ▼
-                                       returns a JSON list of installs
-       ◄─────────────────────────────  back over HTTP
-   prints the same install table
-```
-
-The remote case is the **important** one for sim's "agent on a Mac, solver on a license server" use case. The remote endpoint runs **the same Python `detect_installed()` code** the local case runs — it just runs it on a different host. There is no second copy of the detection logic.
-
-**Implication for the driver protocol:** `detect_installed()` must be a pure Python method that depends only on stdlib + the driver's own helpers. It must NOT need the SDK to be installed (that is the whole point — we are detecting the *solver*, before we know which SDK to install).
-
-### 5.3 Bootstrap also goes through the right host
-
-```
-$ sim --host 100.90.110.79 env install fluent-pyfluent-0-38
-       │
-       ▼
-   POST /env/install
-       │
-       ▼
-   sim serve creates .sim/envs/fluent-0-38/ ON THE WINDOWS BOX,
-   not on the user's Mac
-```
-
-This is required because the SDK needs to live next to the solver binary — installing PyFluent on a Mac when Fluent runs on Windows is meaningless. The same `--host` flag that controls `connect` and `exec` also controls `check` and `env`.
-
----
-
-## 6. The `compatibility.yaml` schema
-
-One file per driver, at `sim-cli/src/sim/drivers/<solver>/compatibility.yaml`. This is the single source of truth.
+Each driver folder may contain a `compatibility.yaml` that declares the SDK versions, solver versions, and skill-layer slugs it supports. This is the unit of compatibility throughout the runtime: a driver is compatible with a given solver install when at least one of its profiles matches.
 
 ```yaml
-# sim-cli/src/sim/drivers/fluent/compatibility.yaml
-driver: fluent
-sdk_package: ansys-fluent-core
+# src/sim/drivers/<name>/compatibility.yaml  (or inside a plugin package)
+driver: <name>
+sdk_package: <pypi-distribution-name>          # may be omitted for SDK-less drivers
 
-# Each profile is a (solver-version-range, SDK-version-range) named tuple
-# that the driver code, the skill, and the CI matrix all agree on.
 profiles:
-
-  - name: pyfluent_0_38_modern
-    sdk: ">=0.38,<0.39"
-    solver_versions: ["24.2", "25.1", "25.2"]
-    skill_revision: v2
-    runner_module: sim_runners.fluent.pyfluent_038
-    extras_alias: fluent-pyfluent-0-38
+  - name: <stable-identifier>
+    sdk: ">=X.Y,<Z.W"                          # PEP 440 specifier, optional
+    solver_versions: [...]                     # concrete solver versions tested
+    runner_module: <python-import-path>        # optional runner subprocess
+    active_sdk_layer: <slug>                   # optional, for sim-skills overlays
+    active_solver_layer: <slug>                # optional, for sim-skills overlays
     notes: |
-      Uses .general.material accessor (PyFluent 0.38+).
-      Fluent 24.1 dropped upstream — DO NOT pick this profile for 24.1.
+      Free-form notes surfaced in `sim check` output.
 
-  - name: pyfluent_0_37_legacy
-    sdk: ">=0.37,<0.38"
-    solver_versions: ["24.1", "24.2", "25.1"]
-    skill_revision: v1
-    runner_module: sim_runners.fluent.pyfluent_037
-    extras_alias: fluent-pyfluent-0-37
-    notes: |
-      Direct cell_zone.<zone>.material accessor.
-      Last profile that supports Fluent 24.1.
-
-# Profiles that are no longer maintained.
-# Listed so resolution errors can hint at the right migration target.
 deprecated:
-  - profile: pyfluent_0_30_alpha
-    reason: predates DriverProtocol; no longer maintained
-    last_supported_in_sim_cli: "0.1"
-    migrate_to: pyfluent_0_37_legacy
+  - profile: <old-profile-name>
+    reason: ...
+    migrate_to: <newer-profile-name>
 ```
 
-### 6.1 Field reference
+Field rules:
 
 | Field | Required | Meaning |
 |---|---|---|
-| `driver` | ✓ | Must match the driver's registered name in `drivers/__init__.py`. |
-| `sdk_package` | ✓ | Distribution name as it appears on PyPI / the registry the driver pulls from. |
-| `profiles[].name` | ✓ | Stable identifier. **Never rename** — agents and skill folders reference it. |
-| `profiles[].sdk` | ✓ | PEP 440 specifier for the SDK version range. |
-| `profiles[].solver_versions` | ✓ | Concrete solver versions tested against this SDK range. List, not range — version reporting from solvers is messy. |
-| `profiles[].skill_revision` | ✓ | Identifier the skill folder uses to scope its `snippets/<rev>/` and `reference/<rev>/`. |
-| `profiles[].runner_module` | ✓ | Python import path of the per-profile runner module that lives inside the profile env. |
-| `profiles[].extras_alias` |   | Name of the matching `[project.optional-dependencies]` extra in pyproject.toml. Power users can `pip install sim-cli[<alias>]` to skip `sim env`. |
-| `profiles[].notes` |   | Free-form, surfaced in `sim check` output. |
-| `deprecated[]` |   | Old profile names + migration hints. |
+| `driver` | yes | Must match the driver's registered name. |
+| `sdk_package` | no | Distribution name on PyPI / the index the driver depends on, when one exists. |
+| `profiles[].name` | yes | Stable identifier — never rename, agents and skill folders reference it. |
+| `profiles[].sdk` | no | PEP 440 specifier for the SDK version range. |
+| `profiles[].solver_versions` | no | Concrete solver versions tested against this profile. |
+| `profiles[].runner_module` | no | Import path of the per-profile runner module that lives inside an isolated env. |
+| `profiles[].active_sdk_layer` | no | Slug of the matching `sim-skills/<driver>/sdk/<slug>/` layer. |
+| `profiles[].active_solver_layer` | no | Slug of the matching `sim-skills/<driver>/solver/<slug>/` layer. |
+| `profiles[].notes` | no | Surfaced in `sim check`. |
+| `deprecated[]` | no | Old profile names + migration hints. |
 
-### 6.2 Resolution rules
+### Resolution
 
 Given a detected solver version `V`:
+
 1. Walk `profiles` in declaration order.
-2. The first profile whose `solver_versions` contains `V` is the *preferred* match.
+2. The first profile whose `solver_versions` contains `V` wins.
 3. If no profile matches, return `unsupported` and surface the deprecated table for hints.
-4. If multiple profiles match the same `V` (intentional overlap during migration), the first one wins; both are surfaced in `sim check` output for the user to override with `--profile`.
-
-### 6.3 Versioning the schema itself
-
-The schema version is implied by sim-cli version. Schema breaking changes require a sim-cli minor bump and a `version-compat-migration.md` note.
+4. Multiple matches — first wins, but `sim check` surfaces all of them so the user can override with `--profile`.
 
 ---
 
-## 7. Driver protocol additions
+## 4. Detection and bootstrap
 
-Two new methods on `DriverProtocol`. Both are pure Python; neither imports the SDK.
+The user-facing flow stays per-solver and lazy:
 
-```python
-@dataclass(frozen=True)
-class SolverInstall:
-    name: str            # driver name, e.g. "fluent"
-    version: str         # detected solver version, e.g. "25.2"
-    path: str            # filesystem path to the installation root
-    source: str          # how we found it: "env:AWP_ROOT252", "registry", "default-path"
-    extra: dict          # driver-specific metadata (e.g. {"license_server": "..."})
+1. `sim check <solver>` calls the driver's `detect_installed()` (pure stdlib, no SDK import) on the local host or, with `--host`, on a remote `sim serve` over `GET /detect/<solver>`. It reports installs and resolved profiles; it does **not** install anything.
+2. `sim env install <profile>` (when implemented for that driver) creates an isolated venv under `.sim/envs/<profile>/`, pins the SDK inside it, and installs the runner module that talks JSON-over-stdio to the core.
+3. `sim connect --solver <name>` picks the matching profile, ensures the env exists, and dispatches.
 
-
-class DriverProtocol(Protocol):
-    name: str
-
-    # ... existing methods (lint, connect, parse_output, run_file) ...
-
-    def detect_installed(self) -> list[SolverInstall]:
-        """Scan THIS host for installations of this driver's solver.
-
-        Pure Python. Must NOT import the SDK. Must NOT launch the solver.
-        Must be safe to call when nothing is installed (returns []).
-        Should be cheap (≤ a few hundred ms) — it runs in interactive paths.
-        """
-
-    def runner_for_profile(self, profile_name: str) -> str:
-        """Return the import path of the runner module for a given profile.
-
-        Implemented as a small helper that reads compatibility.yaml.
-        Provided by a default mixin so most drivers do not override it.
-        """
-```
-
-### 7.1 Detection patterns by solver
-
-Each driver gets a different scan strategy. The catalogue:
-
-| Driver | Where to look |
-|---|---|
-| `fluent` | `AWP_ROOT*` env vars; `C:\Program Files\ANSYS Inc\v???\fluent\ntbin\win64\fluent.exe`; Windows registry key `HKLM\SOFTWARE\Ansys, Inc.\Fluent` |
-| `comsol` | `C:\Program Files\COMSOL\COMSOL??\Multiphysics\bin\win64\comsol.exe`; macOS `/Applications/COMSOL Multiphysics ??.app`; `COMSOL_HOME` env var |
-| `matlab` | Windows registry `HKLM\SOFTWARE\MathWorks\MATLAB\<release>`; `C:\Program Files\MATLAB\R????`; `which matlab` on Linux |
-| `openfoam` | `WM_PROJECT_DIR` env var (the canonical OpenFOAM marker); `which simpleFoam` |
-| `flotherm` | Windows registry `HKLM\SOFTWARE\Mentor Graphics\Flotherm`; default install dir |
-| `ansa` | `C:\BETA_CAE_Systems\ansa_v??\ansa_win64.exe`; `ANSA_HOME` env var |
-| `pybamm` | This one is special — PyBaMM is itself a pip package, not a separate solver binary. Detection means *importing* the package, so `pybamm` is the only driver where `detect_installed()` may import its SDK. |
-
-These rules are stable across years; we encode them once.
+The core sim process never imports any solver SDK directly — all SDK imports happen inside the runner subprocess, so a bug in one SDK cannot crash the core, and side-by-side multi-version installs are natural.
 
 ---
 
-## 8. The runner subprocess + IPC protocol
+## 5. Profile environments and runner subprocesses
 
-Each profile env contains a small `sim_driver_runner.<solver>` Python module. The core sim process spawns it as a subprocess and talks to it via JSON-over-stdio. This is the same trick LSP, DAP, MCP, and `pylance --stdio` use.
-
-### 8.1 Process layout
+When a driver opts into a profile env, its layout is:
 
 ```
-sim-cli core process                       profile env
-─────────────────────                      ─────────────────────────
-sim CLI / sim serve                        .sim/envs/fluent-0-38/
-   │                                          ├─ bin/python
-   │                                          └─ site-packages/
-   │                                              ├─ ansys-fluent-core 0.38.1
-   │                                              └─ sim_driver_runner/
-   │                                                    └─ fluent/
-   │                                                          └─ pyfluent_038.py
-   │
-   │  spawn:
-   │     <env>/bin/python -m sim_driver_runner.fluent.pyfluent_038
-   │
-   ▼
-   stdin / stdout JSON pipes ◄────────────► runner main loop
+sim-runtime core process               profile env
+─────────────────────                  ─────────────────────────
+sim CLI / sim serve                    .sim/envs/<profile>/
+   │                                       ├─ bin/python
+   │  spawn: <env>/bin/python -m            └─ site-packages/
+   │         <runner_module>                     ├─ <SDK pinned>
+   ▼                                              └─ sim_driver_runner/<driver>/
+   stdin/stdout JSON pipes ◄─────────► runner main loop
 ```
 
-The core process **never imports PyFluent**. All SDK imports happen inside the runner. This means:
-- `sim` startup time stays fast as we add drivers
-- A bug in PyFluent 0.38 cannot crash the sim core
-- Multiple profiles can run side by side (one runner subprocess per active session)
+The wire protocol is newline-delimited JSON over stdin/stdout; one message per line. Operations: `handshake`, `connect`, `exec`, `inspect`, `disconnect`, `shutdown`. Errors come back as `{"id": N, "ok": false, "error": {...}}`.
 
-### 8.2 Wire protocol
-
-Newline-delimited JSON. Every message is a single line. One JSON object per line.
-
-```json
-// from core to runner
-{"id": 1, "op": "handshake"}
-{"id": 2, "op": "connect", "args": {"mode": "solver", "ui_mode": "gui", "processors": 2}}
-{"id": 3, "op": "exec", "args": {"code": "solver.settings.mesh.check()", "label": "mesh-check"}}
-{"id": 4, "op": "inspect", "args": {"name": "session.summary"}}
-{"id": 5, "op": "disconnect"}
-{"id": 6, "op": "shutdown"}
-
-// from runner to core (responses)
-{"id": 1, "ok": true, "data": {"sdk_version": "0.38.1", "solver_version": "25.2", "profile": "pyfluent_0_38_modern"}}
-{"id": 2, "ok": true, "data": {"session_id": "f1f9..."}}
-{"id": 3, "ok": true, "data": {"stdout": "...", "result": null, "elapsed_s": 0.42}}
-{"id": 3, "ok": false, "error": {"type": "AttributeError", "message": "..."}}
-```
-
-### 8.3 Lifecycle
-
-```
-1. core: spawn runner
-2. core → runner: {op: "handshake"}
-3. runner → core: {ok: true, data: {sdk_version, solver_version, profile}}
-4. core: validate against compatibility.yaml; abort if mismatch
-5. core → runner: {op: "connect", args: {...}}
-6. ... loop on exec / inspect ...
-7. core → runner: {op: "disconnect"}
-8. core → runner: {op: "shutdown"}
-9. runner: graceful exit
-```
-
-If the runner dies between messages, the core marks the session as crashed and surfaces the runner's stderr in the next `sim ps` / `sim inspect` call. We do NOT auto-restart — agent should observe the crash and decide.
-
-### 8.4 Why JSON-over-stdio (not gRPC, not sockets, not shared memory)
-
-- **Zero infrastructure** — no port allocation, no firewall, no auth, no schema compiler
-- **Same primitive LSP/DAP/MCP use** — well-trodden, lots of reference implementations
-- **Trivial to debug** — `cat` the pipe, see human-readable JSON
-- **Process isolation is automatic** — when the runner exits, its file descriptors close
-
-Sockets become attractive when we want to share one runner across multiple core processes (which we don't), or for IPC across machines (`sim --host` already covers that case at a higher layer).
+This is the same primitive LSP, DAP, and MCP use. It costs no port allocation, no firewall, no auth, and it isolates SDKs that have mutually exclusive dependency closures. Runner death is treated as session crash — sim does not auto-restart; the agent observes and decides.
 
 ---
 
-## 9. Subcommand changes
+## 6. Where the rest of the design lives
 
-| Subcommand | Today | After M1 |
-|---|---|---|
-| `sim check <solver>` | Returns "installed yes/no" based on a Python import attempt | **Calls `detect_installed()` on local OR remote host (via `--host`); prints all installs + their resolved profiles + bootstrap status** |
-| `sim env install <profile>` | does not exist | **Creates `.sim/envs/<profile>/` with the right SDK pinned, also installs the runner shim** |
-| `sim env list` | does not exist | **Lists all bootstrapped envs and their state** |
-| `sim env remove <profile>` | does not exist | **Removes a profile env** |
-| `sim connect --solver <name>` | Direct in-process driver call; uses whatever SDK pip installed | **Detects, picks profile, ensures env exists, spawns runner subprocess, dispatches** |
-| `sim inspect session.versions` | does not exist | **Returns `{sdk, solver, profile, env_path}`** |
-| `sim ps` | shows `connected/mode/run_count` | also shows the active profile + env path |
+Per-driver compatibility matrices, detection patterns, and runner implementations live in the driver itself — inside this repo for built-in OSS drivers, inside the plugin package for everything else. The public `sim-runtime` repo intentionally stays thin and version-agnostic; it owns the contract, not the data.
 
-### 9.1 `--host` is uniform
-
-All subcommands that touch a solver accept `--host <ip>`. With `--host` set, the subcommand is a thin HTTP wrapper around an endpoint on the remote `sim serve`:
-
-| Command | Endpoint |
-|---|---|
-| `sim --host X check fluent` | `GET /detect/fluent` |
-| `sim --host X env install <profile>` | `POST /env/install` |
-| `sim --host X env list` | `GET /env/list` |
-| `sim --host X connect --solver fluent` | `POST /connect` (existing, extended) |
-
-Without `--host`, the same code paths run locally. Same Python; different transport.
-
----
-
-## 10. Skill side: what `sim-skills/` must do
-
-Every skill protocol gets a mandatory **Step 0** before any solver-specific code:
-
-> **Step 0 — Detect the runtime profile.** After `sim connect`, immediately run:
-> ```bash
-> sim --host <ip> inspect session.versions
-> ```
-> Read the returned `profile` field. Use it to choose which `<skill>/snippets/<profile>/*.py` and `<skill>/reference/<profile>/*.md` files to load. **Never read snippets from the wrong profile folder.** If `profile` is empty or unrecognized, stop and surface the version table to the user.
-
-Skill folder layout becomes profile-aware:
-
-```
-sim-skills/fluent/
-  SKILL.md                        ← protocol; version-agnostic; mandates Step 0
-  compatibility.md                ← human-readable version of compatibility.yaml
-  reference/
-    common/                       ← rules that apply to ALL profiles
-      input_classification.md
-      acceptance_criteria.md
-    pyfluent_0_38_modern/         ← per-profile reference
-      boundary_conditions.md
-    pyfluent_0_37_legacy/
-      boundary_conditions.md
-  snippets/
-    common/                       ← profile-agnostic snippets
-      00_mesh_check.py
-    pyfluent_0_38_modern/
-      05_set_material.py
-    pyfluent_0_37_legacy/
-      05_set_material.py
-  workflows/
-    common/
-    pyfluent_0_38_modern/
-      mixing_elbow.py
-```
-
-Snippet files MUST start with a metadata header:
-
-```python
-# profile: pyfluent_0_38_modern
-# requires:
-#   solver: in ["24.2", "25.1", "25.2"]
-#   sdk: ">=0.38,<0.39"
-```
-
-`sim lint` parses this header and refuses to send a snippet to a session whose `profile` does not match. The agent gets a fail-fast error instead of an `AttributeError` ten lines into a Python exec.
-
-The `sim-skills/CLAUDE.md` cross-skill conventions section gets a new mandatory rule (added in task #2 below):
-
-> **Rule (runtime version awareness):** Step 0 of every skill protocol MUST be `sim inspect session.versions`. Snippets MUST be loaded from the matching profile folder. Reference docs in `<skill>/reference/<profile>/` override anything in `<skill>/reference/common/` for that profile.
-
----
-
-## 11. Why this design and not the alternatives
-
-| Alternative | Why we did not pick it |
-|---|---|
-| **Single SDK pin in `dependencies`** | Current state. The thing we are fixing. |
-| **Per-release sim-cli pins** (`sim-cli 0.2 ⇔ Fluent 25R2`) | A workstation with Fluent 24R2 + 25R2 side by side has no way to use both. Also forces users to pin sim-cli to a specific solver version, which is the wrong direction. |
-| **Per-(solver, version) separate driver classes** (`fluent@25`, `fluent@24`) | Code duplication explodes. Doesn't scale to 50 backends. Agents would have to learn dozens of driver names. |
-| **Distribute as N separate packages** (`sim-fluent-modern`, `sim-fluent-legacy`) | dbt does this, but they have a corporate ecosystem maintaining each adapter. We are too small to maintain N release pipelines. |
-| **Capability detection only, no version metadata** | Right asymptotic answer (browser-style polyfills) but enormous upfront cost. We adopt it gradually for high-frequency operations only — see §12. |
-| **One universal venv with all SDKs side by side** | Many SDKs have mutually exclusive dependency closures (e.g. PyFluent 0.37 vs 0.38). Pip cannot resolve. |
-
-The rejected ideas all collapse against either Axiom B (must detect at runtime) or Axiom C (must isolate per profile).
-
----
-
-## 12. Future work (post-M1)
-
-These are explicitly **not** in M1 but the design must not foreclose them.
-
-- **Façade layer for high-frequency operations.** The driver could expose a stable cross-profile API for the ~10 most-used calls (e.g. `session.bc.set_velocity_inlet(...)`) and dispatch internally. Browser-polyfill style. Skill snippets that use the façade become version-agnostic. We add this when the maintenance pain of profile-specific snippets exceeds the cost of building façades.
-- **CI matrix with self-hosted runners.** GitHub Actions matrix that expands `compatibility.yaml` into one job per (sdk_version, solver_version) cell, runs the relevant integration tests, and gates release on all green. Solver-license-required jobs run on a self-hosted runner inside the lab.
-- **`sim env update` and lockfiles per profile.** Each `.sim/envs/<profile>/` carries its own `uv.lock` so SDKs are reproducible across machines. `sim env update <profile>` refreshes within the compatibility.yaml constraint window.
-- **Auto-bootstrap on `sim connect --solver X`.** If no env is bootstrapped yet for the resolved profile, prompt or `--auto-install` to do it inline. Already in the M1 plan as task #9.
-- **Cross-host detection caching.** When the user's day-to-day workflow targets one license server, cache that server's `detect/fluent` response for some short TTL.
-
----
-
-## 13. M1 implementation roadmap (the contract for the rest of this work)
-
-Each row is one task in the project task tracker. Order matters; later tasks depend on earlier ones.
-
-| # | Task | Output | Risk |
-|---|---|---|---|
-| 1 | Write this doc | `docs/architecture/version-compat.md` | 0 |
-| 2 | Update `sim-skills/CLAUDE.md` Step 0 rule | mandatory runtime detection rule | 0 |
-| 3 | `compatibility.yaml` schema + Fluent's first version | yaml file + `sim/compat.py` loader | low |
-| 4 | `Driver.detect_installed()` protocol + Fluent impl | new method on DriverProtocol; Fluent scanner | low |
-| 5 | `sim check <solver>` on-demand local + remote | extended subcommand + `GET /detect/<solver>` endpoint | low |
-| 6 | `sim env install/list/remove` | new subcommand; `.sim/envs/` management; uv preferred, stdlib fallback | medium |
-| 7 | `sim_driver_runner` + JSON-over-stdio IPC | runner package + protocol implementation | **medium-high** |
-| 8 | Refactor Fluent driver to dispatch through runner | thin client in core; PyFluent calls move to runner | medium |
-| 9 | `sim connect` auto-bootstrap on first use + `inspect session.versions` | end-to-end happy path | medium |
-| 10 | Update 4 READMEs + pyproject extras | docs catch up to the new install flow | 0 |
-
-After M1 completes:
-- The four-axis problem from §2 is **structurally solved** for Fluent
-- Adding any other solver to this model is "fill in the same five files" (compatibility.yaml, detect_installed, runner module, skill snippet folders, README install line)
-- We are positioned for the post-M1 work in §12 without further architectural changes
-
----
-
-## 14. Glossary
-
-- **Profile** — a named `(SDK version range, solver version list)` tuple defined in `compatibility.yaml`. The unit of compatibility throughout this design.
-- **Profile env** — an isolated venv under `.sim/envs/<profile-name>/` containing the SDK pinned for one profile plus the matching runner module.
-- **Runner** — the small Python program that lives inside a profile env, imports the SDK, and exposes a JSON-over-stdio interface to the core sim process.
-- **Detect** — calling `driver.detect_installed()` (locally) or `GET /detect/<solver>` (remote) to enumerate solver installations on a host. Pure Python, no SDK required.
-- **Bootstrap** — creating a profile env and installing the SDK + runner into it. Happens via `sim env install`.
-- **Dispatch** — the core sim process spawning a runner subprocess and forwarding `connect`/`exec`/`inspect`/`disconnect` calls into it.
-- **Skill revision** — a stable identifier (e.g. `v1`, `v2`) used as the folder name under `<skill>/snippets/` and `<skill>/reference/` to scope content to a profile.
+For the layered skill-content design that consumes `active_sdk_layer` / `active_solver_layer`, see [`skills-layering-plan.md`](skills-layering-plan.md).


### PR DESCRIPTION
## Summary

After the recent driver removals (#56, #58, #59), several public docs still described the removed drivers as if they shipped in-tree and named third-party software in prose. This PR sanitizes for compliance and factual accuracy.

## Files changed (lines before / after)

| File | Before | After | Notes |
|---|---:|---:|---|
| `CLAUDE.md` | 244 | 192 | Registry table -> 2-paragraph driver-discovery description; Test Layout trimmed to actual contents of `tests/base/`; persistent-session and SDK-specific paragraphs dropped; privacy section examples genericized so the doc itself stops naming closed-source software. |
| `docs/architecture/version-compat.md` | 502 | 130 | **Option A** stub. Drops the solver-specific design (axes, four-version problem, detect-then-bootstrap diagrams, per-product detection tables, JSON wire-protocol examples). Keeps the driver-discovery contract, generic `compatibility.yaml` schema, profile-env / runner-subprocess concept, and a forward link to the skills-layering doc. |
| `docs/architecture/skills-layering-plan.md` | 308 | 306 | Running examples replaced with placeholders (`<driver>`, `<sdk-slug>`, `<solver-slug>`). The design content is unchanged. |
| `docs/architecture/multi-session-and-config.md` | 203 | 204 | One named-solver pin example genericized; two JSON examples that hard-coded driver names use placeholders now. |
| `docs/DEVELOPMENT.md` | 107 | 109 | Project-layout block no longer references the now-removed solver folders; "Adding a new driver" mentions both `_BUILTIN_REGISTRY` (in-tree) and the `sim.drivers` entry-point group; `SIM_DEV_MODE` example genericized. |
| **Total** | **1364** | **941** | -423 lines |

## Verification

A grep sweep across all five edited files for any remaining product-name strings returned no matches.

## Out of scope

- **README.md / README.de.md / README.ja.md / README.zh.md** still carry product names in a worked example. Holding for a follow-up PR rather than expanding this one — the four READMEs need translation alignment too, which is a separate concern.
- **`pyproject.toml` version**: not bumped (per the "hold versions during refactor" rule).

## Test plan

- [ ] grep sweep returns zero matches across the 5 edited files.
- [ ] Manually verify: links from `README.md` to `docs/architecture/version-compat.md` still resolve.
- [ ] Skim the new version-compat.md stub to confirm it documents the contract that out-of-tree driver packages need to implement.
- [ ] Confirm CI is green (no doc-link checker should break — all relative links inside the edited docs still resolve).
