### PR TITLE
chore(readme): trim Trademarks list to products mentioned in this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,17 +246,8 @@ Users are responsible for obtaining a valid license for each underlying solver a
 
 ### Trademarks
 
-All product, solver, and company names appearing in this repository are used for identification purposes only. Ownership is retained by the respective holders:
+`sim-cli` is an independent open-source project and is **not affiliated with, endorsed by, or sponsored by** any solver vendor. Product, solver, and company names referenced anywhere in this repository remain the property of their respective owners:
 
-- **Ansys®**, **Fluent®**, **Workbench®**, **Mechanical®**, **MAPDL**, **CFX®**, **LS-DYNA®**, **ICEM CFD™**, **DPF** are trademarks or registered trademarks of **ANSYS, Inc.**
-- **Abaqus®**, **SIMULIA®** are trademarks of **Dassault Systèmes**.
-- **COMSOL Multiphysics®** is a trademark of **COMSOL AB**.
-- **MATLAB®** is a registered trademark of **The MathWorks, Inc.**
-- **Simcenter™ STAR-CCM+**, **Simcenter Flotherm™** are trademarks of **Siemens Digital Industries Software**.
-- **ANSA®** is a trademark of **BETA CAE Systems**.
-- **HyperMesh®**, **Altair®** are trademarks of **Altair Engineering, Inc.**
-- **ParaView®** is a trademark of **Kitware, Inc.**
 - **OpenFOAM®** is a registered trademark of **OpenCFD Ltd.**
+- **ParaView®** is a trademark of **Kitware, Inc.**
 - All other solver and product names are trademarks of their respective owners.
-
-`sim-cli` is an independent open-source project and is **not affiliated with, endorsed by, or sponsored by** any of the vendors listed above.


### PR DESCRIPTION
## Summary

After the recent driver removals (sim-cli #56, #58, #59), the README body no longer names any specific commercial solvers. Keeping a long roster of trademark notices for products that aren't mentioned anywhere in the repo turns the notice itself into the disclosure surface those notices are meant to cushion.

This PR reduces the Trademarks list to the two OSS products that may still surface in supporting docs / future expansion (OpenFOAM, ParaView), keeps the catch-all line, and keeps the not-affiliated disclaimer.

## Diff

\`README.md\` only — 8 commercial-vendor bullets removed, intro line tightened, structure preserved.