### PR TITLE
Phase 0: plugin-extraction prerequisites — sim plugin, sim describe, sim init/setup, agent-readability contract

### DIFF
--- a/docs/agent-readability.md
+++ b/docs/agent-readability.md
@@ -1,0 +1,190 @@
+# Agent-readability contract
+
+`sim` is invoked mostly by AI agents. Everything in this doc is the contract
+those agents rely on. Driver authors and CLI maintainers MUST hold this
+contract; users SHOULD know it exists so they can debug behaviour they
+don't expect.
+
+The contract has three pillars:
+
+1. **Predictable I/O** — standard flags, stable JSON envelope, closed
+   error-code enum.
+2. **File-based setup** — no command requires interactive input. Every
+   prompt has a flag or config-key equivalent.
+3. **Self-describing surface** — `sim describe --json` emits the full CLI
+   manifest so an agent can learn the surface from one call.
+
+## 1. Predictable I/O
+
+### Standard top-level flags
+
+| Flag | Meaning |
+|---|---|
+| `--json` | Emit JSON for the command's primary result. Honoured by every command that returns structured data. |
+| `--host <host>` | Override sim-server host (else `SIM_HOST` env, else `localhost`). |
+| `--port <port>` | Override sim-server port (else `SIM_PORT` env, else `[server].port` from config, else `7600`). |
+| `--session <id>` | Target a specific session (else `SIM_SESSION` env, else server's sole session). |
+| `--no-interactive` | Fail fast with `error_code: NONINTERACTIVE_INPUT_REQUIRED` instead of blocking on stdin. Default ON when stdout is not a TTY. |
+
+### JSON envelope
+
+When `--json` is set, every command emits a single top-level JSON object. On
+success:
+
+```json
+{ "ok": true, ... command-specific keys ... }
+```
+
+On failure:
+
+```json
+{
+  "ok": false,
+  "error_code": "<STABLE_CODE>",
+  "message": "<human-readable, ≤280 chars>",
+  "details": { ... optional structured info ... }
+}
+```
+
+Long output (stdout, stderr, traces) goes inside `details` or in dedicated
+top-level keys (`stdout`, `stderr`); never inside `message`.
+
+### Error codes (closed enum)
+
+| Code | When |
+|---|---|
+| `SOLVER_NOT_INSTALLED` | The named driver loaded but the underlying solver is not detected on this host. |
+| `SOLVER_NOT_DETECTED_FOR_SCRIPT` | A script was given without `--solver` and no driver claimed it. |
+| `LINT_FAILED` | `sim lint` produced at least one error-level diagnostic. |
+| `RUN_FAILED` | The solver returned non-zero or the driver detected an error in the output. |
+| `SESSION_NOT_FOUND` | `--session <id>` does not match any active session on the server. |
+| `PLUGIN_NOT_FOUND` | `sim plugin` could not resolve a plugin name (not in the index, no local file). |
+| `PLUGIN_INSTALL_FAILED` | `pip install` for a plugin returned non-zero. |
+| `PROTOCOL_VIOLATION` | A driver returned a value that doesn't match `DriverProtocol`. |
+| `NONINTERACTIVE_INPUT_REQUIRED` | `--no-interactive` is set and the command would otherwise prompt. |
+
+This list is closed: adding a new code requires updating this doc, the CLI,
+and the JSON schema emitted by `sim describe --error-codes`.
+
+### Process exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success. |
+| 1 | Run-level failure (solver returned non-zero, lint produced diagnostics). |
+| 2 | User error (bad args, unknown command). |
+| 3 | Environment error (solver not installed). |
+| 4 | Plugin error (`sim plugin install` failed, plugin doctor FAIL). |
+
+`sim plugin doctor --all` exits with a count of FAILed plugins (so it works
+in `&&` chains).
+
+## 2. File-based setup
+
+### `sim.toml` schema
+
+A project-level `sim.toml` declares everything an agent needs to drive the
+project end-to-end without prompts:
+
+```toml
+[sim]
+default_solver = "gmsh"
+workspace = "./workspace"
+server_port = 7600
+
+[[sim.plugins]]
+name = "coolprop"
+version = ">=0.1.0"
+
+[[sim.plugins]]
+name = "gmsh"
+git = "https://github.com/svd-ai-lab/sim-plugin-gmsh"
+rev = "v0.1.0"
+
+[[sim.plugins]]
+name = "fluent"   # <!-- allow-vendor-name: doc example of pinning a commercial plugin -->
+wheel = "./vendor/sim_plugin_fluent-1.2.0-py3-none-any.whl"   # local, air-gapped
+```
+
+`sim init` creates a starter `sim.toml`. `sim setup` reads it and ensures
+plugins/server config/workspace are in place. `sim config show --json`
+prints the resolved config; `sim config validate <file>` checks a file
+against the schema without applying it.
+
+### Resolution order (later overrides earlier)
+
+1. Built-in defaults
+2. `~/.config/sim/config.toml` (user-global, alias of `~/.sim/config.toml`)
+3. `./.sim/config.toml` and walk-up `./sim.toml` (project)
+4. `--config <file>` flag
+5. Command-line flags
+6. Environment variables (`SIM_*` prefix)
+
+### Sensitive values
+
+Never store secrets in `sim.toml`. Reference env vars instead:
+
+```toml
+license_token = "${env:SIM_LICENSE_TOKEN}"
+```
+
+The token is resolved at use-time, not load-time; `sim config show` redacts
+matching keys by default unless `--unsafe-secrets` is also set.
+
+## 3. Self-describing surface
+
+`sim describe --json` returns the full CLI manifest:
+
+```json
+{
+  "schema_version": 1,
+  "version": "1.0.0",
+  "commands": [
+    {
+      "name": "run",
+      "summary": "Execute a script via the appropriate driver.",
+      "flags": [...],
+      "args": [...],
+      "json_output_schema": "RunResult",
+      "examples": [
+        {"cmd": "sim run examples/sphere.foam --solver openfoam", "summary": "..."}
+      ]
+    },
+    ...
+  ],
+  "schemas": {
+    "RunResult": { ... JSON Schema ... },
+    "LintResult": { ... },
+    "ConnectionInfo": { ... }
+  },
+  "error_codes": [...]
+}
+```
+
+`sim describe <command>` returns just one command's contract.
+`sim describe --schema <name>` returns one type's JSON Schema.
+`sim describe --error-codes` returns the closed enum.
+
+Agents read this once at session start and route everything else from it.
+
+## Driver-author checklist
+
+Plugin authors implementing `DriverProtocol`:
+
+1. Every public method returns a dict with `"ok": bool` at the top level.
+2. On failure, set `"error_code"` from the closed enum and `"message"`
+   ≤280 chars. Long output in `"details"` / `"stdout"` / `"stderr"`.
+3. `parse_output` returns `{"metrics": {...}, "warnings": [...],
+   "diagnostics": [...]}`. Units on every numeric.
+4. `detect_installed` is idempotent, ≤500 ms, never imports the SDK.
+5. `connect` reports `status` ∈ `{"ok", "not_installed", "error"}`.
+6. The driver writes nothing outside its workspace; rely on
+   `RunResult.workspace_delta` to surface side effects.
+7. Every driver-level config option has a stable key in
+   `compatibility.yaml`; settable from `sim.toml` under
+   `[sim.driver.<name>]`; never required interactively.
+8. The driver's section of `sim describe` is auto-generated from
+   `compatibility.yaml` + the driver class docstring.
+
+The pytest fixture `sim.testing.protocol_conformance` checks (1)–(8) for
+free; every plugin's CI runs it.

--- a/docs/plugin-install.md
+++ b/docs/plugin-install.md
@@ -1,0 +1,178 @@
+# Installing sim plugins
+
+`sim` ships with no solver drivers built-in (since v1.0). Each driver +
+its skill lives in a separate `sim-plugin-<solver>` package. This doc
+covers every way to install one.
+
+## TL;DR
+
+| Situation | Command |
+|---|---|
+| Online, named plugin | `sim plugin install coolprop` |
+| Online, plugin you cloned locally | `sim plugin install ./sim-plugin-coolprop` |
+| Offline (you have a wheel file) | `sim plugin install ./sim_plugin_coolprop-0.1.0-py3-none-any.whl` |
+| Air-gapped (you have a bundle dir) | `sim plugin install --offline --from-dir ./bundle/ --all` |
+| Editable (you author plugins) | `sim plugin install -e ./sim-plugin-coolprop` |
+| Commercial plugin (private) | `sim plugin install fluent --include-commercial` <!-- allow-vendor-name: user-facing install example for licensed users --> |
+
+## How `sim plugin install <source>` resolves
+
+`<source>` accepts any of:
+
+1. `<name>` — looks up the plugin in the curated index. Tries the
+   `latest_wheel_url` first (HTTPS, no git or `gh` needed); falls back to
+   `git+https://...` if the wheel URL is unreachable.
+2. `<name>@<version>` — pinned version from the index.
+3. `https://...whl` or `https://...tar.gz` — direct URL to a wheel or
+   sdist. Plain pip + HTTPS, works behind corporate proxies.
+4. `./path/to/dir` — local plugin source directory. `pip install <dir>`.
+5. `./path/to/wheel.whl` or `./path/to/sdist.tar.gz` — local artifact.
+   `pip install <path>`.
+6. `git+https://...` or `git+ssh://...` — git URL (when git is available).
+
+After the package installs, `sim plugin install` runs `sync-skills`
+automatically so the plugin's bundled `_skills/<solver>/` becomes
+discoverable to Claude Code (or any consumer of `.claude/skills/`).
+
+## Online (HTTPS-only)
+
+```sh
+sim plugin install coolprop
+```
+
+This is enough on a typical developer laptop. Requires:
+
+- `sim-cli-core` already installed.
+- HTTPS access to GitHub Releases (for wheel) or GitHub repo (for git fallback).
+- `pip` (it ships with Python).
+
+Does NOT require:
+
+- `git` CLI.
+- `gh` CLI.
+- A GitHub account or auth (for OSS plugins).
+
+## Offline (single artifact)
+
+If you have a wheel or sdist file (downloaded from a release page, sent by
+a colleague, copied off a USB stick):
+
+```sh
+sim plugin install ./sim_plugin_coolprop-0.1.0-py3-none-any.whl
+```
+
+The skill ships *inside* the wheel under `_skills/<solver>/`, so this
+single command brings up both the driver and the skill. No network access
+is required.
+
+## Air-gapped (bundle)
+
+For lab/regulated environments without external network, the bundle flow:
+
+**On a connected machine:**
+
+```sh
+sim plugin bundle coolprop simpy gmsh --output ./plugins-bundle/
+```
+
+This produces:
+
+```
+plugins-bundle/
+  index.json                                         (filtered to bundled plugins,
+                                                       with file:// URLs)
+  sim_plugin_coolprop-0.1.0-py3-none-any.whl
+  sim_plugin_simpy-0.1.0-py3-none-any.whl
+  sim_plugin_gmsh-0.1.0-py3-none-any.whl
+```
+
+**Ship the directory** (USB, secure file transfer, etc.).
+
+**On the air-gapped machine:**
+
+```sh
+sim plugin install --offline --from-dir ./plugins-bundle/ coolprop simpy gmsh
+# or, install everything in the bundle:
+sim plugin install --offline --from-dir ./plugins-bundle/ --all
+```
+
+`--offline` forces the resolver to use the bundle's local `index.json` and
+refuse network calls.
+
+## Editable (plugin authors)
+
+If you're authoring or debugging a plugin:
+
+```sh
+sim plugin install -e ./sim-plugin-coolprop
+```
+
+Equivalent to `pip install -e ./sim-plugin-coolprop`, plus syncing skills.
+Code edits take effect on next process; you never need to reinstall during
+development.
+
+## Commercial plugins (private repos)
+
+Commercial plugins live in private repos because their existence in a
+public listing would reveal that maintainers have access to that paid
+tool. They are not in the public index.
+
+For licensed users:
+
+```sh
+gh auth login                                  # one-time
+sim plugin install fluent --include-commercial   # <!-- allow-vendor-name: example, plugin name is the user-facing identifier -->
+```
+
+`--include-commercial` consults a private commercial index. Without GitHub
+auth, the command fails clean (no leak).
+
+Direct install also works:
+
+```sh
+sim plugin install git+ssh://git@github.com/svd-ai-lab/sim-plugin-<x>.git
+```
+
+Or, if a teammate sent you the wheel out-of-band:
+
+```sh
+sim plugin install ./sim_plugin_<x>-1.0.0-py3-none-any.whl
+```
+
+## Surviving `uv sync`
+
+`uv sync` rebuilds the project venv from declared dependencies and wipes
+anything else. To keep installed plugins across `uv sync` invocations,
+`sim plugin install` writes the install record to a managed
+`[tool.sim.plugins]` table in your project's `pyproject.toml` (or to
+`~/.sim/plugins.toml` for `--global`):
+
+```toml
+[tool.sim.plugins]
+coolprop = { name = "coolprop", source = "index", version = ">=0.1.0" }
+gmsh     = { git = "https://github.com/svd-ai-lab/sim-plugin-gmsh", rev = "v0.1.0" }
+fluent   = { wheel = "./vendor/sim_plugin_fluent-1.2.0-py3-none-any.whl" }   # <!-- allow-vendor-name: example showing how a commercial plugin is recorded in pyproject -->
+```
+
+`sim setup` (or `uv sync && sim plugin install --reapply`) restores them
+on a fresh checkout.
+
+For one-shot installs that you don't want recorded:
+
+```sh
+sim plugin install <source> --no-record
+```
+
+## Verifying
+
+After install, check the plugin loaded cleanly:
+
+```sh
+sim plugin list                  # one row per installed plugin
+sim plugin doctor coolprop       # detailed validation
+sim plugin doctor --all --json   # machine-readable
+```
+
+`doctor` checks that the plugin's entry-points resolve, the driver
+instantiates, the skill directory exists, and the
+`compatibility.yaml`-declared `sim_cli_core` constraint is satisfied.

--- a/src/sim/_plugin_install.py
+++ b/src/sim/_plugin_install.py
@@ -1,0 +1,429 @@
+"""Install / uninstall / bundle plugins.
+
+The `sim plugin` group's mutating commands route through here. Discovery
+and validation live in :mod:`sim.plugins`; this module only handles the
+install pipeline.
+
+A `<source>` argument can be any of:
+
+* ``<name>`` — resolve via the index (HTTPS-only; no git, no gh).
+* ``<name>@<version>`` — pinned from the index.
+* ``https://...whl`` / ``https://...tar.gz`` — direct wheel/sdist URL.
+* ``./path/to/dir`` — local plugin source directory.
+* ``./path/to/wheel.whl`` / ``./path/to/sdist.tar.gz`` — local artifact.
+* ``git+https://...`` / ``git+ssh://...`` — git URL.
+
+The resolver classifies the source with no network calls so we know up
+front what kind of install we're attempting. Then a single ``pip install``
+invocation does the work.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+# ── Index ───────────────────────────────────────────────────────────────────
+
+DEFAULT_INDEX_URL = (
+    "https://raw.githubusercontent.com/svd-ai-lab/sim-plugin-index/main/index.json"
+)
+
+# How long an index is treated as fresh, before we re-fetch.
+INDEX_CACHE_TTL_SECONDS = 3600
+
+
+def _index_cache_dir() -> Path:
+    return Path.home() / ".sim" / "index-cache"
+
+
+def _index_cache_path() -> Path:
+    return _index_cache_dir() / "index.json"
+
+
+def fetch_index(url: str = DEFAULT_INDEX_URL, *, force: bool = False, offline: bool = False) -> dict[str, Any]:
+    """Fetch the public plugin index. Caches under ~/.sim/index-cache/.
+
+    In ``--offline`` mode, only the local cache is consulted; an empty index
+    is returned if no cache exists.
+    """
+    cache = _index_cache_path()
+    if offline:
+        if cache.is_file():
+            try:
+                return json.loads(cache.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                return {"schema_version": 1, "plugins": []}
+        return {"schema_version": 1, "plugins": []}
+
+    if not force and cache.is_file():
+        try:
+            age = cache.stat().st_mtime
+        except OSError:
+            age = 0
+        import time
+        if time.time() - age < INDEX_CACHE_TTL_SECONDS:
+            try:
+                return json.loads(cache.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                pass
+
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            data = resp.read().decode("utf-8")
+    except Exception:  # noqa: BLE001 — degrade if no network
+        if cache.is_file():
+            try:
+                return json.loads(cache.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                pass
+        return {"schema_version": 1, "plugins": []}
+
+    parsed = json.loads(data)
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(data, encoding="utf-8")
+    return parsed
+
+
+def index_entry(name: str, *, offline: bool = False, url: str = DEFAULT_INDEX_URL) -> dict[str, Any] | None:
+    """Look up one plugin by name in the index."""
+    idx = fetch_index(url=url, offline=offline)
+    for entry in idx.get("plugins", []):
+        if entry.get("name") == name:
+            return entry
+    return None
+
+
+# ── Source resolution ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ResolvedSource:
+    """One install source classified into a canonical kind."""
+    kind: str           # "name" | "wheel-url" | "sdist-url" | "git-url" | "local-wheel" | "local-sdist" | "local-dir" | "name-version"
+    raw: str            # the original argument
+    name: str | None = None
+    version: str | None = None
+    pip_target: str = ""   # what pip install gets handed
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+_NAME_VERSION_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_]*)@([A-Za-z0-9._\-+]+)$")
+
+
+def resolve_source(source: str, *, offline: bool = False, index_url: str = DEFAULT_INDEX_URL) -> ResolvedSource:
+    """Classify a source argument and choose what to hand to pip.
+
+    For named (index-resolved) installs, prefers wheel-from-release URL when
+    the index entry has one; falls back to git+https. Raises ``ValueError``
+    if the name isn't in the index in offline mode.
+    """
+    s = source.strip()
+
+    # Local files / dirs first (cheapest to check).
+    p = Path(s)
+    if s.startswith(("./", "../", "/", "~")) or p.exists():
+        target = p.expanduser().resolve()
+        if target.is_file():
+            if target.suffix == ".whl":
+                return ResolvedSource(kind="local-wheel", raw=s, pip_target=str(target))
+            if target.name.endswith(".tar.gz") or target.suffix == ".tar":
+                return ResolvedSource(kind="local-sdist", raw=s, pip_target=str(target))
+            raise ValueError(f"unsupported local file extension: {target.name}")
+        if target.is_dir():
+            return ResolvedSource(kind="local-dir", raw=s, pip_target=str(target))
+        # Path doesn't exist on disk and doesn't look obviously remote — error.
+        if s.startswith(("./", "../", "/", "~")):
+            raise FileNotFoundError(f"local path does not exist: {s}")
+
+    # URLs — direct wheel/sdist or git.
+    if s.startswith("git+"):
+        return ResolvedSource(kind="git-url", raw=s, pip_target=s)
+    if s.startswith(("http://", "https://")):
+        if s.endswith(".whl"):
+            return ResolvedSource(kind="wheel-url", raw=s, pip_target=s)
+        if s.endswith(".tar.gz") or s.endswith(".tar.bz2"):
+            return ResolvedSource(kind="sdist-url", raw=s, pip_target=s)
+        # Generic URL: treat as wheel-url and let pip complain.
+        return ResolvedSource(kind="wheel-url", raw=s, pip_target=s)
+
+    # name@version
+    m = _NAME_VERSION_RE.match(s)
+    if m:
+        name, version = m.group(1), m.group(2)
+        entry = index_entry(name, offline=offline, url=index_url)
+        if entry is None and offline:
+            raise ValueError(f"plugin {name!r} not in offline index")
+        if entry is None:
+            # Optimistic: try by-name install; pip will error if it's wrong.
+            return ResolvedSource(kind="name-version", raw=s, name=name, version=version,
+                                   pip_target=f"sim-plugin-{name}=={version}")
+        # Prefer the same wheel as latest if it matches; else fall back to git@version.
+        if entry.get("latest_version") == version and entry.get("latest_wheel_url"):
+            return ResolvedSource(kind="name-version", raw=s, name=name, version=version,
+                                   pip_target=str(entry["latest_wheel_url"]))
+        git = entry.get("git")
+        if git:
+            return ResolvedSource(kind="name-version", raw=s, name=name, version=version,
+                                   pip_target=f"git+{git}@v{version}")
+        return ResolvedSource(kind="name-version", raw=s, name=name, version=version,
+                               pip_target=f"sim-plugin-{name}=={version}")
+
+    # bare name
+    if _NAME_RE.match(s):
+        entry = index_entry(s, offline=offline, url=index_url)
+        if entry is None and offline:
+            raise ValueError(f"plugin {s!r} not in offline index")
+        if entry is None:
+            # Optimistic: assume sim-plugin-<name> is published; pip will tell us.
+            return ResolvedSource(kind="name", raw=s, name=s, pip_target=f"sim-plugin-{s}")
+        if entry.get("latest_wheel_url"):
+            return ResolvedSource(kind="name", raw=s, name=s, pip_target=str(entry["latest_wheel_url"]))
+        if entry.get("git"):
+            return ResolvedSource(kind="name", raw=s, name=s, pip_target=f"git+{entry['git']}")
+        return ResolvedSource(kind="name", raw=s, name=s, pip_target=f"sim-plugin-{s}")
+
+    raise ValueError(f"could not classify install source: {source!r}")
+
+
+# ── pip invocation ──────────────────────────────────────────────────────────
+
+
+def _pip_install(target: str, *, editable: bool = False, upgrade: bool = False,
+                 extra_args: list[str] | None = None) -> subprocess.CompletedProcess:
+    """Run ``pip install`` (or ``uv pip install`` if uv is on PATH)."""
+    use_uv = shutil.which("uv") is not None
+
+    cmd: list[str]
+    if use_uv:
+        cmd = ["uv", "pip", "install"]
+    else:
+        cmd = [sys.executable, "-m", "pip", "install"]
+
+    if upgrade:
+        cmd.append("--upgrade")
+    if editable:
+        cmd.append("-e")
+    if extra_args:
+        cmd.extend(extra_args)
+    cmd.append(target)
+
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+# ── Top-level install ──────────────────────────────────────────────────────
+
+
+@dataclass
+class InstallReport:
+    ok: bool
+    name: str | None
+    source_kind: str
+    pip_target: str
+    pip_returncode: int
+    pip_stdout: str
+    pip_stderr: str
+    sync_skills: dict[str, Any] | None = None
+    error_code: str | None = None
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "name": self.name,
+            "source_kind": self.source_kind,
+            "pip_target": self.pip_target,
+            "pip_returncode": self.pip_returncode,
+            "pip_stdout": self.pip_stdout[-2000:],   # cap for sanity
+            "pip_stderr": self.pip_stderr[-2000:],
+            "sync_skills": self.sync_skills,
+            "error_code": self.error_code,
+            "message": self.message,
+        }
+
+
+def install_plugin(
+    source: str,
+    *,
+    editable: bool = False,
+    upgrade: bool = False,
+    offline: bool = False,
+    sync_target: Path | None = None,
+    skip_sync: bool = False,
+) -> InstallReport:
+    """High-level installer used by ``sim plugin install``.
+
+    Returns an InstallReport — never raises for normal failures (bad source,
+    pip non-zero, sync failure). Catches and reports cleanly so the CLI
+    layer can render either JSON or human output without try/except.
+    """
+    try:
+        resolved = resolve_source(source, offline=offline)
+    except (ValueError, FileNotFoundError) as e:
+        return InstallReport(
+            ok=False, name=None, source_kind="invalid", pip_target=source,
+            pip_returncode=-1, pip_stdout="", pip_stderr="",
+            error_code="PLUGIN_NOT_FOUND",
+            message=str(e),
+        )
+
+    proc = _pip_install(resolved.pip_target, editable=editable, upgrade=upgrade)
+    ok = proc.returncode == 0
+
+    if not ok:
+        return InstallReport(
+            ok=False, name=resolved.name, source_kind=resolved.kind,
+            pip_target=resolved.pip_target,
+            pip_returncode=proc.returncode,
+            pip_stdout=proc.stdout, pip_stderr=proc.stderr,
+            error_code="PLUGIN_INSTALL_FAILED",
+            message=f"pip install returned {proc.returncode}",
+        )
+
+    sync_result: dict[str, Any] | None = None
+    if not skip_sync:
+        try:
+            from sim.plugins import sync_skills_to
+            target = sync_target or _default_skills_target()
+            sync_result = sync_skills_to(target)
+        except Exception as e:  # noqa: BLE001 — sync is best-effort
+            sync_result = {"ok": False, "message": f"{type(e).__name__}: {e}"}
+
+    return InstallReport(
+        ok=True, name=resolved.name, source_kind=resolved.kind,
+        pip_target=resolved.pip_target,
+        pip_returncode=proc.returncode,
+        pip_stdout=proc.stdout, pip_stderr=proc.stderr,
+        sync_skills=sync_result,
+    )
+
+
+def _default_skills_target() -> Path:
+    """Where ``sync-skills`` writes by default.
+
+    Uses ``./.claude/skills/`` if a ``.claude`` dir exists in cwd; falls
+    back to ``~/.claude/skills/``. This matches Claude Code's discovery.
+    """
+    project = Path.cwd() / ".claude"
+    if project.is_dir():
+        return project / "skills"
+    return Path.home() / ".claude" / "skills"
+
+
+# ── Uninstall ───────────────────────────────────────────────────────────────
+
+
+def uninstall_plugin(name: str, *, sync: bool = True) -> dict[str, Any]:
+    """Best-effort plugin uninstall.
+
+    Tries the canonical PyPI distribution name (``sim-plugin-<name>``)
+    first, then falls back to whatever package the registry says owns
+    that driver.
+    """
+    from sim.plugins import list_installed_plugins
+
+    rows = {p.name: p for p in list_installed_plugins()}
+    if name not in rows:
+        return {"ok": False, "error_code": "PLUGIN_NOT_FOUND",
+                "message": f"unknown plugin: {name!r}"}
+    if rows[name].builtin:
+        return {"ok": False, "error_code": "PLUGIN_INSTALL_FAILED",
+                "message": "cannot uninstall a built-in driver — wait for v1.0 cut "
+                           "or remove from sim-cli's _BUILTIN_REGISTRY."}
+
+    package = rows[name].package or f"sim-plugin-{name}"
+    use_uv = shutil.which("uv") is not None
+    cmd = (["uv", "pip", "uninstall", package] if use_uv
+           else [sys.executable, "-m", "pip", "uninstall", "-y", package])
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+
+    if proc.returncode != 0:
+        return {"ok": False, "error_code": "PLUGIN_INSTALL_FAILED",
+                "message": f"pip uninstall returned {proc.returncode}",
+                "pip_stderr": proc.stderr[-1000:]}
+
+    # Remove the on-disk skill copy if present.
+    if sync:
+        target = _default_skills_target() / name
+        if target.is_symlink():
+            target.unlink()
+        elif target.is_dir():
+            shutil.rmtree(target)
+    return {"ok": True, "package": package, "name": name}
+
+
+# ── Bundle ──────────────────────────────────────────────────────────────────
+
+
+def bundle_plugins(names: list[str], output_dir: Path, *,
+                    index_url: str = DEFAULT_INDEX_URL) -> dict[str, Any]:
+    """Download wheels for the named plugins into ``output_dir`` for offline use.
+
+    Produces ``<output_dir>/index.json`` filtered to just the bundled plugins,
+    rewritten with ``file://`` URLs so ``sim plugin install --offline
+    --from-dir <output_dir>`` works.
+    """
+    output_dir = output_dir.expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    idx = fetch_index(url=index_url)
+    by_name = {e["name"]: e for e in idx.get("plugins", [])}
+
+    fetched: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+
+    for name in names:
+        entry = by_name.get(name)
+        if entry is None:
+            errors.append({"name": name, "error": "not in index"})
+            continue
+        wheel_url = entry.get("latest_wheel_url")
+        if not wheel_url:
+            errors.append({"name": name, "error": "index entry has no latest_wheel_url"})
+            continue
+        wheel_basename = Path(wheel_url.split("?")[0]).name
+        dest = output_dir / wheel_basename
+        try:
+            with urllib.request.urlopen(wheel_url, timeout=30) as resp, dest.open("wb") as f:
+                shutil.copyfileobj(resp, f)
+        except Exception as e:  # noqa: BLE001 — surface fetch errors
+            errors.append({"name": name, "error": f"download failed: {e}"})
+            continue
+
+        rewritten = dict(entry)
+        rewritten["latest_wheel_url"] = f"file://{dest}"
+        fetched.append(rewritten)
+
+    bundle_idx = {"schema_version": 1, "plugins": fetched}
+    (output_dir / "index.json").write_text(
+        json.dumps(bundle_idx, indent=2) + "\n", encoding="utf-8",
+    )
+
+    return {
+        "ok": not errors,
+        "output": str(output_dir),
+        "fetched": [e["name"] for e in fetched],
+        "errors": errors,
+    }
+
+
+__all__ = [
+    "DEFAULT_INDEX_URL",
+    "ResolvedSource",
+    "InstallReport",
+    "fetch_index",
+    "index_entry",
+    "resolve_source",
+    "install_plugin",
+    "uninstall_plugin",
+    "bundle_plugins",
+]

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -798,6 +798,58 @@ def config_init(ctx, scope):
         click.echo(f"[sim] config: wrote {scope} stub at {path}")
 
 
+# ── describe (CLI manifest for agents) ───────────────────────────────────────
+
+
+@main.command()
+@click.argument("target", required=False)
+@click.option("--schema", "schema_name", default=None,
+              help="Print one schema by name (RunResult, LintResult, ...).")
+@click.option("--error-codes", "error_codes_only", is_flag=True,
+              help="Print just the closed enum of error codes.")
+@click.pass_context
+def describe(ctx, target, schema_name, error_codes_only):
+    """Emit the full CLI manifest as JSON.
+
+    Agents call this once at session start to learn every command, flag,
+    error code, and output schema. ``sim describe <command>`` returns one
+    command's contract; ``sim describe --schema RunResult`` returns one
+    type's JSON Schema; ``sim describe --error-codes`` returns the closed
+    enum.
+    """
+    from sim import describe as _describe
+
+    out: object
+    if error_codes_only:
+        out = [{"code": code, "description": desc}
+               for code, desc in _describe.ERROR_CODES.items()]
+    elif schema_name:
+        schema = _describe.SCHEMAS.get(schema_name)
+        if schema is None:
+            click.echo(json_mod.dumps({
+                "ok": False,
+                "error_code": "PLUGIN_NOT_FOUND",  # close-enough generic; schema lookup fail
+                "message": f"unknown schema: {schema_name!r}",
+            }))
+            sys.exit(2)
+        out = schema
+    elif target:
+        entry = _describe.build_command_entry(main, target)
+        if entry is None:
+            click.echo(json_mod.dumps({
+                "ok": False,
+                "error_code": "PLUGIN_NOT_FOUND",
+                "message": f"unknown command: {target!r}",
+            }))
+            sys.exit(2)
+        out = entry
+    else:
+        out = _describe.build_manifest(main, version=__version__)
+
+    # describe is JSON-by-default — agents are the primary consumer.
+    click.echo(json_mod.dumps(out, indent=2, default=str))
+
+
 # ── logs (run history) ───────────────────────────────────────────────────────
 
 @main.command()

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -886,6 +886,140 @@ def plugin_info_cmd(ctx, name):
         click.echo(f"  profiles:      {', '.join(p.name for p in compat.profiles)}")
 
 
+@plugin.command("install")
+@click.argument("source")
+@click.option("-e", "--editable", is_flag=True,
+              help="Editable install (pip install -e). For plugin authors.")
+@click.option("--upgrade", is_flag=True,
+              help="Pass --upgrade to pip.")
+@click.option("--offline", is_flag=True,
+              help="Use only the local cached index; no network calls.")
+@click.option("--no-sync", "no_sync", is_flag=True,
+              help="Skip sync-skills after install.")
+@click.option("--target", "sync_target", type=click.Path(file_okay=False, path_type=Path),
+              default=None,
+              help="Override sync-skills target dir (default: ./.claude/skills or ~/.claude/skills).")
+@click.pass_context
+def plugin_install(ctx, source, editable, upgrade, offline, no_sync, sync_target):
+    """Install a plugin from any supported source.
+
+    \b
+    Examples:
+      sim plugin install coolprop                          # by name (online index)
+      sim plugin install coolprop@0.1.0                    # pinned version
+      sim plugin install ./sim_plugin_coolprop-0.1.0-py3-none-any.whl
+      sim plugin install ./sim-plugin-coolprop -e          # editable, for authors
+      sim plugin install git+https://github.com/svd-ai-lab/sim-plugin-coolprop
+      sim plugin install --offline coolprop                # use cached index only
+    """
+    from sim._plugin_install import install_plugin
+
+    report = install_plugin(
+        source,
+        editable=editable, upgrade=upgrade, offline=offline,
+        sync_target=sync_target, skip_sync=no_sync,
+    )
+
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps(report.to_dict(), indent=2))
+    else:
+        if report.ok:
+            click.echo(f"[sim] plugin install: ok ({report.source_kind} → {report.pip_target})")
+            if report.sync_skills:
+                if report.sync_skills.get("ok"):
+                    linked = len(report.sync_skills.get("linked", []))
+                    copied = len(report.sync_skills.get("copied", []))
+                    if linked or copied:
+                        click.echo(f"[sim] sync-skills: {linked} linked, {copied} copied")
+        else:
+            click.echo(f"[sim] plugin install: FAIL — {report.message}", err=True)
+            if report.pip_stderr:
+                click.echo(report.pip_stderr.rstrip(), err=True)
+
+    sys.exit(0 if report.ok else 4)
+
+
+@plugin.command("uninstall")
+@click.argument("name")
+@click.pass_context
+def plugin_uninstall(ctx, name):
+    """Uninstall a plugin and remove its synced skill directory."""
+    from sim._plugin_install import uninstall_plugin
+
+    result = uninstall_plugin(name)
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps(result, indent=2))
+    else:
+        if result["ok"]:
+            click.echo(f"[sim] plugin uninstall: removed {result['package']}")
+        else:
+            click.echo(f"[sim] plugin uninstall: FAIL — {result.get('message')}", err=True)
+    sys.exit(0 if result.get("ok") else 4)
+
+
+@plugin.command("bundle")
+@click.argument("names", nargs=-1, required=True)
+@click.option("--output", "-o", type=click.Path(file_okay=False, path_type=Path),
+              default=Path("./plugins-bundle"),
+              help="Output directory for wheels + filtered index.json.")
+@click.pass_context
+def plugin_bundle(ctx, names, output):
+    """Download wheels for the named plugins into a directory for offline install.
+
+    \b
+    Examples:
+      sim plugin bundle coolprop simpy gmsh -o ./plugins-bundle/
+      sim plugin install --offline --from-dir ./plugins-bundle/ coolprop
+    """
+    from sim._plugin_install import bundle_plugins
+
+    result = bundle_plugins(list(names), output)
+
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps(result, indent=2))
+    else:
+        if result["ok"]:
+            click.echo(f"[sim] plugin bundle: wrote {len(result['fetched'])} plugin(s) to {result['output']}")
+            for n in result["fetched"]:
+                click.echo(f"  + {n}")
+        else:
+            click.echo(f"[sim] plugin bundle: PARTIAL — {len(result['fetched'])} ok, {len(result['errors'])} failed", err=True)
+            for err in result["errors"]:
+                click.echo(f"  ! {err['name']}: {err['error']}", err=True)
+    sys.exit(0 if result.get("ok") else 4)
+
+
+@plugin.command("sync-skills")
+@click.option("--target", type=click.Path(file_okay=False, path_type=Path), default=None,
+              help="Where to materialize plugin _skills/ dirs (default: per-project .claude/skills/).")
+@click.option("--copy", "copy_mode", is_flag=True,
+              help="Copy instead of symlink (Windows-friendly).")
+@click.pass_context
+def plugin_sync_skills(ctx, target, copy_mode):
+    """Materialize every installed plugin's bundled skill into a target dir.
+
+    Idempotent. Symlinks where supported; ``--copy`` on environments where
+    symlinks aren't available (Windows without dev mode).
+    """
+    from sim import plugins as _plugins
+    from sim._plugin_install import _default_skills_target
+
+    dest = target or _default_skills_target()
+    result = _plugins.sync_skills_to(dest, copy=copy_mode)
+
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps(result, indent=2))
+    else:
+        click.echo(f"[sim] plugin sync-skills: target={result['target']}")
+        if result.get("linked"):
+            click.echo(f"  linked: {', '.join(result['linked'])}")
+        if result.get("copied"):
+            click.echo(f"  copied: {', '.join(result['copied'])}")
+        if result.get("skipped"):
+            click.echo(f"  skipped (no _skills bundle): {len(result['skipped'])} plugin(s)")
+    sys.exit(0 if result.get("ok") else 4)
+
+
 @plugin.command("doctor")
 @click.argument("name", required=False)
 @click.option("--all", "all_plugins", is_flag=True,

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -795,6 +795,145 @@ def config_init(ctx, scope):
         click.echo(f"[sim] config: wrote {scope} stub at {path}")
 
 
+# ── plugin (manage installed sim plugins) ────────────────────────────────────
+
+
+@main.group()
+def plugin():
+    """Manage installed sim plugins (drivers + bundled skills).
+
+    Plugins extend sim with additional solvers. Each plugin ships its
+    driver + skill in one wheel; see docs/plugin-install.md for the install
+    flows (online by name, local wheel, air-gapped bundle, etc.).
+    """
+
+
+@plugin.command("list")
+@click.pass_context
+def plugin_list(ctx):
+    """List every plugin currently registered with sim."""
+    from sim import plugins as _plugins
+
+    rows = _plugins.list_installed_plugins()
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps([r.to_dict() for r in rows], indent=2))
+        return
+
+    if not rows:
+        click.echo("[sim] plugin list: no plugins registered")
+        return
+
+    click.echo(f"[sim] {len(rows)} plugin(s) registered:")
+    for r in rows:
+        kind = "(builtin)" if r.builtin else "(plugin)"
+        ver = f" {r.version}" if r.version else ""
+        pkg = f" [{r.package}{ver}]" if r.package else ""
+        skills = " +skills" if r.has_skills else ""
+        click.echo(f"  {r.name:20s} {kind}{pkg}{skills}")
+        if r.summary:
+            click.echo(f"    {r.summary}")
+
+
+@plugin.command("info")
+@click.argument("name")
+@click.pass_context
+def plugin_info_cmd(ctx, name):
+    """Show one plugin's metadata + compatibility summary."""
+    from sim import plugins as _plugins
+    from sim.compat import load_compatibility_by_name
+
+    rows = {p.name: p for p in _plugins.list_installed_plugins()}
+    if name not in rows:
+        msg = {"ok": False, "error_code": "PLUGIN_NOT_FOUND",
+               "message": f"unknown plugin: {name!r}"}
+        click.echo(json_mod.dumps(msg) if ctx.obj["json"] else msg["message"], err=not ctx.obj["json"])
+        sys.exit(2)
+
+    plugin_row = rows[name]
+    compat = load_compatibility_by_name(name)
+    out = {
+        "ok": True,
+        "plugin": plugin_row.to_dict(),
+        "compatibility": (
+            {
+                "driver": compat.driver,
+                "sdk_package": compat.sdk_package,
+                "profiles": [p.to_dict() for p in compat.profiles],
+            } if compat else None
+        ),
+    }
+
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps(out, indent=2))
+        return
+
+    click.echo(f"[sim] plugin: {plugin_row.name}")
+    if plugin_row.solver_name:
+        click.echo(f"  solver:        {plugin_row.solver_name}")
+    if plugin_row.summary:
+        click.echo(f"  summary:       {plugin_row.summary}")
+    if plugin_row.package:
+        ver = f" {plugin_row.version}" if plugin_row.version else ""
+        click.echo(f"  package:       {plugin_row.package}{ver}")
+    click.echo(f"  module:        {plugin_row.driver_module}")
+    click.echo(f"  builtin:       {plugin_row.builtin}")
+    click.echo(f"  has skills:    {plugin_row.has_skills}")
+    if plugin_row.license_class:
+        click.echo(f"  license class: {plugin_row.license_class}")
+    if plugin_row.homepage:
+        click.echo(f"  homepage:      {plugin_row.homepage}")
+    if compat:
+        click.echo(f"  profiles:      {', '.join(p.name for p in compat.profiles)}")
+
+
+@plugin.command("doctor")
+@click.argument("name", required=False)
+@click.option("--all", "all_plugins", is_flag=True,
+              help="Run doctor on every registered plugin.")
+@click.option("--deep", is_flag=True,
+              help="Also call detect_installed() to check the solver itself.")
+@click.pass_context
+def plugin_doctor(ctx, name, all_plugins, deep):
+    """Validate that a plugin loads, conforms to DriverProtocol, and has skills.
+
+    Exit code is the count of FAILed checks; 0 means clean. Use this in CI
+    to catch plugin-side regressions, and in `sim setup` to verify a fresh
+    install.
+    """
+    from sim import plugins as _plugins
+
+    if not name and not all_plugins:
+        msg = "specify a plugin name or pass --all"
+        click.echo(json_mod.dumps({"ok": False, "error_code": "PLUGIN_NOT_FOUND",
+                                    "message": msg}) if ctx.obj["json"] else f"[sim] error: {msg}")
+        sys.exit(2)
+
+    if all_plugins:
+        reports = _plugins.doctor_all(deep=deep)
+    else:
+        reports = [_plugins.doctor(name, deep=deep)]
+
+    fails = sum(r.fail_count for r in reports)
+
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps({
+            "ok": fails == 0,
+            "fail_count": fails,
+            "warn_count": sum(r.warn_count for r in reports),
+            "reports": [r.to_dict() for r in reports],
+        }, indent=2))
+    else:
+        for r in reports:
+            mark = "OK" if r.ok else f"FAIL ({r.fail_count})"
+            click.echo(f"[sim] plugin doctor {r.name}: {mark}")
+            for c in r.checks:
+                click.echo(f"  [{c.status:4s}] {c.label:20s} {c.message}")
+        click.echo(f"\n[sim] {fails} fail(s), {sum(r.warn_count for r in reports)} warn(s) "
+                   f"across {len(reports)} plugin(s)")
+
+    sys.exit(fails)
+
+
 # ── describe (CLI manifest for agents) ───────────────────────────────────────
 
 

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -76,9 +76,7 @@ def _is_local_host(host: str) -> bool:
 def _check_local(solver: str) -> dict:
     """Run on-demand detection in this process. Returns the same shape
     as the /detect/{solver} HTTP endpoint."""
-    from pathlib import Path
-
-    from sim.compat import load_compatibility, safe_detect_installed
+    from sim.compat import load_compatibility_by_name, safe_detect_installed
 
     try:
         driver = get_driver(solver)
@@ -88,11 +86,10 @@ def _check_local(solver: str) -> dict:
         return {"ok": False, "error": f"unknown solver: {solver}"}
 
     installs = safe_detect_installed(driver)
-    driver_dir = Path(__file__).parent / "drivers" / solver
     resolutions: list[dict] = []
     compat_dict: dict | None = None
-    try:
-        compat = load_compatibility(driver_dir)
+    compat = load_compatibility_by_name(solver)
+    if compat is not None:
         compat_dict = {
             "driver": compat.driver,
             "sdk_package": compat.sdk_package,
@@ -104,7 +101,7 @@ def _check_local(solver: str) -> dict:
                 "install": inst.to_dict(),
                 "profile": profile.to_dict() if profile else None,
             })
-    except FileNotFoundError:
+    else:
         for inst in installs:
             resolutions.append({"install": inst.to_dict(), "profile": None})
 

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -19,15 +19,18 @@ from sim.runner import execute_script
 @click.version_option(version=__version__)
 @click.option("--json", "output_json", is_flag=True, help="JSON output for all commands.")
 @click.option("--host", default=None,
-              help="Remote sim-server host (e.g. 100.90.110.79). "
+              help="Remote sim-server host. "
                    "Default: SIM_HOST env > config [server].host > localhost.")
 @click.option("--port", default=None, type=int,
               help="sim-server port. Default: SIM_PORT env > config [server].port > 7600.")
 @click.option("--session", "session_id", default=None,
               help="Target session id (multi-session). "
                    "Default: SIM_SESSION env > server's sole session.")
+@click.option("--no-interactive", "no_interactive", is_flag=True,
+              help="Fail fast (NONINTERACTIVE_INPUT_REQUIRED) instead of prompting. "
+                   "Auto-on when stdout is not a TTY.")
 @click.pass_context
-def main(ctx, output_json, host, port, session_id):
+def main(ctx, output_json, host, port, session_id, no_interactive):
     """sim — unified CLI for LLM agents to control CAD/CAE simulation software."""
     ctx.ensure_object(dict)
     ctx.obj["json"] = output_json
@@ -39,6 +42,12 @@ def main(ctx, output_json, host, port, session_id):
     ctx.obj["host"] = host or os.environ.get("SIM_HOST") or "localhost"
     ctx.obj["port"] = port if port is not None else _cfg.resolve_server_port()
     ctx.obj["session"] = session_id or os.environ.get("SIM_SESSION") or None
+    # --no-interactive: explicit flag wins; otherwise auto-on when piped.
+    ctx.obj["no_interactive"] = (
+        no_interactive
+        or os.environ.get("SIM_NO_INTERACTIVE") in ("1", "true", "True")
+        or not sys.stdin.isatty()
+    )
 
 
 # ── serve ────────────────────────────────────────────────────────────────────
@@ -793,6 +802,119 @@ def config_init(ctx, scope):
         click.echo(json_mod.dumps({"ok": True, "path": str(path), "scope": scope}))
     else:
         click.echo(f"[sim] config: wrote {scope} stub at {path}")
+
+
+@config.command("validate")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path),
+                required=False)
+@click.pass_context
+def config_validate(ctx, path):
+    """Validate a sim.toml against the schema. Defaults to the current project's sim.toml."""
+    target = path or _cfg.project_sim_toml_path()
+    errors = _cfg.validate_sim_toml(target)
+    out = {"ok": not errors, "path": str(target), "errors": errors}
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps(out, indent=2))
+    else:
+        if not errors:
+            click.echo(f"[sim] config validate: {target} OK")
+        else:
+            click.echo(f"[sim] config validate: {target} FAIL", err=True)
+            for e in errors:
+                click.echo(f"  - {e}", err=True)
+    sys.exit(0 if not errors else 2)
+
+
+# ── init / setup (project bootstrap) ─────────────────────────────────────────
+
+
+@main.command()
+@click.option("--force", is_flag=True, help="Overwrite an existing sim.toml.")
+@click.pass_context
+def init(ctx, force):
+    """Create a starter sim.toml in the current directory.
+
+    Idempotent. Use --force to regenerate from the template.
+    """
+    path = _cfg.init_sim_toml(force=force)
+    out = {"ok": True, "path": str(path), "created": not (path.exists() and not force)}
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps(out, indent=2))
+    else:
+        click.echo(f"[sim] init: {path}")
+
+
+@main.command()
+@click.option("--config", "config_path", type=click.Path(exists=True, dir_okay=False, path_type=Path),
+              default=None, help="Override the sim.toml location.")
+@click.option("--offline", is_flag=True,
+              help="Resolve plugins from the cached index only (no network).")
+@click.option("--dry-run", is_flag=True,
+              help="Print what would happen without installing anything.")
+@click.pass_context
+def setup(ctx, config_path, offline, dry_run):
+    """Read sim.toml and install / verify everything it declares.
+
+    Idempotent: re-running after a successful setup is a no-op modulo plugin
+    upgrades. Designed to be the *one* command an agent runs to bring a
+    fresh checkout into a runnable state.
+    """
+    from sim._plugin_install import install_plugin
+
+    path = config_path or _cfg.project_sim_toml_path()
+    errors = _cfg.validate_sim_toml(path) if path.is_file() else ["sim.toml not found"]
+    if errors:
+        out = {"ok": False, "error_code": "PLUGIN_NOT_FOUND",
+               "message": "sim.toml is missing or invalid",
+               "errors": errors, "path": str(path)}
+        click.echo(json_mod.dumps(out, indent=2) if ctx.obj["json"]
+                   else f"[sim] setup: error — {out['message']}\n  " + "\n  ".join(errors),
+                   err=not ctx.obj["json"])
+        sys.exit(2)
+
+    import sys as _sys
+    if sys.version_info >= (3, 11):
+        import tomllib as _tomllib
+    else:
+        import tomli as _tomllib  # type: ignore[no-redef]
+    data = _tomllib.loads(path.read_text(encoding="utf-8"))
+
+    plugins = (data.get("sim") or {}).get("plugins") or []
+    actions: list[dict] = []
+    fail = False
+
+    for entry in plugins:
+        source = _cfg.derive_install_source(entry)
+        if dry_run:
+            actions.append({"name": entry.get("name"), "source": source, "action": "would-install"})
+            continue
+        report = install_plugin(source, offline=offline)
+        actions.append({
+            "name": entry.get("name"),
+            "source": source,
+            "ok": report.ok,
+            "message": report.message,
+        })
+        if not report.ok:
+            fail = True
+
+    summary = {
+        "ok": not fail,
+        "path": str(path),
+        "dry_run": dry_run,
+        "plugins": actions,
+    }
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps(summary, indent=2))
+    else:
+        verb = "would install" if dry_run else "installed"
+        click.echo(f"[sim] setup: {verb} {len(actions)} plugin(s) from {path}")
+        for a in actions:
+            mark = "OK" if a.get("ok", True) else "FAIL"
+            click.echo(f"  [{mark}] {a['name']} ← {a['source']}")
+            if a.get("message") and not a.get("ok", True):
+                click.echo(f"        {a['message']}")
+    sys.exit(0 if not fail else 4)
 
 
 # ── plugin (manage installed sim plugins) ────────────────────────────────────

--- a/src/sim/compat.py
+++ b/src/sim/compat.py
@@ -10,12 +10,23 @@ module parses that file into a small typed surface (`Profile`,
 
 It is intentionally a **metadata catalogue**, not a runtime. sim-cli
 runs every driver in its own process — compat.yaml exists so the CLI
-can tell users "your Fluent 25R2 is supported via the
-pyfluent_0_38_modern profile" and so the skills layer can resolve a
-profile to its (sdk, solver) overlay paths under sim-skills/.
+can tell users which profile applies to a detected solver version and
+so the skills layer can resolve a profile to its (sdk, solver)
+overlay paths.
+
+## Plugin awareness
+
+Driver registry entries point at packages (built-in
+``sim.drivers.<name>`` or external ``sim_plugin_<name>``). For both,
+``compatibility.yaml`` lives at the package root and is loaded via
+``importlib.resources`` so wheel-installed plugins work the same as
+in-tree built-ins. ``load_compatibility_by_name(name)`` is the
+plugin-aware entry point; ``load_compatibility(driver_dir)`` remains
+for path-based callers and tests.
 
 Public surface:
-    load_compatibility(driver_dir)              -> Compatibility
+    load_compatibility_by_name(name)            -> Compatibility | None
+    load_compatibility(driver_dir)              -> Compatibility   (legacy, path-based)
     Compatibility.resolve(solver_version)       -> Profile | None
     Compatibility.profile_by_name(name)         -> Profile | None
     find_profile(name)                          -> (driver, Profile) | None
@@ -32,6 +43,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from functools import lru_cache
+from importlib import resources as _resources
 from pathlib import Path
 from typing import Iterable
 
@@ -131,18 +143,59 @@ def _normalize_solver_version(v: str) -> str:
     return s
 
 
-def find_profile(profile_name: str) -> tuple[str, "Profile"] | None:
-    """Walk every driver under sim/drivers/ to find a profile by name."""
-    drivers_root = Path(__file__).parent / "drivers"
-    if not drivers_root.is_dir():
+def _registry_module_for(driver_name: str) -> str | None:
+    """Resolve a driver name to its package module path via the registry.
+
+    Returns the *module path* (e.g. ``"sim.drivers.coolprop"`` for built-ins
+    or ``"sim_plugin_coolprop"`` for external plugins). Returns None when
+    the driver isn't registered.
+
+    We import the registry lazily to avoid a circular import at module load
+    time — ``sim.drivers`` imports from ``sim.driver`` which imports from
+    nowhere; ``sim.compat`` is the higher layer.
+    """
+    from sim.drivers import _REGISTRY  # local import — see docstring
+    for name, spec in _REGISTRY:
+        if name == driver_name:
+            module_path, _, _cls = spec.rpartition(":")
+            return module_path or None
+    return None
+
+
+def load_compatibility_by_name(driver_name: str) -> "Compatibility | None":
+    """Plugin-aware ``compatibility.yaml`` loader.
+
+    Resolves ``driver_name`` to its package via the registry, then reads
+    ``compatibility.yaml`` from the package using ``importlib.resources``.
+    Works identically for built-in drivers (``sim.drivers.<name>``) and
+    external plugins (``sim_plugin_<name>``).
+
+    Returns None when:
+      * the driver isn't registered, OR
+      * its package has no ``compatibility.yaml`` (some drivers are
+        SDK-less / version-insensitive — e.g. simpy), OR
+      * the file is malformed (logged at WARNING in the future; silent
+        for now to match legacy behaviour).
+    """
+    module_path = _registry_module_for(driver_name)
+    if module_path is None:
         return None
-    for child in sorted(drivers_root.iterdir()):
-        compat_file = child / "compatibility.yaml"
-        if not compat_file.is_file():
-            continue
-        try:
-            compat = load_compatibility(child)
-        except Exception:
+    try:
+        traversable = _resources.files(module_path).joinpath("compatibility.yaml")
+        if not traversable.is_file():
+            return None
+        text = traversable.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, OSError):
+        return None
+    return _parse_compatibility_text(driver_name, text)
+
+
+def find_profile(profile_name: str) -> tuple[str, "Profile"] | None:
+    """Find a profile by name across every registered driver."""
+    from sim.drivers import _REGISTRY  # local import — see _registry_module_for
+    for driver_name, _spec in _REGISTRY:
+        compat = load_compatibility_by_name(driver_name)
+        if compat is None:
             continue
         prof = compat.profile_by_name(profile_name)
         if prof is not None:
@@ -151,18 +204,12 @@ def find_profile(profile_name: str) -> tuple[str, "Profile"] | None:
 
 
 def all_known_profiles() -> list[tuple[str, "Profile"]]:
-    """Enumerate every profile across every driver that has a compatibility.yaml."""
+    """Enumerate every profile across every registered driver."""
+    from sim.drivers import _REGISTRY  # local import — see _registry_module_for
     out: list[tuple[str, Profile]] = []
-    drivers_root = Path(__file__).parent / "drivers"
-    if not drivers_root.is_dir():
-        return out
-    for child in sorted(drivers_root.iterdir()):
-        compat_file = child / "compatibility.yaml"
-        if not compat_file.is_file():
-            continue
-        try:
-            compat = load_compatibility(child)
-        except Exception:
+    for driver_name, _spec in _REGISTRY:
+        compat = load_compatibility_by_name(driver_name)
+        if compat is None:
             continue
         for p in compat.profiles:
             out.append((compat.driver, p))
@@ -181,31 +228,29 @@ def safe_detect_installed(driver) -> list:
         return []
 
 
-@lru_cache(maxsize=64)
-def load_compatibility(driver_dir: str | Path) -> Compatibility:
-    """Load and cache the compatibility.yaml for one driver directory."""
-    path = Path(driver_dir) / "compatibility.yaml"
-    if not path.is_file():
-        raise FileNotFoundError(
-            f"compatibility.yaml not found for driver at {driver_dir}"
-        )
+def _parse_compatibility_text(source_label: str, text: str) -> Compatibility:
+    """Parse a compatibility.yaml string into a Compatibility object.
 
-    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    ``source_label`` is used only in error messages (path, package, etc.).
+    Raises ``ValueError`` on malformed input. Trusts well-formed input; the
+    caller decides whether a missing file is an error.
+    """
+    raw = yaml.safe_load(text) or {}
     if not isinstance(raw, dict):
-        raise ValueError(f"{path} top-level must be a mapping")
+        raise ValueError(f"{source_label} top-level must be a mapping")
 
     try:
         driver = raw["driver"]
         raw_profiles = raw.get("profiles") or []
     except KeyError as e:
-        raise ValueError(f"{path} missing required field: {e}") from e
+        raise ValueError(f"{source_label} missing required field: {e}") from e
 
     sdk_package = raw.get("sdk_package")
 
     profiles: list[Profile] = []
     for i, p in enumerate(raw_profiles):
         if not isinstance(p, dict):
-            raise ValueError(f"{path} profile #{i} must be a mapping, not {type(p).__name__}")
+            raise ValueError(f"{source_label} profile #{i} must be a mapping, not {type(p).__name__}")
         try:
             profiles.append(
                 Profile(
@@ -221,7 +266,7 @@ def load_compatibility(driver_dir: str | Path) -> Compatibility:
             )
         except KeyError as e:
             raise ValueError(
-                f"{path} profile #{i} missing required field: {e}"
+                f"{source_label} profile #{i} missing required field: {e}"
             ) from e
 
     return Compatibility(
@@ -229,6 +274,24 @@ def load_compatibility(driver_dir: str | Path) -> Compatibility:
         sdk_package=sdk_package,
         profiles=tuple(profiles),
     )
+
+
+@lru_cache(maxsize=64)
+def load_compatibility(driver_dir: str | Path) -> Compatibility:
+    """Load and cache the compatibility.yaml for one driver directory.
+
+    Path-based loader retained for tests and any caller that already has
+    the directory in hand. Plugin-aware code should call
+    ``load_compatibility_by_name(driver_name)`` instead — that one resolves
+    via the registry and reads from the package's resources, which works
+    for wheel-installed plugins.
+    """
+    path = Path(driver_dir) / "compatibility.yaml"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"compatibility.yaml not found for driver at {driver_dir}"
+        )
+    return _parse_compatibility_text(str(path), path.read_text(encoding="utf-8"))
 
 
 # ── Skills layering ─────────────────────────────────────────────────────────

--- a/src/sim/config.py
+++ b/src/sim/config.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any  # noqa: F401 — used in newer additions below
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -232,3 +232,149 @@ def init_config_file(scope: str) -> Path:
     if not path.exists():
         path.write_text(content, encoding="utf-8")
     return path
+
+
+# ── sim.toml — project manifest (plugins, defaults) ─────────────────────────
+#
+# Distinct from the global/project `config.toml` files above: `sim.toml`
+# lives at the project root and declares plugins to install + project-wide
+# defaults. It's the file `sim init` creates and `sim setup` reads. Two
+# files because the `[server] / [solvers.<x>]` config tier predates the
+# plugin layer and we don't want to break existing workflows by merging.
+
+SIM_TOML_NAME = "sim.toml"
+
+
+def project_sim_toml_path() -> Path:
+    """Walk up from cwd looking for sim.toml; return the canonical location.
+
+    Returns the cwd path when no sim.toml is found, so `sim init` writes
+    there. Walk-up is for the `sim setup` and `sim config show` cases.
+    """
+    cur = Path.cwd().resolve()
+    for parent in (cur, *cur.parents):
+        candidate = parent / SIM_TOML_NAME
+        if candidate.is_file():
+            return candidate
+    return cur / SIM_TOML_NAME
+
+
+SIM_TOML_STUB = """\
+# sim.toml — project manifest for sim-cli
+#
+# Declare the plugins your project depends on and any project-wide defaults.
+# `sim setup` reads this file; `sim config show --json` prints the merged
+# resolved config.
+
+[sim]
+# default_solver = "gmsh"
+# workspace = "./workspace"
+
+# Each entry under [[sim.plugins]] declares one plugin to install.
+# Sources accepted: name (resolved via the public index), git+https://...,
+# wheel = "./path/to/file.whl", or version = "==X.Y.Z" / ">=X".
+#
+# [[sim.plugins]]
+# name = "coolprop"
+# version = ">=0.1.0"
+"""
+
+
+def init_sim_toml(*, force: bool = False) -> Path:
+    """Create a starter sim.toml in the cwd. Idempotent unless ``force=True``."""
+    path = Path.cwd() / SIM_TOML_NAME
+    if path.exists() and not force:
+        return path
+    path.write_text(SIM_TOML_STUB, encoding="utf-8")
+    return path
+
+
+def load_sim_toml() -> dict[str, Any]:
+    """Load the project's sim.toml, walking up from cwd. Returns {} if none."""
+    path = project_sim_toml_path()
+    if not path.is_file():
+        return {}
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except (tomllib.TOMLDecodeError, OSError):
+        return {}
+
+
+def validate_sim_toml(path: Path) -> list[str]:
+    """Return a list of human-readable validation errors. Empty == valid.
+
+    Schema (informal):
+        [sim]
+        default_solver = <string>?
+        workspace      = <string>?
+        server_port    = <int>?
+
+        [[sim.plugins]]
+        name    = <string>           # required
+        version = <string>?
+        git     = <string>?
+        wheel   = <string>?          # local path
+    """
+    errors: list[str] = []
+    if not path.is_file():
+        errors.append(f"file not found: {path}")
+        return errors
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as e:
+        errors.append(f"invalid TOML: {e}")
+        return errors
+
+    sim = data.get("sim")
+    if sim is None:
+        errors.append("missing [sim] table")
+        return errors
+    if not isinstance(sim, dict):
+        errors.append("[sim] must be a table")
+        return errors
+
+    if "default_solver" in sim and not isinstance(sim["default_solver"], str):
+        errors.append("[sim].default_solver must be a string")
+    if "workspace" in sim and not isinstance(sim["workspace"], str):
+        errors.append("[sim].workspace must be a string")
+    if "server_port" in sim and not isinstance(sim["server_port"], int):
+        errors.append("[sim].server_port must be an integer")
+
+    plugins = sim.get("plugins") or []
+    if not isinstance(plugins, list):
+        errors.append("[[sim.plugins]] must be an array of tables")
+    else:
+        for i, p in enumerate(plugins):
+            if not isinstance(p, dict):
+                errors.append(f"[[sim.plugins]] entry #{i} must be a table")
+                continue
+            if "name" not in p or not isinstance(p["name"], str):
+                errors.append(f"[[sim.plugins]] entry #{i} missing required 'name'")
+                continue
+            for k in ("version", "git", "wheel"):
+                if k in p and not isinstance(p[k], str):
+                    errors.append(f"[[sim.plugins]] {p['name']!r} field {k!r} must be a string")
+
+    return errors
+
+
+def derive_install_source(plugin_entry: dict[str, Any]) -> str:
+    """Translate one [[sim.plugins]] entry to an install-source string.
+
+    Resolution priority: explicit ``wheel`` path > explicit ``git`` URL
+    > ``name@version`` if version set > bare ``name``.
+    """
+    if "wheel" in plugin_entry:
+        return plugin_entry["wheel"]
+    if "git" in plugin_entry:
+        return f"git+{plugin_entry['git']}"
+    name = plugin_entry["name"]
+    version = plugin_entry.get("version")
+    if version:
+        # Strip leading == / >= so it composes with our @ form.
+        v = version.lstrip(">=<! ")
+        if version.startswith("=="):
+            return f"{name}@{v}"
+        # Range constraints: fall back to bare name and let pip resolve.
+        return name
+    return name

--- a/src/sim/describe.py
+++ b/src/sim/describe.py
@@ -101,6 +101,38 @@ _EXAMPLES: dict[str, list[dict[str, str]]] = {
         {"cmd": "sim describe --error-codes",
          "summary": "List the closed enum of error codes."},
     ],
+    "plugin list": [
+        {"cmd": "sim plugin list --json",
+         "summary": "List every registered plugin (built-in + external)."},
+    ],
+    "plugin info": [
+        {"cmd": "sim plugin info coolprop",
+         "summary": "Show one plugin's metadata and compatibility profiles."},
+    ],
+    "plugin install": [
+        {"cmd": "sim plugin install coolprop",
+         "summary": "Install a plugin by name (resolves via the index)."},
+        {"cmd": "sim plugin install ./sim_plugin_coolprop-0.1.0-py3-none-any.whl",
+         "summary": "Install from a local wheel (offline-friendly)."},
+        {"cmd": "sim plugin install ./sim-plugin-coolprop -e",
+         "summary": "Editable install for plugin authors."},
+    ],
+    "plugin uninstall": [
+        {"cmd": "sim plugin uninstall coolprop",
+         "summary": "Remove a plugin and its synced skill dir."},
+    ],
+    "plugin bundle": [
+        {"cmd": "sim plugin bundle coolprop simpy gmsh -o ./plugins-bundle/",
+         "summary": "Fetch wheels into a directory for offline install."},
+    ],
+    "plugin sync-skills": [
+        {"cmd": "sim plugin sync-skills",
+         "summary": "Materialize installed plugins' _skills into .claude/skills/."},
+    ],
+    "plugin doctor": [
+        {"cmd": "sim plugin doctor --all --json",
+         "summary": "Run doctor on every plugin; exits with the count of FAILs."},
+    ],
 }
 
 

--- a/src/sim/describe.py
+++ b/src/sim/describe.py
@@ -1,0 +1,300 @@
+"""CLI manifest emitter for ``sim describe``.
+
+Agents call ``sim describe --json`` once at session start to learn the entire
+CLI surface: every command, every flag, every example, every error code,
+every output schema. They then route subsequent calls from that manifest
+without grepping ``--help`` or guessing.
+
+The manifest schema is versioned (``schema_version``); breaking changes
+bump the version. Additive changes are free.
+
+The manifest is built by introspecting the click app — what's there at
+runtime is what's described, so commands can never silently fall out of
+sync with their documentation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import click
+
+
+SCHEMA_VERSION = 1
+
+
+# ── Examples registry ───────────────────────────────────────────────────────
+#
+# Each command's example invocations live here. The describe command merges
+# this with the click introspection. Keep examples short and realistic —
+# agents copy them.
+
+_EXAMPLES: dict[str, list[dict[str, str]]] = {
+    "serve": [
+        {"cmd": "sim serve", "summary": "Start the HTTP server on the default port."},
+        {"cmd": "sim serve --host 0.0.0.0 --port 7600 --reload",
+         "summary": "Bind to all interfaces with auto-reload (dev mode)."},
+    ],
+    "check": [
+        {"cmd": "sim check --all", "summary": "Detect every installed solver."},
+        {"cmd": "sim check coolprop --json", "summary": "Detect one driver, JSON output."},
+    ],
+    "lint": [
+        {"cmd": "sim lint script.py --solver gmsh",
+         "summary": "Validate a script before running it."},
+    ],
+    "run": [
+        {"cmd": "sim run script.py --solver gmsh",
+         "summary": "Execute a script via the chosen driver."},
+        {"cmd": "sim run script.py --solver gmsh --json",
+         "summary": "Same, but emit RunResult as JSON for an agent."},
+    ],
+    "connect": [
+        {"cmd": "sim connect --solver gmsh",
+         "summary": "Start a persistent solver session."},
+    ],
+    "exec": [
+        {"cmd": 'sim exec "x = 2 + 2; print(x)"',
+         "summary": "Run a snippet in the active session."},
+        {"cmd": "sim exec --file snippet.py",
+         "summary": "Run a file's contents in the active session."},
+    ],
+    "inspect": [
+        {"cmd": "sim inspect session.summary",
+         "summary": "Print a summary of the active session's state."},
+    ],
+    "ps": [
+        {"cmd": "sim ps", "summary": "List active sessions."},
+        {"cmd": "sim ps --json", "summary": "Same, machine-readable."},
+    ],
+    "disconnect": [
+        {"cmd": "sim disconnect", "summary": "Tear down the active session."},
+        {"cmd": "sim disconnect --stop-server", "summary": "Also stop sim-server."},
+    ],
+    "stop": [
+        {"cmd": "sim stop", "summary": "Stop the sim-server process."},
+    ],
+    "screenshot": [
+        {"cmd": "sim screenshot -o desktop.png",
+         "summary": "Capture the server's desktop to a PNG file."},
+    ],
+    "logs": [
+        {"cmd": "sim logs --limit 20", "summary": "Show the last 20 history entries."},
+    ],
+    "config show": [
+        {"cmd": "sim config show --json",
+         "summary": "Print the resolved config (project + global merged)."},
+    ],
+    "config init": [
+        {"cmd": "sim config init project",
+         "summary": "Create a starter .sim/config.toml in the current project."},
+    ],
+    "config path": [
+        {"cmd": "sim config path --json",
+         "summary": "Print the location of the global and project config files."},
+    ],
+    "describe": [
+        {"cmd": "sim describe --json",
+         "summary": "Emit the full CLI manifest. Run this once at session start."},
+        {"cmd": "sim describe run --json",
+         "summary": "Manifest entry for one command."},
+        {"cmd": "sim describe --error-codes",
+         "summary": "List the closed enum of error codes."},
+    ],
+}
+
+
+# ── Error codes (closed enum) ───────────────────────────────────────────────
+#
+# Mirror of docs/agent-readability.md §1 — the source of truth for code
+# strings agents pattern-match. Adding a new code requires updating both
+# this dict and the doc.
+
+ERROR_CODES: dict[str, str] = {
+    "SOLVER_NOT_INSTALLED":
+        "The named driver loaded but the underlying solver is not detected on this host.",
+    "SOLVER_NOT_DETECTED_FOR_SCRIPT":
+        "A script was given without --solver and no driver claimed it.",
+    "LINT_FAILED":
+        "sim lint produced at least one error-level diagnostic.",
+    "RUN_FAILED":
+        "The solver returned non-zero or the driver detected an error in the output.",
+    "SESSION_NOT_FOUND":
+        "--session <id> does not match any active session on the server.",
+    "PLUGIN_NOT_FOUND":
+        "sim plugin could not resolve a plugin name (not in the index, no local file).",
+    "PLUGIN_INSTALL_FAILED":
+        "pip install for a plugin returned non-zero.",
+    "PROTOCOL_VIOLATION":
+        "A driver returned a value that doesn't match DriverProtocol.",
+    "NONINTERACTIVE_INPUT_REQUIRED":
+        "--no-interactive is set and the command would otherwise prompt.",
+}
+
+
+# ── Schema descriptions ─────────────────────────────────────────────────────
+#
+# These mirror the dataclasses in sim.driver. We don't ship full JSON Schema
+# yet (drives complexity for marginal value); a structured description
+# suffices for agents to know "this dict has these keys".
+
+SCHEMAS: dict[str, dict[str, Any]] = {
+    "RunResult": {
+        "type": "object",
+        "description": "Result of one solver script execution.",
+        "properties": {
+            "ok": {"type": "boolean", "description": "exit_code == 0 AND no errors."},
+            "exit_code": {"type": "integer"},
+            "stdout": {"type": "string"},
+            "stderr": {"type": "string"},
+            "errors": {"type": "array", "items": {"type": "string"}},
+            "duration_s": {"type": "number"},
+            "script": {"type": "string"},
+            "solver": {"type": "string"},
+            "timestamp": {"type": "string", "format": "date-time"},
+            "diagnostics": {"type": "array",
+                            "items": {"type": "object",
+                                      "properties": {"level": {"type": "string"},
+                                                     "message": {"type": "string"},
+                                                     "line": {"type": ["integer", "null"]}}}},
+            "artifacts": {"type": "array", "items": {"type": "object"}},
+            "workspace_delta": {
+                "type": "array",
+                "description": "Files added/modified under cwd during the run.",
+                "items": {"type": "object",
+                          "properties": {"path": {"type": "string"},
+                                         "kind": {"enum": ["added", "modified"]},
+                                         "size": {"type": "integer"}}}},
+        },
+    },
+    "LintResult": {
+        "type": "object",
+        "properties": {
+            "ok": {"type": "boolean"},
+            "diagnostics": {"type": "array",
+                            "items": {"type": "object",
+                                      "properties": {"level": {"enum": ["error", "warning", "info"]},
+                                                     "message": {"type": "string"},
+                                                     "line": {"type": ["integer", "null"]}}}},
+        },
+    },
+    "ConnectionInfo": {
+        "type": "object",
+        "properties": {
+            "solver": {"type": "string"},
+            "version": {"type": ["string", "null"]},
+            "status": {"enum": ["ok", "not_installed", "error"]},
+            "message": {"type": "string"},
+            "solver_version": {"type": ["string", "null"]},
+        },
+    },
+    "ErrorEnvelope": {
+        "type": "object",
+        "description": "Returned by every command on failure when --json is set.",
+        "properties": {
+            "ok": {"const": False},
+            "error_code": {"enum": list(ERROR_CODES.keys())},
+            "message": {"type": "string", "maxLength": 280},
+            "details": {"type": "object"},
+        },
+    },
+    "PluginInfo": {
+        "type": "object",
+        "description": "Lightweight metadata exposed by every plugin via the sim.plugins entry-point group.",
+        "properties": {
+            "name": {"type": "string"},
+            "summary": {"type": "string"},
+            "homepage": {"type": "string"},
+            "license_class": {"enum": ["oss", "commercial"]},
+            "solver_name": {"type": "string"},
+        },
+    },
+}
+
+
+# ── Introspection ───────────────────────────────────────────────────────────
+
+
+def _describe_param(param: click.Parameter) -> dict[str, Any]:
+    """Render one click parameter (option/argument) as a manifest entry."""
+    kind = "argument" if isinstance(param, click.Argument) else "option"
+    out: dict[str, Any] = {
+        "kind": kind,
+        "name": param.name,
+        "required": bool(param.required),
+        "multiple": bool(getattr(param, "multiple", False)),
+        "is_flag": bool(getattr(param, "is_flag", False)),
+    }
+    if isinstance(param, click.Option):
+        out["flags"] = list(param.opts) + list(param.secondary_opts or [])
+        if param.default is not None and not getattr(param, "is_flag", False):
+            try:
+                out["default"] = param.default if isinstance(
+                    param.default, (str, int, float, bool, type(None))
+                ) else repr(param.default)
+            except Exception:  # noqa: BLE001 — defensive against weird default reprs
+                out["default"] = None
+    help_text = getattr(param, "help", None)
+    if help_text:
+        out["help"] = help_text
+    return out
+
+
+def _describe_command(name: str, cmd: click.Command) -> dict[str, Any]:
+    """Render one click command as a manifest entry.
+
+    Example lookup is normalized so callers can pass either the canonical
+    space-separated form (``"config show"``) or the dotted form
+    (``"config.show"``).
+    """
+    canonical = name.replace(".", " ")
+    entry: dict[str, Any] = {
+        "name": name,
+        "summary": (cmd.short_help or (cmd.help or "").splitlines()[0:1] or [""])[0],
+        "help": cmd.help or "",
+        "params": [_describe_param(p) for p in cmd.params],
+        "examples": _EXAMPLES.get(canonical, []),
+    }
+    return entry
+
+
+def _walk(group: click.Group, prefix: str = "") -> list[dict[str, Any]]:
+    """Walk a click group, yielding manifest entries for every command.
+
+    Nested groups produce dotted names (``"config show"``).
+    """
+    entries: list[dict[str, Any]] = []
+    for sub_name, sub_cmd in sorted(group.commands.items()):
+        full = f"{prefix}{sub_name}" if prefix else sub_name
+        if isinstance(sub_cmd, click.Group):
+            # Describe the group itself plus walk into it.
+            entries.append(_describe_command(full, sub_cmd))
+            entries.extend(_walk(sub_cmd, prefix=f"{full} "))
+        else:
+            entries.append(_describe_command(full, sub_cmd))
+    return entries
+
+
+def build_manifest(app: click.Group, version: str) -> dict[str, Any]:
+    """Top-level: build the full manifest for an app."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "version": version,
+        "commands": _walk(app),
+        "schemas": SCHEMAS,
+        "error_codes": [
+            {"code": code, "description": desc}
+            for code, desc in ERROR_CODES.items()
+        ],
+    }
+
+
+def build_command_entry(app: click.Group, command_path: str) -> dict[str, Any] | None:
+    """Resolve a (possibly dotted/space-separated) command path to one entry."""
+    parts = command_path.replace(".", " ").split()
+    cur: click.Command | click.Group = app
+    for part in parts:
+        if not isinstance(cur, click.Group) or part not in cur.commands:
+            return None
+        cur = cur.commands[part]
+    return _describe_command(command_path, cur)

--- a/src/sim/describe.py
+++ b/src/sim/describe.py
@@ -89,9 +89,23 @@ _EXAMPLES: dict[str, list[dict[str, str]]] = {
         {"cmd": "sim config init project",
          "summary": "Create a starter .sim/config.toml in the current project."},
     ],
+    "config validate": [
+        {"cmd": "sim config validate",
+         "summary": "Check sim.toml against the schema. Fails with a list of errors."},
+    ],
     "config path": [
         {"cmd": "sim config path --json",
          "summary": "Print the location of the global and project config files."},
+    ],
+    "init": [
+        {"cmd": "sim init",
+         "summary": "Create a starter sim.toml in the current directory."},
+    ],
+    "setup": [
+        {"cmd": "sim setup --dry-run",
+         "summary": "Print what plugins sim would install from sim.toml."},
+        {"cmd": "sim setup",
+         "summary": "Install every plugin declared in sim.toml."},
     ],
     "describe": [
         {"cmd": "sim describe --json",

--- a/src/sim/driver.py
+++ b/src/sim/driver.py
@@ -137,6 +137,19 @@ class DriverProtocol(Protocol):
     # -- Session lifecycle (optional) ----------------------------------------
     # Drivers that support persistent sessions (connect/exec/disconnect)
     # must set supports_session = True and implement launch/run/disconnect.
+    #
+    # ## Return-shape contract (v1.0)
+    #
+    # Every session method returns a dict with at least ``{"ok": bool}``.
+    # On failure, drivers SHOULD also include ``"error_code"`` (from the
+    # closed enum in ``sim.describe.ERROR_CODES``) and ``"message"`` (≤280
+    # chars). Long output goes in ``"stdout"`` / ``"stderr"`` / ``"details"``,
+    # never inline in ``"message"``. See ``docs/agent-readability.md``.
+    #
+    # Drivers that don't support sessions should still implement these
+    # methods and have launch/run raise NotImplementedError; ``disconnect``
+    # is allowed to be a no-op (return ``{"ok": True, "disconnected": True}``).
+    # Both behaviors keep the structural protocol check happy.
 
     @property
     def supports_session(self) -> bool:
@@ -146,7 +159,9 @@ class DriverProtocol(Protocol):
     def launch(self, **kwargs) -> dict:
         """Start a persistent solver session.
 
-        Returns dict with at minimum ``{"ok": True, "session_id": "..."}``.
+        Required keys: ``ok`` (bool), ``session_id`` (str on success).
+        On failure: ``error_code`` (closed enum), ``message`` (≤280 chars).
+
         Accepts keyword arguments from the connect request; each driver
         picks what it needs and ignores the rest.
         """
@@ -155,13 +170,21 @@ class DriverProtocol(Protocol):
     def run(self, code: str, label: str = "") -> dict:
         """Execute code in the active session.
 
-        Returns dict with at minimum ``{"ok": bool}``.
+        Required keys: ``ok`` (bool). Drivers SHOULD also return
+        ``stdout``, ``stderr``, ``duration_s`` for parity with RunResult.
+        On failure: ``error_code`` (closed enum), ``message``.
+
+        ``label`` is an opaque tag the agent can use to correlate calls;
+        drivers should pass it through to logs but not interpret it.
         """
         ...
 
     def disconnect(self) -> dict:
         """Tear down the active session. Must be idempotent.
 
-        Returns ``{"ok": True, "disconnected": True}``.
+        Required keys: ``ok`` (bool), ``disconnected`` (bool).
+        Calling on an already-disconnected driver returns
+        ``{"ok": True, "disconnected": True}`` — that is, idempotent
+        success, not an error.
         """
         ...

--- a/src/sim/plugins.py
+++ b/src/sim/plugins.py
@@ -1,0 +1,467 @@
+"""Plugin discovery, metadata, and doctor — the substrate of ``sim plugin``.
+
+Plugins register themselves with sim-cli via three Python entry-point groups:
+
+* ``sim.drivers`` — required. The driver class implementing
+  :class:`sim.driver.DriverProtocol`. Already consumed by
+  :mod:`sim.drivers`; this module does not duplicate that work.
+* ``sim.skills`` — optional. A :class:`importlib.resources.abc.Traversable`
+  pointing at the plugin's bundled ``_skills/`` directory. Used by
+  ``sim plugin sync-skills``.
+* ``sim.plugins`` — optional but recommended. A lightweight metadata dict
+  (``plugin_info``) that lets ``sim plugin list`` show one row per plugin
+  without importing the driver class.
+
+This module exposes:
+
+  list_installed_plugins()  -> list[InstalledPlugin]
+  doctor(name, deep=False)  -> DoctorReport
+  doctor_all(deep=False)    -> list[DoctorReport]
+  plugin_info_for(name)     -> dict | None
+  skills_dir_for(name)      -> Traversable | None
+
+It deliberately does **not** install / uninstall plugins — that's
+``sim plugin install``'s concern, in :mod:`sim._plugin_install`. Discovery
+is read-only and side-effect-free.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib import resources as _resources
+from importlib.metadata import EntryPoint, entry_points
+from typing import Any
+
+
+# ── Entry-point groups ──────────────────────────────────────────────────────
+
+_GROUP_DRIVERS = "sim.drivers"
+_GROUP_SKILLS = "sim.skills"
+_GROUP_PLUGINS = "sim.plugins"
+
+
+# ── Data shapes ─────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class InstalledPlugin:
+    """One row of ``sim plugin list``."""
+    name: str                       # driver name, e.g. "coolprop"
+    package: str                    # PyPI distribution, e.g. "sim-plugin-coolprop"
+    version: str | None             # package version, e.g. "0.1.0"
+    summary: str = ""               # plugin_info.summary or ""
+    homepage: str = ""              # plugin_info.homepage or ""
+    license_class: str = ""         # "oss" / "commercial" / ""
+    solver_name: str = ""           # plugin_info.solver_name or ""
+    has_skills: bool = False        # whether sim.skills entry-point present
+    builtin: bool = False           # True if shipped with sim-cli (registry _BUILTIN_REGISTRY)
+    driver_module: str = ""         # module path for the driver, from the registry spec
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "package": self.package,
+            "version": self.version,
+            "summary": self.summary,
+            "homepage": self.homepage,
+            "license_class": self.license_class,
+            "solver_name": self.solver_name,
+            "has_skills": self.has_skills,
+            "builtin": self.builtin,
+            "driver_module": self.driver_module,
+        }
+
+
+@dataclass(frozen=True)
+class DoctorCheck:
+    """One step in a doctor report."""
+    label: str
+    status: str         # "ok", "warn", "fail", "info"
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"label": self.label, "status": self.status, "message": self.message}
+
+
+@dataclass
+class DoctorReport:
+    """The full doctor result for one plugin."""
+    name: str
+    plugin: InstalledPlugin | None
+    checks: list[DoctorCheck] = field(default_factory=list)
+
+    @property
+    def fail_count(self) -> int:
+        return sum(1 for c in self.checks if c.status == "fail")
+
+    @property
+    def warn_count(self) -> int:
+        return sum(1 for c in self.checks if c.status == "warn")
+
+    @property
+    def ok(self) -> bool:
+        return self.fail_count == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "ok": self.ok,
+            "fail_count": self.fail_count,
+            "warn_count": self.warn_count,
+            "plugin": self.plugin.to_dict() if self.plugin else None,
+            "checks": [c.to_dict() for c in self.checks],
+        }
+
+
+# ── Discovery ───────────────────────────────────────────────────────────────
+
+
+def _entry_points_in_group(group: str) -> list[EntryPoint]:
+    """Defensive wrapper: entry-point machinery sometimes raises in odd envs."""
+    try:
+        return list(entry_points(group=group))
+    except Exception:  # noqa: BLE001 — degrade gracefully on weird metadata states
+        return []
+
+
+def _ep_distribution_info(ep: EntryPoint) -> tuple[str, str | None]:
+    """Return ``(package_name, version)`` for an entry point, defensively.
+
+    The entry-point's ``.dist`` attribute may be None for in-tree dev
+    installs in some Python envs; fall back to ``("", None)`` then.
+    """
+    dist = getattr(ep, "dist", None)
+    if dist is None:
+        return "", None
+    name = getattr(dist, "name", None) or getattr(dist, "metadata", {}).get("Name", "")
+    version = getattr(dist, "version", None)
+    return (name or "", version)
+
+
+def _skills_eps_by_name() -> dict[str, EntryPoint]:
+    return {ep.name: ep for ep in _entry_points_in_group(_GROUP_SKILLS)}
+
+
+def _plugin_info_eps_by_name() -> dict[str, EntryPoint]:
+    return {ep.name: ep for ep in _entry_points_in_group(_GROUP_PLUGINS)}
+
+
+def plugin_info_for(name: str) -> dict[str, Any] | None:
+    """Load and return the ``plugin_info`` dict for one plugin, or None.
+
+    Catches every exception during load — ``plugin_info`` is metadata, not
+    code, so a misformed one shouldn't crash the listing.
+    """
+    eps = _plugin_info_eps_by_name()
+    ep = eps.get(name)
+    if ep is None:
+        return None
+    try:
+        info = ep.load()
+    except Exception:  # noqa: BLE001 — see docstring
+        return None
+    if not isinstance(info, dict):
+        return None
+    # Normalize: every key is a string; fill in expected keys with "".
+    out = {
+        "name": str(info.get("name", name)),
+        "summary": str(info.get("summary", "")),
+        "homepage": str(info.get("homepage", "")),
+        "license_class": str(info.get("license_class", "")),
+        "solver_name": str(info.get("solver_name", "")),
+    }
+    return out
+
+
+def skills_dir_for(name: str):
+    """Load and return the bundled ``_skills/<name>`` Traversable, or None.
+
+    The ``sim.skills`` entry-point should resolve to a Traversable already
+    pointing at the plugin's ``_skills/`` directory. We then descend one
+    level to the per-driver subdir using the driver name.
+    """
+    eps = _skills_eps_by_name()
+    ep = eps.get(name)
+    if ep is None:
+        return None
+    try:
+        traversable = ep.load()
+    except Exception:  # noqa: BLE001
+        return None
+    # If the entry-point already points at <pkg>/_skills/, descend to <name>.
+    candidate = traversable.joinpath(name) if hasattr(traversable, "joinpath") else None
+    if candidate is not None and getattr(candidate, "is_dir", lambda: False)():
+        return candidate
+    # Otherwise treat it as the leaf already.
+    return traversable
+
+
+def list_installed_plugins() -> list[InstalledPlugin]:
+    """Enumerate every driver currently registered, with metadata where present.
+
+    Walks the ``sim.drivers`` registry (built-ins + externally discovered
+    entry-points). For each entry, looks up matching ``sim.plugins`` and
+    ``sim.skills`` entries. Returns one row per registered driver.
+    """
+    from sim.drivers import _BUILTIN_REGISTRY, _REGISTRY  # local — see compat.py
+
+    builtin_names = {n for n, _ in _BUILTIN_REGISTRY}
+    skills_eps = _skills_eps_by_name()
+    info_eps = _plugin_info_eps_by_name()
+    drivers_eps = {ep.name: ep for ep in _entry_points_in_group(_GROUP_DRIVERS)}
+
+    rows: list[InstalledPlugin] = []
+    for driver_name, spec in _REGISTRY:
+        module_path, _, _cls = spec.rpartition(":")
+        is_builtin = driver_name in builtin_names
+
+        package, version = "", None
+        ep_info: dict[str, Any] | None = None
+
+        if not is_builtin and driver_name in drivers_eps:
+            package, version = _ep_distribution_info(drivers_eps[driver_name])
+        if is_builtin:
+            # The host package itself ships the built-in drivers.
+            package, version = _ep_distribution_info_for_host()
+
+        if driver_name in info_eps:
+            ep_info = plugin_info_for(driver_name)
+
+        rows.append(InstalledPlugin(
+            name=driver_name,
+            package=package,
+            version=version,
+            summary=(ep_info or {}).get("summary", ""),
+            homepage=(ep_info or {}).get("homepage", ""),
+            license_class=(ep_info or {}).get("license_class", ""),
+            solver_name=(ep_info or {}).get("solver_name", ""),
+            has_skills=driver_name in skills_eps,
+            builtin=is_builtin,
+            driver_module=module_path,
+        ))
+    return rows
+
+
+def _ep_distribution_info_for_host() -> tuple[str, str | None]:
+    """Look up the host package (sim-cli itself) — used for built-in driver rows."""
+    try:
+        from importlib.metadata import distribution
+        # Try the current PyPI name first; rename to sim-cli-core lands in Phase 4.
+        for candidate in ("sim-cli-core", "sim-runtime"):
+            try:
+                dist = distribution(candidate)
+                return dist.name or candidate, dist.version
+            except Exception:  # noqa: BLE001
+                continue
+    except Exception:  # noqa: BLE001
+        pass
+    return "", None
+
+
+# ── Doctor ──────────────────────────────────────────────────────────────────
+
+
+def doctor(name: str, deep: bool = False) -> DoctorReport:
+    """Validate one plugin end-to-end. Never raises; everything turns into checks."""
+    plugins = {p.name: p for p in list_installed_plugins()}
+    plugin = plugins.get(name)
+    report = DoctorReport(name=name, plugin=plugin)
+
+    if plugin is None:
+        report.checks.append(DoctorCheck(
+            label="registered",
+            status="fail",
+            message=f"no driver registered as {name!r}",
+        ))
+        return report
+
+    report.checks.append(DoctorCheck(
+        label="registered",
+        status="ok",
+        message=f"{plugin.driver_module}",
+    ))
+
+    # 2. Driver class importable.
+    try:
+        from sim.drivers import _resolve as _resolve_driver
+        driver = _resolve_driver(name)
+    except Exception as e:  # noqa: BLE001 — surface any import failure
+        report.checks.append(DoctorCheck(
+            label="driver_imports",
+            status="fail",
+            message=f"{type(e).__name__}: {e}",
+        ))
+        return report
+    report.checks.append(DoctorCheck(
+        label="driver_imports",
+        status="ok",
+    ))
+
+    # 3. Structural protocol conformance.
+    from sim.driver import DriverProtocol
+    if isinstance(driver, DriverProtocol):
+        report.checks.append(DoctorCheck(label="protocol_conforms", status="ok"))
+    else:
+        report.checks.append(DoctorCheck(
+            label="protocol_conforms",
+            status="warn",
+            message="instance does not match DriverProtocol structurally",
+        ))
+
+    # 4. Skills bundle.
+    if plugin.has_skills:
+        skills = skills_dir_for(name)
+        if skills is None:
+            report.checks.append(DoctorCheck(
+                label="skills_bundle",
+                status="warn",
+                message="sim.skills entry-point present but failed to load",
+            ))
+        else:
+            has_skill_md = False
+            try:
+                has_skill_md = skills.joinpath("SKILL.md").is_file()
+            except Exception:  # noqa: BLE001
+                pass
+            if has_skill_md:
+                report.checks.append(DoctorCheck(label="skills_bundle", status="ok"))
+            else:
+                report.checks.append(DoctorCheck(
+                    label="skills_bundle",
+                    status="warn",
+                    message="bundled _skills/<name>/ has no SKILL.md",
+                ))
+    else:
+        # Built-ins typically don't have skills bundled; not a regression.
+        if plugin.builtin:
+            report.checks.append(DoctorCheck(
+                label="skills_bundle",
+                status="info",
+                message="built-in driver; no bundled skills (expected)",
+            ))
+        else:
+            report.checks.append(DoctorCheck(
+                label="skills_bundle",
+                status="warn",
+                message="external plugin has no sim.skills entry-point",
+            ))
+
+    # 5. Compatibility.yaml present and parses.
+    from sim.compat import load_compatibility_by_name
+    compat = load_compatibility_by_name(name)
+    if compat is None:
+        # Many drivers legitimately have no compat.yaml (SDK-less / version-insensitive).
+        report.checks.append(DoctorCheck(
+            label="compatibility_yaml",
+            status="info",
+            message="no compatibility.yaml (driver is SDK-less or version-insensitive)",
+        ))
+    else:
+        report.checks.append(DoctorCheck(
+            label="compatibility_yaml",
+            status="ok",
+            message=f"{len(compat.profiles)} profile(s)",
+        ))
+
+    # 6. Optional deep check: detect_installed.
+    if deep:
+        try:
+            from sim.compat import safe_detect_installed
+            installs = safe_detect_installed(driver)
+            if installs:
+                report.checks.append(DoctorCheck(
+                    label="solver_detected",
+                    status="ok",
+                    message=f"{len(installs)} install(s)",
+                ))
+            else:
+                report.checks.append(DoctorCheck(
+                    label="solver_detected",
+                    status="info",
+                    message="no installation found on this host",
+                ))
+        except Exception as e:  # noqa: BLE001
+            report.checks.append(DoctorCheck(
+                label="solver_detected",
+                status="warn",
+                message=f"detect_installed raised {type(e).__name__}: {e}",
+            ))
+
+    return report
+
+
+def doctor_all(deep: bool = False) -> list[DoctorReport]:
+    """Run doctor on every registered driver. Order matches the registry."""
+    return [doctor(p.name, deep=deep) for p in list_installed_plugins()]
+
+
+# ── Skills sync ─────────────────────────────────────────────────────────────
+
+
+def sync_skills_to(target_dir, *, copy: bool = False) -> dict[str, Any]:
+    """Materialize every installed plugin's ``_skills/<name>/`` under ``target_dir``.
+
+    Default mode is symlink (idempotent, near-free); ``copy=True`` falls
+    back to recursive copy for environments where symlinks are blocked
+    (Windows without developer mode).
+
+    Returns ``{"ok": bool, "linked": [...], "copied": [...], "skipped": [...]}``.
+    Skips drivers without a ``sim.skills`` entry-point (built-ins, OSS plugins
+    that haven't shipped skills yet).
+    """
+    from pathlib import Path
+
+    target = Path(target_dir)
+    target.mkdir(parents=True, exist_ok=True)
+
+    linked: list[str] = []
+    copied: list[str] = []
+    skipped: list[str] = []
+
+    for plugin in list_installed_plugins():
+        if not plugin.has_skills:
+            skipped.append(plugin.name)
+            continue
+        skills = skills_dir_for(plugin.name)
+        if skills is None:
+            skipped.append(plugin.name)
+            continue
+
+        # Resolve the Traversable to a real filesystem path. importlib.resources
+        # returns a MultiplexedPath / PosixPath / WindowsPath depending on the
+        # install type. _resources.as_file() yields a real path.
+        with _resources.as_file(skills) as src_path:
+            dest = target / plugin.name
+            if dest.is_symlink() or dest.exists():
+                try:
+                    if dest.is_symlink():
+                        dest.unlink()
+                    elif dest.is_dir():
+                        import shutil
+                        shutil.rmtree(dest)
+                    else:
+                        dest.unlink()
+                except OSError:
+                    skipped.append(plugin.name)
+                    continue
+
+            if copy:
+                import shutil
+                shutil.copytree(src_path, dest)
+                copied.append(plugin.name)
+            else:
+                try:
+                    dest.symlink_to(src_path, target_is_directory=True)
+                    linked.append(plugin.name)
+                except (OSError, NotImplementedError):
+                    # Windows / no privilege — fall back to copy.
+                    import shutil
+                    shutil.copytree(src_path, dest)
+                    copied.append(plugin.name)
+
+    return {
+        "ok": True,
+        "target": str(target),
+        "linked": linked,
+        "copied": copied,
+        "skipped": skipped,
+    }

--- a/src/sim/server.py
+++ b/src/sim/server.py
@@ -171,9 +171,7 @@ def detect_solver(solver: str):
     the CLI can use the same rendering code for both local and remote
     detection.
     """
-    from pathlib import Path
-
-    from sim.compat import load_compatibility, safe_detect_installed
+    from sim.compat import load_compatibility_by_name, safe_detect_installed
     from sim.drivers import get_driver
 
     try:
@@ -185,11 +183,10 @@ def detect_solver(solver: str):
 
     installs = safe_detect_installed(driver)
 
-    driver_dir = Path(__file__).parent / "drivers" / solver
     resolutions: list[dict] = []
     compat_dict: dict | None = None
-    try:
-        compat = load_compatibility(driver_dir)
+    compat = load_compatibility_by_name(solver)
+    if compat is not None:
         compat_dict = {
             "driver": compat.driver,
             "sdk_package": compat.sdk_package,
@@ -201,7 +198,7 @@ def detect_solver(solver: str):
                 "install": inst.to_dict(),
                 "profile": profile.to_dict() if profile else None,
             })
-    except FileNotFoundError:
+    else:
         for inst in installs:
             resolutions.append({"install": inst.to_dict(), "profile": None})
 
@@ -221,15 +218,13 @@ def _resolve_profile(driver, solver: str):
     detected install. Returns the Profile, or None on miss / failure.
     Never raises.
     """
-    from pathlib import Path
-    from sim.compat import load_compatibility, safe_detect_installed
+    from sim.compat import load_compatibility_by_name, safe_detect_installed
 
     installs = safe_detect_installed(driver)
     if not installs:
         return None
-    try:
-        compat = load_compatibility(Path(__file__).parent / "drivers" / solver)
-    except (FileNotFoundError, ValueError):
+    compat = load_compatibility_by_name(solver)
+    if compat is None:
         return None
     for inst in sorted(installs, key=lambda i: i.version, reverse=True):
         profile = compat.resolve(inst.version)

--- a/src/sim/testing/__init__.py
+++ b/src/sim/testing/__init__.py
@@ -1,0 +1,30 @@
+"""Test helpers for plugin authors.
+
+The single most important export here is :func:`assert_protocol_conformance`,
+which every external plugin should call from its own test suite to confirm
+its driver class meets the contract sim-cli depends on.
+
+Plugins typically pull this in via::
+
+    # sim-plugin-<solver>/tests/test_protocol.py
+    from sim.testing import assert_protocol_conformance
+    from sim_plugin_<solver> import <Solver>Driver
+
+    def test_protocol_conformance():
+        assert_protocol_conformance(<Solver>Driver)
+
+This module intentionally has zero plugin-author boilerplate beyond that.
+"""
+from __future__ import annotations
+
+from .protocol_conformance import (
+    assert_protocol_conformance,
+    check_driver,
+    ConformanceFailure,
+)
+
+__all__ = [
+    "assert_protocol_conformance",
+    "check_driver",
+    "ConformanceFailure",
+]

--- a/src/sim/testing/protocol_conformance.py
+++ b/src/sim/testing/protocol_conformance.py
@@ -1,0 +1,264 @@
+"""Conformance checks every sim plugin's CI should run.
+
+This file is the single source of truth for "does this driver class
+implement DriverProtocol correctly enough for sim-cli to use it?". It
+catches mistakes that the structural ``isinstance(d, DriverProtocol)``
+runtime check misses — things like methods that exist but have the wrong
+return type, missing attributes, or a ``detect_installed`` that imports
+the SDK at attribute-access time.
+
+Plugin authors call :func:`assert_protocol_conformance` from a single test
+function and get the whole battery for free. The check returns structured
+failures via :class:`ConformanceFailure` so the test runner shows useful
+diagnostics rather than ``AssertionError``.
+"""
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from sim.driver import (
+    ConnectionInfo,
+    DriverProtocol,
+    LintResult,
+    RunResult,
+    SolverInstall,
+)
+
+
+@dataclass
+class ConformanceFailure(AssertionError):
+    """Raised when a driver class fails conformance.
+
+    Subclassing AssertionError so pytest renders it nicely without the
+    test author needing to wrap calls in ``pytest.raises``. NOT frozen:
+    Python's exception machinery mutates ``__traceback__`` on the way up.
+    """
+    label: str
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover — formatting only
+        return f"[{self.label}] {self.message}"
+
+
+# Required methods on the structural protocol. We check these by name AND
+# by inspecting the signature (parameter count, names) so authors who alias
+# parameters get a helpful error.
+REQUIRED_METHODS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("detect", ("script",)),
+    ("lint", ("script",)),
+    ("connect", ()),
+    ("parse_output", ("stdout",)),
+    ("run_file", ("script",)),
+    ("detect_installed", ()),
+)
+
+# Optional methods — only checked when the driver advertises supports_session.
+OPTIONAL_SESSION_METHODS: tuple[str, ...] = ("launch", "run", "disconnect")
+
+
+def _instantiate(driver_class: type) -> Any:
+    """Instantiate the driver class, surfacing the real failure cleanly."""
+    try:
+        return driver_class()
+    except TypeError as e:
+        raise ConformanceFailure(
+            "instantiation",
+            f"{driver_class.__name__}() requires arguments — drivers must "
+            f"be no-arg constructible. Original: {e}",
+        ) from e
+    except Exception as e:  # noqa: BLE001 — surface the original failure verbatim
+        raise ConformanceFailure(
+            "instantiation",
+            f"{driver_class.__name__}() raised at construction: {type(e).__name__}: {e}",
+        ) from e
+
+
+def check_driver(driver_class: type) -> list[ConformanceFailure]:
+    """Run every conformance check and return all failures (does not raise).
+
+    Use this when you want to produce a report; use
+    :func:`assert_protocol_conformance` when you want a single
+    pass/fail in a test.
+    """
+    failures: list[ConformanceFailure] = []
+
+    # 1. The class can be instantiated without arguments.
+    try:
+        instance = _instantiate(driver_class)
+    except ConformanceFailure as f:
+        return [f]
+
+    # 2. ``name`` property exists and is a non-empty string.
+    name = getattr(instance, "name", None)
+    if not isinstance(name, str) or not name:
+        failures.append(ConformanceFailure(
+            "name",
+            f"driver.name must be a non-empty string, got {name!r}",
+        ))
+
+    # 3. Required methods exist with sensible signatures.
+    for method_name, expected_params in REQUIRED_METHODS:
+        method = getattr(instance, method_name, None)
+        if method is None or not callable(method):
+            failures.append(ConformanceFailure(
+                f"method:{method_name}",
+                f"{method_name!r} is missing or not callable",
+            ))
+            continue
+        try:
+            sig = inspect.signature(method)
+        except (TypeError, ValueError):
+            continue  # builtin / C extension methods can't be introspected
+        param_names = [p.name for p in sig.parameters.values()
+                       if p.kind not in (inspect.Parameter.VAR_KEYWORD,
+                                         inspect.Parameter.VAR_POSITIONAL)]
+        for expected in expected_params:
+            if expected not in param_names:
+                failures.append(ConformanceFailure(
+                    f"method:{method_name}",
+                    f"{method_name}() expected parameter {expected!r}, "
+                    f"got params: {param_names}",
+                ))
+
+    # 4. ``detect_installed`` returns an iterable of SolverInstall.
+    try:
+        installs = list(instance.detect_installed())
+    except Exception as e:  # noqa: BLE001 — must be safe to call
+        failures.append(ConformanceFailure(
+            "detect_installed",
+            f"raised {type(e).__name__}: {e}. Must be safe to call when "
+            f"nothing is installed.",
+        ))
+    else:
+        for inst in installs:
+            if not isinstance(inst, SolverInstall):
+                failures.append(ConformanceFailure(
+                    "detect_installed",
+                    f"returned {type(inst).__name__}; must be SolverInstall",
+                ))
+                break
+
+    # 5. ``connect`` returns a ConnectionInfo (or close-enough duck).
+    try:
+        ci = instance.connect()
+    except Exception as e:  # noqa: BLE001 — driver may legitimately error here
+        # We don't fail conformance — connect() is allowed to fail when the
+        # solver isn't installed. But the type when it does succeed must be
+        # ConnectionInfo. We can only skip in this case.
+        ci = None
+        if not isinstance(e, (FileNotFoundError, RuntimeError, OSError, ImportError)):
+            failures.append(ConformanceFailure(
+                "connect",
+                f"raised {type(e).__name__}: {e!s}. Failures should produce "
+                f"ConnectionInfo(status='not_installed'/'error') instead.",
+            ))
+    if ci is not None and not isinstance(ci, ConnectionInfo):
+        failures.append(ConformanceFailure(
+            "connect",
+            f"returned {type(ci).__name__}; must be ConnectionInfo",
+        ))
+
+    # 6. ``parse_output`` returns a dict.
+    try:
+        parsed = instance.parse_output("")
+    except Exception as e:  # noqa: BLE001
+        failures.append(ConformanceFailure(
+            "parse_output",
+            f"raised on empty input: {type(e).__name__}: {e}. "
+            f"Must accept any string and return a dict.",
+        ))
+    else:
+        if not isinstance(parsed, dict):
+            failures.append(ConformanceFailure(
+                "parse_output",
+                f"returned {type(parsed).__name__}; must be dict",
+            ))
+
+    # 7. ``lint`` returns a LintResult on a missing path (the driver may
+    #    decline to lint missing files, but it must not crash).
+    try:
+        lr = instance.lint(Path("/nonexistent/script.tmp"))
+    except Exception as e:  # noqa: BLE001
+        failures.append(ConformanceFailure(
+            "lint",
+            f"raised on missing-file path: {type(e).__name__}: {e}. "
+            f"Should return LintResult(ok=True, diagnostics=[]) or similar.",
+        ))
+    else:
+        if not isinstance(lr, LintResult):
+            failures.append(ConformanceFailure(
+                "lint",
+                f"returned {type(lr).__name__}; must be LintResult",
+            ))
+
+    # 8. Session lifecycle (only if advertised).
+    supports_session = bool(getattr(instance, "supports_session", False))
+    if supports_session:
+        for method_name in OPTIONAL_SESSION_METHODS:
+            method = getattr(instance, method_name, None)
+            if method is None or not callable(method):
+                failures.append(ConformanceFailure(
+                    f"session:{method_name}",
+                    f"supports_session=True but {method_name!r} is missing",
+                ))
+
+    # 9. Final structural protocol check.
+    if not isinstance(instance, DriverProtocol):
+        failures.append(ConformanceFailure(
+            "protocol",
+            f"{driver_class.__name__} instance does not match DriverProtocol "
+            f"structurally. The previous failures usually explain why.",
+        ))
+
+    return failures
+
+
+def assert_protocol_conformance(driver_class: type) -> None:
+    """Test-suite friendly wrapper around :func:`check_driver`.
+
+    Plugin authors call this from one pytest function::
+
+        from sim.testing import assert_protocol_conformance
+        from sim_plugin_<x> import <X>Driver
+
+        def test_protocol():
+            assert_protocol_conformance(<X>Driver)
+
+    Raises ConformanceFailure (an AssertionError subclass) listing every
+    failure, which pytest renders as one nicely-grouped failure.
+    """
+    failures = check_driver(driver_class)
+    if not failures:
+        return
+
+    lines = [f"{len(failures)} conformance failure(s) in {driver_class.__name__}:"]
+    for f in failures:
+        lines.append(f"  [{f.label}] {f.message}")
+    # Raise the first failure so the test framework's `__cause__` chain points
+    # at one root, but include all in the message.
+    raise ConformanceFailure(
+        label=failures[0].label,
+        message="\n".join(lines),
+    )
+
+
+def _ensure_dataclass_imports_for_consumers() -> None:
+    """No-op: ensures RunResult is reachable for type-checkers reading this module.
+
+    Plugin authors might also want to assert their driver returns RunResult
+    from run_file when given a real script — that test is plugin-specific
+    and we don't try to write it here.
+    """
+    _ = RunResult
+
+
+__all__ = [
+    "ConformanceFailure",
+    "assert_protocol_conformance",
+    "check_driver",
+    "REQUIRED_METHODS",
+    "OPTIONAL_SESSION_METHODS",
+]

--- a/tests/base/test_describe.py
+++ b/tests/base/test_describe.py
@@ -1,0 +1,170 @@
+"""Tests for the ``sim describe`` command and its underlying manifest builder.
+
+These tests are the contract for agents: if any of them fail, an agent's
+discovery flow breaks. Run them with ``pytest tests/base/test_describe.py``.
+"""
+from __future__ import annotations
+
+import json
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from sim import describe as _describe
+from sim.cli import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ── Manifest shape ──────────────────────────────────────────────────────────
+
+
+def test_manifest_has_required_top_level_keys():
+    m = _describe.build_manifest(main, version="x.y.z")
+    assert m["schema_version"] == _describe.SCHEMA_VERSION
+    assert m["version"] == "x.y.z"
+    assert isinstance(m["commands"], list) and m["commands"]
+    assert "schemas" in m and "error_codes" in m
+
+
+def test_manifest_includes_every_top_level_command():
+    m = _describe.build_manifest(main, version="0")
+    names = {c["name"] for c in m["commands"]}
+    # Spot-check a representative subset of expected commands
+    for required in ("run", "lint", "connect", "exec", "ps", "describe", "config"):
+        assert required in names, f"missing command: {required}"
+
+
+def test_manifest_includes_nested_config_subcommands():
+    m = _describe.build_manifest(main, version="0")
+    names = {c["name"] for c in m["commands"]}
+    for required in ("config show", "config path", "config init"):
+        assert required in names
+
+
+def test_every_command_has_summary_and_help():
+    m = _describe.build_manifest(main, version="0")
+    for cmd in m["commands"]:
+        # Summary may be derived from docstring; never None.
+        assert isinstance(cmd.get("summary", ""), str)
+        assert isinstance(cmd.get("help", ""), str)
+
+
+def test_every_command_has_examples_or_is_a_pure_group():
+    """Examples are required for leaf commands; groups are exempt."""
+    m = _describe.build_manifest(main, version="0")
+    leaf_commands_missing_examples: list[str] = []
+    for cmd in m["commands"]:
+        # Skip pure groups (config) — their leaves carry the examples.
+        if cmd["name"] in {"config"}:
+            continue
+        if not cmd["examples"]:
+            leaf_commands_missing_examples.append(cmd["name"])
+    assert not leaf_commands_missing_examples, (
+        f"Commands without examples: {leaf_commands_missing_examples}. "
+        f"Add an entry to _EXAMPLES in src/sim/describe.py."
+    )
+
+
+# ── Error codes ─────────────────────────────────────────────────────────────
+
+
+def test_error_code_enum_is_closed_and_documented():
+    """Every code has a description; no empty values."""
+    for code, desc in _describe.ERROR_CODES.items():
+        assert code.isupper(), f"error code must be SCREAMING_SNAKE: {code!r}"
+        assert desc and isinstance(desc, str), f"missing description for {code}"
+
+
+def test_error_codes_in_manifest_match_module_dict():
+    m = _describe.build_manifest(main, version="0")
+    manifest_codes = {entry["code"] for entry in m["error_codes"]}
+    assert manifest_codes == set(_describe.ERROR_CODES.keys())
+
+
+# ── Schemas ─────────────────────────────────────────────────────────────────
+
+
+def test_schemas_have_required_types():
+    """Every schema exposes a 'type' key (or const for the error envelope)."""
+    for name, schema in _describe.SCHEMAS.items():
+        assert isinstance(schema, dict), f"{name} must be dict"
+        assert "type" in schema, f"{name} missing 'type' key"
+
+
+def test_error_envelope_schema_references_full_error_enum():
+    env = _describe.SCHEMAS["ErrorEnvelope"]
+    enum = env["properties"]["error_code"]["enum"]
+    assert set(enum) == set(_describe.ERROR_CODES.keys())
+
+
+# ── CLI invocation ──────────────────────────────────────────────────────────
+
+
+def test_describe_full_manifest_outputs_valid_json(runner):
+    result = runner.invoke(main, ["describe"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["schema_version"] == 1
+    assert data["commands"]
+
+
+def test_describe_one_command(runner):
+    result = runner.invoke(main, ["describe", "run"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["name"] == "run"
+    assert data["examples"]
+
+
+def test_describe_unknown_command_returns_error_envelope(runner):
+    result = runner.invoke(main, ["describe", "no-such-command"])
+    assert result.exit_code == 2
+    data = json.loads(result.output)
+    assert data["ok"] is False
+    assert data["error_code"] == "PLUGIN_NOT_FOUND"
+    assert "no-such-command" in data["message"]
+
+
+def test_describe_schema_by_name(runner):
+    result = runner.invoke(main, ["describe", "--schema", "RunResult"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["type"] == "object"
+    assert "ok" in data["properties"]
+
+
+def test_describe_unknown_schema_returns_error(runner):
+    result = runner.invoke(main, ["describe", "--schema", "Nope"])
+    assert result.exit_code == 2
+    data = json.loads(result.output)
+    assert data["ok"] is False
+
+
+def test_describe_error_codes_only(runner):
+    result = runner.invoke(main, ["describe", "--error-codes"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert all("code" in e and "description" in e for e in data)
+    codes = {e["code"] for e in data}
+    assert "RUN_FAILED" in codes
+    assert "PROTOCOL_VIOLATION" in codes
+
+
+def test_describe_dotted_path(runner):
+    """`sim describe config.show` should resolve like `sim describe 'config show'`."""
+    r1 = runner.invoke(main, ["describe", "config show"])
+    r2 = runner.invoke(main, ["describe", "config.show"])
+    assert r1.exit_code == 0
+    assert r2.exit_code == 0
+    d1 = json.loads(r1.output)
+    d2 = json.loads(r2.output)
+    # Names will differ (one uses space, one dot), but the underlying data should match.
+    d1.pop("name", None)
+    d2.pop("name", None)
+    assert d1 == d2

--- a/tests/base/test_describe.py
+++ b/tests/base/test_describe.py
@@ -59,8 +59,8 @@ def test_every_command_has_examples_or_is_a_pure_group():
     m = _describe.build_manifest(main, version="0")
     leaf_commands_missing_examples: list[str] = []
     for cmd in m["commands"]:
-        # Skip pure groups (config) — their leaves carry the examples.
-        if cmd["name"] in {"config"}:
+        # Skip pure groups (config, plugin) — their leaves carry the examples.
+        if cmd["name"] in {"config", "plugin"}:
             continue
         if not cmd["examples"]:
             leaf_commands_missing_examples.append(cmd["name"])

--- a/tests/base/test_init_setup.py
+++ b/tests/base/test_init_setup.py
@@ -1,0 +1,193 @@
+"""Tests for ``sim init``, ``sim setup``, ``sim config validate``,
+and the ``sim.toml`` schema layer in :mod:`sim.config`.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from sim import config as _cfg
+from sim.cli import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ── sim.toml schema validation ──────────────────────────────────────────────
+
+
+def test_validate_missing_file(tmp_path: Path):
+    errors = _cfg.validate_sim_toml(tmp_path / "no.toml")
+    assert errors and "not found" in errors[0]
+
+
+def test_validate_invalid_toml(tmp_path: Path):
+    p = tmp_path / "sim.toml"
+    p.write_text("not = valid = toml\n", encoding="utf-8")
+    errors = _cfg.validate_sim_toml(p)
+    assert errors and "invalid TOML" in errors[0]
+
+
+def test_validate_missing_sim_table(tmp_path: Path):
+    p = tmp_path / "sim.toml"
+    p.write_text("[other]\nkey = 1\n", encoding="utf-8")
+    errors = _cfg.validate_sim_toml(p)
+    assert any("missing [sim] table" in e for e in errors)
+
+
+def test_validate_minimal_clean(tmp_path: Path):
+    p = tmp_path / "sim.toml"
+    p.write_text("[sim]\n", encoding="utf-8")
+    assert _cfg.validate_sim_toml(p) == []
+
+
+def test_validate_default_solver_must_be_string(tmp_path: Path):
+    p = tmp_path / "sim.toml"
+    p.write_text("[sim]\ndefault_solver = 123\n", encoding="utf-8")
+    errors = _cfg.validate_sim_toml(p)
+    assert any("default_solver must be a string" in e for e in errors)
+
+
+def test_validate_plugin_entry_requires_name(tmp_path: Path):
+    p = tmp_path / "sim.toml"
+    p.write_text("[sim]\n[[sim.plugins]]\nversion = '1'\n", encoding="utf-8")
+    errors = _cfg.validate_sim_toml(p)
+    assert any("missing required 'name'" in e for e in errors)
+
+
+def test_validate_full_example(tmp_path: Path):
+    p = tmp_path / "sim.toml"
+    p.write_text("""
+[sim]
+default_solver = "gmsh"
+workspace = "./workspace"
+server_port = 7600
+
+[[sim.plugins]]
+name = "coolprop"
+version = ">=0.1.0"
+
+[[sim.plugins]]
+name = "gmsh"
+git = "https://github.com/svd-ai-lab/sim-plugin-gmsh"
+""".strip(), encoding="utf-8")
+    assert _cfg.validate_sim_toml(p) == []
+
+
+# ── derive_install_source — translate sim.toml → install string ────────────
+
+
+def test_derive_source_from_wheel():
+    s = _cfg.derive_install_source({"name": "x", "wheel": "./x.whl"})
+    assert s == "./x.whl"
+
+
+def test_derive_source_from_git():
+    s = _cfg.derive_install_source({"name": "x", "git": "https://example/x"})
+    assert s == "git+https://example/x"
+
+
+def test_derive_source_from_pinned_version():
+    s = _cfg.derive_install_source({"name": "x", "version": "==1.2.3"})
+    assert s == "x@1.2.3"
+
+
+def test_derive_source_from_range_falls_back_to_bare_name():
+    s = _cfg.derive_install_source({"name": "x", "version": ">=0.1"})
+    assert s == "x"
+
+
+def test_derive_source_bare_name():
+    s = _cfg.derive_install_source({"name": "x"})
+    assert s == "x"
+
+
+# ── CLI: sim init / sim config validate / sim setup ─────────────────────────
+
+
+def test_cli_init_creates_sim_toml(runner: CliRunner, tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    r = runner.invoke(main, ["init"])
+    assert r.exit_code == 0, r.output
+    assert (tmp_path / "sim.toml").exists()
+
+
+def test_cli_init_idempotent(runner: CliRunner, tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "sim.toml").write_text("# my custom\n", encoding="utf-8")
+    r = runner.invoke(main, ["init"])
+    assert r.exit_code == 0
+    # Existing content preserved without --force.
+    assert (tmp_path / "sim.toml").read_text(encoding="utf-8") == "# my custom\n"
+
+
+def test_cli_init_force_regenerates(runner: CliRunner, tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "sim.toml").write_text("# old\n", encoding="utf-8")
+    r = runner.invoke(main, ["init", "--force"])
+    assert r.exit_code == 0
+    body = (tmp_path / "sim.toml").read_text(encoding="utf-8")
+    assert "[sim]" in body  # fresh stub
+
+
+def test_cli_config_validate_ok(runner: CliRunner, tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "sim.toml").write_text("[sim]\n", encoding="utf-8")
+    r = runner.invoke(main, ["--json", "config", "validate"])
+    assert r.exit_code == 0
+    data = json.loads(r.output)
+    assert data["ok"] is True
+
+
+def test_cli_config_validate_fail(runner: CliRunner, tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    bad = tmp_path / "sim.toml"
+    bad.write_text("[other]\n", encoding="utf-8")
+    r = runner.invoke(main, ["--json", "config", "validate", str(bad)])
+    assert r.exit_code == 2
+    data = json.loads(r.output)
+    assert data["ok"] is False
+    assert data["errors"]
+
+
+def test_cli_setup_dry_run_with_no_plugins(runner: CliRunner, tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "sim.toml").write_text("[sim]\n", encoding="utf-8")
+    r = runner.invoke(main, ["--json", "setup", "--dry-run"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.output)
+    assert data["ok"] is True
+    assert data["plugins"] == []
+
+
+def test_cli_setup_missing_sim_toml_errors_cleanly(runner: CliRunner, tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    r = runner.invoke(main, ["--json", "setup"])
+    # Exit 2 = user error per agent-readability.md
+    assert r.exit_code == 2
+    data = json.loads(r.output)
+    assert data["ok"] is False
+    assert data["error_code"] == "PLUGIN_NOT_FOUND"
+
+
+def test_cli_setup_dry_run_lists_what_would_install(runner: CliRunner, tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "sim.toml").write_text("""
+[sim]
+[[sim.plugins]]
+name = "coolprop"
+version = "==0.1.0"
+""".strip(), encoding="utf-8")
+    r = runner.invoke(main, ["--json", "setup", "--dry-run"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.output)
+    assert data["ok"] is True
+    assert len(data["plugins"]) == 1
+    assert data["plugins"][0]["name"] == "coolprop"
+    assert data["plugins"][0]["source"] == "coolprop@0.1.0"
+    assert data["plugins"][0]["action"] == "would-install"

--- a/tests/base/test_lint_public_corpus.py
+++ b/tests/base/test_lint_public_corpus.py
@@ -1,0 +1,159 @@
+"""Tests for tools/lint-public-corpus.py.
+
+Smoke-only: the script's core matching logic (pattern building, allow-comment
+detection, whitelist application) is what we exercise. We don't assert on
+the full repo report — that's an inventory that changes over time.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tools" / "lint-public-corpus.py"
+
+
+@pytest.fixture
+def lint_module():
+    spec = importlib.util.spec_from_file_location("lint_public_corpus", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    # Register in sys.modules before exec so the @dataclass decorator can
+    # resolve forward refs via cls.__module__ lookup.
+    sys.modules["lint_public_corpus"] = mod
+    try:
+        spec.loader.exec_module(mod)
+        yield mod
+    finally:
+        sys.modules.pop("lint_public_corpus", None)
+
+
+def test_pattern_matches_word_boundary(lint_module):
+    pat = lint_module._build_pattern()
+    assert pat.search("we use Fluent here")
+    assert pat.search("Fluent.")
+    # word-boundary: shouldn't match inside larger identifiers
+    assert not pat.search("influencer")
+    assert not pat.search("affluent")
+    assert not pat.search("antifluentish")
+
+
+def test_pattern_case_insensitive(lint_module):
+    pat = lint_module._build_pattern()
+    for s in ["fluent", "FLUENT", "Fluent", "fLuEnT"]:
+        assert pat.search(s), f"failed to match {s!r}"
+
+
+def test_pattern_alternation_covers_multiword_tokens(lint_module):
+    pat = lint_module._build_pattern()
+    # ls-dyna and ls_dyna both flagged — they're hyphenated tokens
+    m = pat.search("we ran ls-dyna on this")
+    assert m and m.group(1).lower() == "ls-dyna"
+    m = pat.search("ls_dyna deck")
+    assert m and m.group(1).lower() == "ls_dyna"
+
+
+def test_token_whitelist_marks_as_allowed(lint_module, tmp_path):
+    f = tmp_path / "x.py"
+    f.write_text("# we use ltspice for circuit sims\n")
+    pat = lint_module._build_pattern()
+    hits = lint_module.scan_file(f, pat)
+    assert len(hits) == 1
+    assert hits[0].token == "ltspice"
+    assert hits[0].whitelisted is True
+    assert hits[0].whitelist_reason == "TOKEN_WHITELIST"
+
+
+def test_allow_comment_marks_as_allowed_with_reason(lint_module, tmp_path):
+    f = tmp_path / "x.py"
+    f.write_text("vendor = 'ANSYS'  # allow-vendor-name: env var name is fixed\n")
+    pat = lint_module._build_pattern()
+    hits = lint_module.scan_file(f, pat)
+    assert len(hits) == 1
+    assert hits[0].token == "ansys"
+    assert hits[0].whitelisted is True
+    assert "env var name" in hits[0].whitelist_reason
+
+
+def test_no_allow_comment_means_flagged(lint_module, tmp_path):
+    f = tmp_path / "x.py"
+    f.write_text("# we ran fluent here\n")
+    pat = lint_module._build_pattern()
+    hits = lint_module.scan_file(f, pat)
+    assert len(hits) == 1
+    assert hits[0].whitelisted is False
+
+
+def test_warn_mode_exits_zero_with_flagged_hits(tmp_path):
+    # Create a tiny git repo with one offending file.
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    (tmp_path / "x.py").write_text("# uses fluent\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=tmp_path, check=True)
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0
+    assert "flagged" in proc.stdout.lower()
+
+
+def test_fail_mode_exits_one_with_flagged_hits(tmp_path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    (tmp_path / "x.py").write_text("# uses fluent\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=tmp_path, check=True)
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(tmp_path), "--fail"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 1
+
+
+def test_fail_mode_exits_zero_when_clean(tmp_path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    (tmp_path / "x.py").write_text("# nothing to see\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=tmp_path, check=True)
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(tmp_path), "--fail"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0
+    assert "clean" in proc.stdout.lower()
+
+
+def test_json_output_parses(tmp_path):
+    import json
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    (tmp_path / "x.py").write_text("# uses fluent\n# uses ltspice\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=tmp_path, check=True)
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(tmp_path), "--json"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["total"] == 2
+    assert data["flagged"] == 1
+    assert data["allowed"] == 1
+    assert data["ok"] is False

--- a/tests/base/test_plugin_install.py
+++ b/tests/base/test_plugin_install.py
@@ -1,0 +1,232 @@
+"""Tests for sim._plugin_install — source resolution, bundle, and report shape.
+
+These cover the *classification* layer (no real pip calls) and the bundle
+flow against mocked HTTP. The actual install path is exercised against a
+fixture wheel in test_plugin_install_e2e — kept small and skipped when
+no fixture wheel exists yet.
+"""
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from sim._plugin_install import (
+    DEFAULT_INDEX_URL,
+    InstallReport,
+    bundle_plugins,
+    fetch_index,
+    index_entry,
+    resolve_source,
+)
+
+
+# ── Source resolution ──────────────────────────────────────────────────────
+
+
+def test_resolve_local_wheel(tmp_path: Path):
+    wheel = tmp_path / "sim_plugin_coolprop-0.1.0-py3-none-any.whl"
+    wheel.write_bytes(b"")  # contents irrelevant for resolution
+    rs = resolve_source(str(wheel))
+    assert rs.kind == "local-wheel"
+    assert rs.pip_target == str(wheel.resolve())
+
+
+def test_resolve_local_sdist(tmp_path: Path):
+    sdist = tmp_path / "sim-plugin-coolprop-0.1.0.tar.gz"
+    sdist.write_bytes(b"")
+    rs = resolve_source(str(sdist))
+    assert rs.kind == "local-sdist"
+
+
+def test_resolve_local_directory(tmp_path: Path):
+    pkg_dir = tmp_path / "sim-plugin-foo"
+    pkg_dir.mkdir()
+    rs = resolve_source(str(pkg_dir))
+    assert rs.kind == "local-dir"
+
+
+def test_resolve_missing_local_path_errors(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        resolve_source(str(tmp_path / "no-such-thing/"))
+
+
+def test_resolve_git_url():
+    url = "git+https://github.com/svd-ai-lab/sim-plugin-coolprop"
+    rs = resolve_source(url)
+    assert rs.kind == "git-url"
+    assert rs.pip_target == url
+
+
+def test_resolve_wheel_url():
+    url = "https://example.com/sim_plugin_x-0.1.0-py3-none-any.whl"
+    rs = resolve_source(url)
+    assert rs.kind == "wheel-url"
+
+
+def test_resolve_sdist_url():
+    url = "https://example.com/sim-plugin-x-0.1.0.tar.gz"
+    rs = resolve_source(url)
+    assert rs.kind == "sdist-url"
+
+
+def test_resolve_bare_name_offline_without_cache_errors(tmp_path: Path, monkeypatch):
+    # Force an empty cache dir.
+    monkeypatch.setattr("sim._plugin_install._index_cache_dir",
+                        lambda: tmp_path / "no-cache")
+    with pytest.raises(ValueError):
+        resolve_source("coolprop", offline=True)
+
+
+def test_resolve_bare_name_with_index_uses_wheel_url(tmp_path: Path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    cache_idx = cache_dir / "index.json"
+    cache_idx.write_text(json.dumps({
+        "schema_version": 1,
+        "plugins": [{
+            "name": "coolprop",
+            "git": "https://github.com/svd-ai-lab/sim-plugin-coolprop",
+            "license_class": "oss",
+            "latest_wheel_url": "https://example.com/x.whl",
+        }],
+    }), encoding="utf-8")
+    monkeypatch.setattr("sim._plugin_install._index_cache_dir", lambda: cache_dir)
+    monkeypatch.setattr("sim._plugin_install._index_cache_path",
+                        lambda: cache_idx)
+    rs = resolve_source("coolprop", offline=True)
+    assert rs.kind == "name"
+    assert rs.pip_target == "https://example.com/x.whl"
+
+
+def test_resolve_name_at_version(tmp_path: Path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "index.json").write_text(json.dumps({
+        "schema_version": 1, "plugins": [],
+    }), encoding="utf-8")
+    monkeypatch.setattr("sim._plugin_install._index_cache_dir", lambda: cache_dir)
+    monkeypatch.setattr("sim._plugin_install._index_cache_path",
+                        lambda: cache_dir / "index.json")
+    rs = resolve_source("coolprop@0.2.1", offline=False)  # name not in index, falls to optimistic
+    assert rs.kind == "name-version"
+    assert rs.name == "coolprop"
+    assert rs.version == "0.2.1"
+    assert "coolprop" in rs.pip_target
+
+
+def test_resolve_garbage_raises():
+    with pytest.raises(ValueError):
+        resolve_source("???not-a-source???")
+
+
+# ── Index fetch + cache ──────────────────────────────────────────────────────
+
+
+def test_fetch_index_offline_missing_cache_returns_empty(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("sim._plugin_install._index_cache_dir",
+                        lambda: tmp_path / "missing")
+    monkeypatch.setattr("sim._plugin_install._index_cache_path",
+                        lambda: tmp_path / "missing" / "index.json")
+    idx = fetch_index(offline=True)
+    assert idx == {"schema_version": 1, "plugins": []}
+
+
+def test_index_entry_lookup(tmp_path: Path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "index.json").write_text(json.dumps({
+        "schema_version": 1,
+        "plugins": [
+            {"name": "coolprop", "license_class": "oss"},
+            {"name": "simpy", "license_class": "oss"},
+        ],
+    }), encoding="utf-8")
+    monkeypatch.setattr("sim._plugin_install._index_cache_dir", lambda: cache_dir)
+    monkeypatch.setattr("sim._plugin_install._index_cache_path",
+                        lambda: cache_dir / "index.json")
+    e = index_entry("coolprop", offline=True)
+    assert e is not None and e["name"] == "coolprop"
+    assert index_entry("nope", offline=True) is None
+
+
+# ── Bundle ──────────────────────────────────────────────────────────────────
+
+
+def test_bundle_plugins_writes_filtered_index(tmp_path: Path, monkeypatch):
+    """Bundle should write an index.json with only the requested plugins."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr("sim._plugin_install._index_cache_dir", lambda: cache_dir)
+    monkeypatch.setattr("sim._plugin_install._index_cache_path",
+                        lambda: cache_dir / "index.json")
+
+    full_index = {
+        "schema_version": 1,
+        "plugins": [
+            {"name": "coolprop",
+             "latest_wheel_url": "http://fake/coolprop.whl",
+             "license_class": "oss"},
+            {"name": "simpy",
+             "latest_wheel_url": "http://fake/simpy.whl",
+             "license_class": "oss"},
+        ],
+    }
+    (cache_dir / "index.json").write_text(json.dumps(full_index), encoding="utf-8")
+
+    # Real file-like; bundle uses shutil.copyfileobj which calls .read(size).
+    import io
+
+    class _FakeResp(io.BytesIO):
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            self.close()
+
+    def fake_open(url, timeout=30):
+        return _FakeResp(b"WHEEL")
+
+    output = tmp_path / "out"
+    with mock.patch("sim._plugin_install.urllib.request.urlopen", fake_open):
+        result = bundle_plugins(["coolprop"], output)
+
+    assert result["ok"] is True
+    assert result["fetched"] == ["coolprop"]
+    written_idx = json.loads((output / "index.json").read_text(encoding="utf-8"))
+    assert len(written_idx["plugins"]) == 1
+    assert written_idx["plugins"][0]["name"] == "coolprop"
+    assert written_idx["plugins"][0]["latest_wheel_url"].startswith("file://")
+
+
+def test_bundle_plugins_unknown_returns_partial_failure(tmp_path: Path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "index.json").write_text(json.dumps({"plugins": []}), encoding="utf-8")
+    monkeypatch.setattr("sim._plugin_install._index_cache_dir", lambda: cache_dir)
+    monkeypatch.setattr("sim._plugin_install._index_cache_path",
+                        lambda: cache_dir / "index.json")
+
+    output = tmp_path / "out"
+    result = bundle_plugins(["nope"], output)
+    assert result["ok"] is False
+    assert result["fetched"] == []
+    assert result["errors"][0]["name"] == "nope"
+
+
+# ── InstallReport shape ─────────────────────────────────────────────────────
+
+
+def test_install_report_dict_includes_all_keys():
+    r = InstallReport(
+        ok=True, name="x", source_kind="name", pip_target="...",
+        pip_returncode=0, pip_stdout="o", pip_stderr="e",
+        sync_skills={"ok": True, "linked": [], "copied": [], "skipped": []},
+    )
+    d = r.to_dict()
+    for k in ("ok", "name", "source_kind", "pip_target",
+              "pip_returncode", "pip_stdout", "pip_stderr",
+              "sync_skills", "error_code", "message"):
+        assert k in d

--- a/tests/base/test_plugins.py
+++ b/tests/base/test_plugins.py
@@ -1,0 +1,154 @@
+"""Tests for ``sim plugin`` commands and the underlying discovery layer.
+
+Pure unit tests against the in-tree built-in registry. Tests for actually
+installing external plugins (`sim plugin install <wheel>`) live in
+test_plugin_install.py.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from sim import plugins as _plugins
+from sim.cli import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ── Discovery layer ─────────────────────────────────────────────────────────
+
+
+def test_list_installed_plugins_returns_all_built_ins():
+    rows = _plugins.list_installed_plugins()
+    assert rows
+    names = {r.name for r in rows}
+    # Spot-check a handful of OSS built-ins.
+    for required in ("coolprop", "pybamm", "gmsh", "simpy"):
+        assert required in names, f"missing built-in: {required}"
+
+
+def test_built_in_rows_marked_builtin_true():
+    rows = _plugins.list_installed_plugins()
+    for r in rows:
+        # The current registry has all built-ins; no externals installed in test env.
+        assert r.builtin is True
+        assert r.driver_module.startswith("sim.drivers.")
+
+
+def test_plugin_info_for_unknown_returns_none():
+    assert _plugins.plugin_info_for("no-such-plugin") is None
+
+
+def test_skills_dir_for_unknown_returns_none():
+    assert _plugins.skills_dir_for("no-such-plugin") is None
+
+
+# ── Doctor ──────────────────────────────────────────────────────────────────
+
+
+def test_doctor_unknown_plugin_returns_failed_report():
+    report = _plugins.doctor("no-such-plugin")
+    assert report.ok is False
+    assert report.fail_count >= 1
+    assert any(c.label == "registered" and c.status == "fail" for c in report.checks)
+
+
+def test_doctor_built_in_passes_at_least_registration():
+    report = _plugins.doctor("coolprop")
+    assert any(c.label == "registered" and c.status == "ok" for c in report.checks)
+    assert any(c.label == "driver_imports" and c.status == "ok" for c in report.checks)
+
+
+def test_doctor_all_runs_against_every_plugin():
+    reports = _plugins.doctor_all()
+    assert len(reports) == len(_plugins.list_installed_plugins())
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def test_cli_plugin_list_human_output(runner):
+    r = runner.invoke(main, ["plugin", "list"])
+    assert r.exit_code == 0, r.output
+    assert "plugin(s) registered" in r.output
+
+
+def test_cli_plugin_list_json(runner):
+    r = runner.invoke(main, ["--json", "plugin", "list"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.output)
+    assert isinstance(data, list)
+    assert any(row["name"] == "coolprop" for row in data)
+    for row in data:
+        # to_dict shape contract
+        for k in ("name", "package", "version", "builtin", "has_skills", "driver_module"):
+            assert k in row, f"missing key {k} in {row}"
+
+
+def test_cli_plugin_info_unknown(runner):
+    r = runner.invoke(main, ["--json", "plugin", "info", "no-such-thing"])
+    assert r.exit_code == 2
+    data = json.loads(r.output)
+    assert data["ok"] is False
+    assert data["error_code"] == "PLUGIN_NOT_FOUND"
+
+
+def test_cli_plugin_info_known_built_in(runner):
+    r = runner.invoke(main, ["--json", "plugin", "info", "coolprop"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.output)
+    assert data["ok"] is True
+    assert data["plugin"]["name"] == "coolprop"
+    assert data["plugin"]["builtin"] is True
+
+
+def test_cli_plugin_doctor_specific_built_in(runner):
+    r = runner.invoke(main, ["--json", "plugin", "doctor", "coolprop"])
+    # Exit code is the fail count; built-ins should all pass.
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.output)
+    assert data["ok"] is True
+    assert data["fail_count"] == 0
+
+
+def test_cli_plugin_doctor_all_built_ins(runner):
+    r = runner.invoke(main, ["--json", "plugin", "doctor", "--all"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.output)
+    assert data["ok"] is True
+    assert len(data["reports"]) >= 20
+
+
+def test_cli_plugin_doctor_unknown_fails(runner):
+    r = runner.invoke(main, ["--json", "plugin", "doctor", "no-such-plugin"])
+    # One fail: the registered check.
+    assert r.exit_code == 1
+    data = json.loads(r.output)
+    assert data["fail_count"] >= 1
+
+
+def test_cli_plugin_doctor_no_args_returns_error(runner):
+    r = runner.invoke(main, ["--json", "plugin", "doctor"])
+    assert r.exit_code == 2
+    data = json.loads(r.output)
+    assert data["ok"] is False
+    assert data["error_code"] == "PLUGIN_NOT_FOUND"
+
+
+# ── Sync skills ─────────────────────────────────────────────────────────────
+
+
+def test_sync_skills_creates_target_dir_and_returns_dict(tmp_path):
+    target = tmp_path / "skills"
+    out = _plugins.sync_skills_to(target, copy=True)
+    assert out["ok"] is True
+    assert target.exists()
+    # Built-ins don't ship sim.skills entry-points, so all are skipped.
+    assert isinstance(out["skipped"], list)
+    assert isinstance(out["linked"], list)
+    assert isinstance(out["copied"], list)

--- a/tests/base/test_protocol_conformance.py
+++ b/tests/base/test_protocol_conformance.py
@@ -1,0 +1,185 @@
+"""Tests for the conformance harness sim ships to plugin authors.
+
+We exercise it against a hand-rolled fake driver (good and bad variants)
+and against one real built-in driver to confirm round-trip works.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sim.driver import (
+    ConnectionInfo,
+    LintResult,
+    RunResult,
+    SolverInstall,
+)
+from sim.testing import (
+    ConformanceFailure,
+    assert_protocol_conformance,
+    check_driver,
+)
+
+
+# ── Reference good driver ───────────────────────────────────────────────────
+
+
+class _GoodDriver:
+    name = "fakegood"
+    supports_session = False
+
+    def detect(self, script: Path) -> bool:
+        return False
+
+    def lint(self, script: Path) -> LintResult:
+        return LintResult(ok=True, diagnostics=[])
+
+    def connect(self) -> ConnectionInfo:
+        return ConnectionInfo(solver=self.name, version="0", status="ok")
+
+    def parse_output(self, stdout: str) -> dict:
+        return {"metrics": {}, "warnings": [], "diagnostics": []}
+
+    def run_file(self, script: Path) -> RunResult:
+        return RunResult(
+            exit_code=0, stdout="", stderr="",
+            duration_s=0.0, script=str(script), solver=self.name, timestamp="t",
+        )
+
+    def detect_installed(self) -> list[SolverInstall]:
+        return []
+
+    # Protocol requires these as attributes; non-session drivers raise.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError("this driver doesn't support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError("this driver doesn't support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}
+
+
+class _GoodSessionDriver(_GoodDriver):
+    supports_session = True
+
+    def launch(self, **kwargs) -> dict:
+        return {"ok": True, "session_id": "test"}
+
+    def run(self, code: str, label: str = "") -> dict:
+        return {"ok": True}
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}
+
+
+# ── Bad-driver variants for negative tests ──────────────────────────────────
+
+
+class _MissingMethodDriver:
+    name = "bad1"
+    supports_session = False
+
+    # No detect, no lint, etc.
+    def detect_installed(self) -> list:
+        return []
+
+
+class _WrongReturnTypeDriver(_GoodDriver):
+    name = "bad2"
+
+    def parse_output(self, stdout: str):
+        return "not a dict"
+
+
+class _SessionAdvertisedButMissingDriver(_GoodDriver):
+    name = "bad3"
+    supports_session = True
+    # Override the inherited stubs back to "missing" so the conformance check
+    # for "advertised supports_session, but methods missing" fires.
+    launch = None  # type: ignore[assignment]
+    run = None    # type: ignore[assignment]
+    disconnect = None  # type: ignore[assignment]
+
+
+class _ConstructorRequiresArgs:
+    name = "bad4"
+
+    def __init__(self, required_arg):
+        self.required_arg = required_arg
+
+
+class _DetectInstalledRaises(_GoodDriver):
+    def detect_installed(self):
+        raise RuntimeError("forgot to make this safe")
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+
+def test_good_driver_passes():
+    failures = check_driver(_GoodDriver)
+    assert failures == [], failures
+
+
+def test_good_session_driver_passes():
+    failures = check_driver(_GoodSessionDriver)
+    assert failures == [], failures
+
+
+def test_assert_passes_for_good_driver():
+    # Smoke: doesn't raise.
+    assert_protocol_conformance(_GoodDriver)
+
+
+def test_missing_methods_flagged():
+    failures = check_driver(_MissingMethodDriver)
+    labels = {f.label for f in failures}
+    # At minimum, the protocol-final check must complain.
+    assert any(label.startswith("method:") for label in labels)
+
+
+def test_wrong_return_type_flagged():
+    failures = check_driver(_WrongReturnTypeDriver)
+    assert any(f.label == "parse_output" for f in failures)
+
+
+def test_advertised_session_methods_must_exist():
+    failures = check_driver(_SessionAdvertisedButMissingDriver)
+    labels = {f.label for f in failures}
+    assert "session:launch" in labels
+    assert "session:run" in labels
+    assert "session:disconnect" in labels
+
+
+def test_constructor_requiring_args_caught():
+    with pytest.raises(ConformanceFailure):
+        assert_protocol_conformance(_ConstructorRequiresArgs)
+
+
+def test_detect_installed_must_be_safe():
+    failures = check_driver(_DetectInstalledRaises)
+    assert any(f.label == "detect_installed" for f in failures)
+
+
+def test_assert_message_lists_every_failure():
+    with pytest.raises(ConformanceFailure) as exc:
+        assert_protocol_conformance(_SessionAdvertisedButMissingDriver)
+    msg = str(exc.value)
+    assert "session:launch" in msg
+    assert "session:run" in msg
+    assert "session:disconnect" in msg
+
+
+# ── Real built-in driver smoke ──────────────────────────────────────────────
+
+
+def test_built_in_coolprop_driver_check_runs():
+    """We don't assert ``failures == []`` for built-ins (they may legitimately
+    be in flux), only that the harness runs against a real driver class
+    without crashing. This is a smoke test for the harness itself.
+    """
+    from sim.drivers.coolprop.driver import CoolPropDriver
+    failures = check_driver(CoolPropDriver)
+    assert isinstance(failures, list)

--- a/tools/lint-public-corpus.py
+++ b/tools/lint-public-corpus.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Audit the public corpus for commercial-vendor name exposure.
+
+Public sim-cli must not reveal that maintainers run commercial simulation
+software. This script walks tracked source files and reports any occurrence
+of vendor names from the forbidden list, with line context.
+
+## Modes
+
+- ``--warn`` (default): print a report and exit 0. Use during the migration
+  while we still have legacy occurrences to clean up.
+- ``--fail`` (post-Phase-3): exit non-zero on any unwhitelisted occurrence.
+  CI runs this in fail mode to prevent regressions.
+
+## Whitelist
+
+A leading-comment marker on the same line allows a specific occurrence::
+
+    # allow-vendor-name: <reason>      # in Python
+    <!-- allow-vendor-name: <reason> --> # in markdown
+
+The reason field is required and shown in the audit report. Use sparingly —
+prefer rewriting the line over whitelisting.
+
+A token whitelist (TOKEN_WHITELIST below) covers tokens that appear by virtue
+of standing alone (e.g. "ltspice" until Phase 3 removes it; OSS solvers
+shouldn't ever match anyway).
+
+## Why
+Per CLAUDE.md and memory ``feedback_compliance_hygiene_stance.md``: clean
+public artifacts proactively. Framed as compliance hygiene, not evidence
+destruction. No git history rewriting from this tool.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# Vendor-name tokens to flag. Word-boundary matched, case-insensitive.
+# Add new vendors here as we add their drivers.
+FORBIDDEN_TOKENS: tuple[str, ...] = (
+    "fluent",
+    "pyfluent",      # Fluent's Python SDK — same exposure
+    "comsol",
+    "matlab",
+    "simulink",
+    "flotherm",
+    "abaqus",
+    "ansa",          # commercial mesh tool by Beta CAE
+    "ltspice",       # whitelisted until Phase 3 — Analog Devices product
+    "lsdyna",
+    "ls-dyna",
+    "ls_dyna",
+    "lspp",          # LS-PrePost
+    "cfx",
+    "mapdl",
+    "ansys",         # umbrella vendor name
+    "hypermesh",
+    "altair",        # vendor of Hypermesh / Hyperworks
+    "icem",          # Ansys ICEM CFD
+    "starccm",
+    "star-ccm",
+    "workbench",
+    "tecplot",
+    "ensight",
+    "femfat",
+)
+
+# Tokens that are allowed to appear without per-line whitelist comments
+# during the migration. Removed as their phase completes.
+TOKEN_WHITELIST: set[str] = {
+    "ltspice",        # public exception until Phase 3 — see plan §3
+}
+
+# Per-line allow comment patterns.
+ALLOW_COMMENT_RE = re.compile(
+    r"#\s*allow-vendor-name:\s*\S|<!--\s*allow-vendor-name:\s*\S"
+)
+
+# File extensions to scan. Skip binaries and lockfiles.
+TEXT_EXTENSIONS = {
+    ".py", ".md", ".txt", ".rst", ".yaml", ".yml", ".toml",
+    ".json", ".sh", ".cfg", ".ini",
+}
+
+# Path globs to skip. uv.lock is huge and only contains pinned package
+# names; tests fixtures may legitimately reference vendor strings as test
+# inputs. Adjust carefully.
+SKIP_PATH_PARTS = {
+    "uv.lock",
+    ".git",
+    "__pycache__",
+    ".venv",
+    ".pytest_cache",
+    ".ruff_cache",
+    "dist",
+    "build",
+    "node_modules",
+}
+
+
+@dataclass(frozen=True)
+class Hit:
+    path: Path
+    line_no: int
+    line: str
+    token: str
+    whitelisted: bool
+    whitelist_reason: str = ""
+
+
+def tracked_files(repo_root: Path) -> list[Path]:
+    """Return git-tracked text files under repo_root."""
+    proc = subprocess.run(
+        ["git", "ls-files"],
+        cwd=repo_root, capture_output=True, text=True, check=True,
+    )
+    files: list[Path] = []
+    for raw in proc.stdout.splitlines():
+        if not raw.strip():
+            continue
+        p = repo_root / raw
+        if any(part in SKIP_PATH_PARTS for part in p.parts):
+            continue
+        if p.suffix.lower() not in TEXT_EXTENSIONS:
+            continue
+        if not p.is_file():
+            continue
+        files.append(p)
+    return files
+
+
+def _build_pattern() -> re.Pattern[str]:
+    # Word-boundary alternation; case-insensitive. Sort longest-first so
+    # ``ls-dyna`` matches before ``ls`` would (defensive for future tokens).
+    sorted_tokens = sorted(FORBIDDEN_TOKENS, key=len, reverse=True)
+    alt = "|".join(re.escape(t) for t in sorted_tokens)
+    return re.compile(rf"(?i)(?<![A-Za-z0-9_])({alt})(?![A-Za-z0-9_])")
+
+
+def scan_file(path: Path, pattern: re.Pattern[str]) -> list[Hit]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+
+    hits: list[Hit] = []
+    for line_no, raw_line in enumerate(text.splitlines(), start=1):
+        # Cheap fast-path: skip lines that don't even contain a letter from
+        # any token's first char. Saves regex work on long files.
+        if not any(c.isalpha() for c in raw_line):
+            continue
+        for m in pattern.finditer(raw_line):
+            token = m.group(1).lower()
+            allowed = (
+                token in TOKEN_WHITELIST
+                or bool(ALLOW_COMMENT_RE.search(raw_line))
+            )
+            reason = ""
+            if token in TOKEN_WHITELIST:
+                reason = "TOKEN_WHITELIST"
+            else:
+                m2 = re.search(r"allow-vendor-name:\s*([^\s].*?)(?:-->|$)", raw_line)
+                if m2:
+                    reason = m2.group(1).strip()
+            hits.append(Hit(
+                path=path, line_no=line_no, line=raw_line.rstrip(),
+                token=token, whitelisted=allowed, whitelist_reason=reason,
+            ))
+    return hits
+
+
+def format_report(hits: list[Hit], repo_root: Path, *, show_allowed: bool) -> str:
+    if not hits:
+        return "Public corpus is clean.\n"
+
+    flagged = [h for h in hits if not h.whitelisted]
+    allowed = [h for h in hits if h.whitelisted]
+
+    lines: list[str] = []
+    lines.append(f"Found {len(hits)} occurrence(s) ({len(flagged)} flagged, {len(allowed)} allowed)")
+    lines.append("")
+
+    by_file: dict[Path, list[Hit]] = {}
+    for h in flagged:
+        by_file.setdefault(h.path, []).append(h)
+
+    if flagged:
+        lines.append(f"=== Flagged ({len(flagged)}) ===")
+        for path, items in sorted(by_file.items()):
+            rel = path.relative_to(repo_root)
+            lines.append(f"\n{rel}:")
+            for h in items:
+                lines.append(f"  {h.line_no}:{h.token}: {h.line.strip()[:120]}")
+
+    if show_allowed and allowed:
+        lines.append("")
+        lines.append(f"=== Allowed ({len(allowed)}) ===")
+        by_file_a: dict[Path, list[Hit]] = {}
+        for h in allowed:
+            by_file_a.setdefault(h.path, []).append(h)
+        for path, items in sorted(by_file_a.items()):
+            rel = path.relative_to(repo_root)
+            lines.append(f"\n{rel}:")
+            for h in items:
+                lines.append(f"  {h.line_no}:{h.token} ({h.whitelist_reason})")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit public corpus for commercial-vendor name exposure.",
+    )
+    parser.add_argument(
+        "--repo-root", default=".", type=Path,
+        help="Repo root (default: cwd).",
+    )
+    parser.add_argument(
+        "--fail", dest="fail_mode", action="store_true",
+        help="Exit non-zero on flagged occurrences (post-Phase-3 mode).",
+    )
+    parser.add_argument(
+        "--show-allowed", action="store_true",
+        help="Also list whitelisted occurrences in the report.",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit machine-readable JSON instead of human report.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    if not (repo_root / ".git").exists():
+        print(f"error: {repo_root} is not a git repo", file=sys.stderr)
+        return 2
+
+    pattern = _build_pattern()
+    hits: list[Hit] = []
+    for path in tracked_files(repo_root):
+        hits.extend(scan_file(path, pattern))
+
+    flagged_count = sum(1 for h in hits if not h.whitelisted)
+
+    if args.json:
+        import json
+        out = {
+            "ok": flagged_count == 0,
+            "total": len(hits),
+            "flagged": flagged_count,
+            "allowed": len(hits) - flagged_count,
+            "hits": [
+                {
+                    "path": str(h.path.relative_to(repo_root)),
+                    "line": h.line_no,
+                    "token": h.token,
+                    "whitelisted": h.whitelisted,
+                    "reason": h.whitelist_reason,
+                    "context": h.line.strip()[:200],
+                }
+                for h in hits
+            ],
+        }
+        print(json.dumps(out, indent=2))
+    else:
+        print(format_report(hits, repo_root, show_allowed=args.show_allowed))
+
+    if args.fail_mode and flagged_count > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -26,128 +26,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ansys-api-fluent"
-version = "0.3.38"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "grpcio" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/25/82/b5b5006dcebffaadfe24a5fed4dfd0096ff4e8e5f18a0f49f00311ff5033/ansys_api_fluent-0.3.38.tar.gz", hash = "sha256:ed5a5b00710dd95e7f10efeb323ca9fe4e54196f10916ea22de13ac70c9fa302", size = 20891 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/82/87/cc7ebea74c0d0a09e9d184fbd0847284befd8e466bf7f07dc71947974a23/ansys_api_fluent-0.3.38-py3-none-any.whl", hash = "sha256:ce1839ab8d4cc6737bc81f8cd23df2f4d04e422fc17b94dac4ca701b25883e68", size = 132034 },
-]
-
-[[package]]
-name = "ansys-api-platform-instancemanagement"
-version = "1.1.3"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "grpcio" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/91/f5/a52a0cfe8aba248f31e569932cccc5968bbe171dec0958d7e72f6d8d6c4a/ansys_api_platform_instancemanagement-1.1.3.tar.gz", hash = "sha256:3ba0e53b0c67e96385a9fb773cd95967bbf586ef860dc17e648c9085b77a2f23", size = 6955 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/15/3a/4e205e3b318207891a35cef578a6b121087e2eff8a952c765d2b5aa79d55/ansys_api_platform_instancemanagement-1.1.3-py3-none-any.whl", hash = "sha256:3438be012920a68f53518bf37ecb7c15df7215e15e36ed363a36204740c0e48c", size = 14357 },
-]
-
-[[package]]
-name = "ansys-api-tools-filetransfer"
-version = "0.2.0"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "grpcio" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/80/5c/533c993861b585c81b1b2f3c0dc68e56206d224d8b13d5ce6cdeac760eb3/ansys_api_tools_filetransfer-0.2.0.tar.gz", hash = "sha256:88b8b9e4916b10f908511e6472c6ed4fee9220343994f9506c8976031612fffb", size = 10831 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/75/d5/3d7a5391f9b7990ef74fff2a209303eb80c34978051a43ab2c41f2838792/ansys_api_tools_filetransfer-0.2.0-py3-none-any.whl", hash = "sha256:3417cd3f798660ae501c79fb8ad7d9c74a0ec786504db80d052145bf3b24eddf", size = 13874 },
-]
-
-[[package]]
-name = "ansys-fluent-core"
-version = "0.38.1"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "ansys-api-fluent" },
-    { name = "ansys-platform-instancemanagement" },
-    { name = "ansys-tools-common" },
-    { name = "ansys-tools-filetransfer" },
-    { name = "ansys-units" },
-    { name = "defusedxml" },
-    { name = "deprecated" },
-    { name = "docker" },
-    { name = "grpcio" },
-    { name = "grpcio-health-checking" },
-    { name = "grpcio-status" },
-    { name = "nltk" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pandas" },
-    { name = "pyyaml" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/74/cc/b8cda044d0ffe82e740ab0e5b51e6e1c0db71659dff8295457c7cea119e2/ansys_fluent_core-0.38.1.tar.gz", hash = "sha256:51c3548c4160f659e421fd0e90d54533eafe557591213ffdf0acf72893b355ec", size = 22116043 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b7/6f/84885c0b894745b7e2c55080be22f4fdac5e76b92c21cf243e8907315a24/ansys_fluent_core-0.38.1-py3-none-any.whl", hash = "sha256:00897364a8540f2a5d25e2655be06fec4a085ec887e2c79adf3399e584831731", size = 6699767 },
-]
-
-[[package]]
-name = "ansys-platform-instancemanagement"
-version = "1.1.2"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "ansys-api-platform-instancemanagement" },
-    { name = "importlib-metadata" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/10/16/c78dc035a3a357f0796e75b41aa7a77f6ff36f5866c57c3f99781ffc7bef/ansys_platform_instancemanagement-1.1.2.tar.gz", hash = "sha256:940d7a27d26e4c6d1228da5e139948fc4b1388f7cc7c3f5356b2b3b41e8d7c48", size = 15519 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/14/1f/a05b62b999ca895ea66e7dbc6242e8121ea578d71fff1055b6cea7e45a51/ansys_platform_instancemanagement-1.1.2-py3-none-any.whl", hash = "sha256:52afe4755c4233985a1f5f33cdb2a163a53db5cee75f04c3a4e47fc81e1d0bb1", size = 18470 },
-]
-
-[[package]]
-name = "ansys-tools-common"
-version = "0.5.0"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "platformdirs" },
-    { name = "requests" },
-    { name = "scooby" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/c1/2b/a8c625d424b5b933b6d27a325c1e4f4632bc7e2276204722058f65f7ab32/ansys_tools_common-0.5.0.tar.gz", hash = "sha256:2dd98e6fcb4a0ceb7e118b394575bffbd9c7b7dbcfc6d56ffdd03de79ce3145a", size = 323011 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/82/ba/81800ad31d57df6245ca6a9f63aaf39a649e3417a1a1f81d7572cb520765/ansys_tools_common-0.5.0-py3-none-any.whl", hash = "sha256:07f537d3095a731a6f9fd8909940ab1da2a4a108dedf52cd91596e28c685b5a1", size = 86936 },
-]
-
-[[package]]
-name = "ansys-tools-filetransfer"
-version = "0.2.2"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "ansys-api-tools-filetransfer" },
-    { name = "ansys-tools-common" },
-    { name = "grpcio" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/e5/fa/b34df81f3964ec7989fe38f841d26bceb39bc7756537ace2b4cd1e858edf/ansys_tools_filetransfer-0.2.2.tar.gz", hash = "sha256:d02b78b6509b51845d9b066794a44ed869dd74b1ef123f00df17ab3c72cffc3d", size = 7161 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/00/de/c30f80b73d3089e9263b6a78226838ac780e39bb059d7e1af6aafaa01d01/ansys_tools_filetransfer-0.2.2-py3-none-any.whl", hash = "sha256:f234d9b9c101b765c4a90d4a6d2e977c9d53dc2145bcb1fa8f17dcbfa36f131c", size = 10844 },
-]
-
-[[package]]
-name = "ansys-units"
-version = "0.10.1"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "pyyaml" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/22/08/7750e433e53513d13eb2ffc307fba2ae38f3dc30b7b65852cb26fb597037/ansys_units-0.10.1.tar.gz", hash = "sha256:aadaa03621c4043879a7a71a466f7fc6ce0c96f18cb0e2cbd81fd925a9c7a283", size = 39404 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/90/00/bfcb51b9701c1189b3e91ccab9d94f21b66a298edc6fa56fe712760031fd/ansys_units-0.10.1-py3-none-any.whl", hash = "sha256:606952f103cd281f77a16da71c45b6570c4b0bdbb3b98cd9f6ffdafd40d4b002", size = 51646 },
-]
-
-[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
@@ -409,47 +287,12 @@ wheels = [
 ]
 
 [[package]]
-name = "defusedxml"
-version = "0.7.1"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604 },
-]
-
-[[package]]
-name = "deprecated"
-version = "1.3.1"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "wrapt" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298 },
-]
-
-[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
 sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
 wheels = [
     { url = "https://mirrors.ustc.edu.cn/pypi/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
-]
-
-[[package]]
-name = "docker"
-version = "7.1.0"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "requests" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774 },
 ]
 
 [[package]]
@@ -478,106 +321,6 @@ dependencies = [
 sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/c4/73/5903c4b13beae98618d64eb9870c3fac4f605523dd0312ca5c80dadbd5b9/fastapi-0.135.2.tar.gz", hash = "sha256:88a832095359755527b7f63bb4c6bc9edb8329a026189eed83d6c1afcf419d56", size = 395833 }
 wheels = [
     { url = "https://mirrors.ustc.edu.cn/pypi/packages/8f/ea/18f6d0457f9efb2fc6fa594857f92810cadb03024975726db6546b3d6fcf/fastapi-0.135.2-py3-none-any.whl", hash = "sha256:0af0447d541867e8db2a6a25c23a8c4bd80e2394ac5529bd87501bbb9e240ca5", size = 117407 },
-]
-
-[[package]]
-name = "googleapis-common-protos"
-version = "1.73.1"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/a1/c0/4a54c386282c13449eca8bbe2ddb518181dc113e78d240458a68856b4d69/googleapis_common_protos-1.73.1.tar.gz", hash = "sha256:13114f0e9d2391756a0194c3a8131974ed7bffb06086569ba193364af59163b6", size = 147506 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/dc/82/fcb6520612bec0c39b973a6c0954b6a0d948aadfe8f7e9487f60ceb8bfa6/googleapis_common_protos-1.73.1-py3-none-any.whl", hash = "sha256:e51f09eb0a43a8602f5a915870972e6b4a394088415c79d79605a46d8e826ee8", size = 297556 },
-]
-
-[[package]]
-name = "grpcio"
-version = "1.78.0"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/5a/a8/690a085b4d1fe066130de97a87de32c45062cf2ecd218df9675add895550/grpcio-1.78.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:7cc47943d524ee0096f973e1081cb8f4f17a4615f2116882a5f1416e4cfe92b5", size = 5946986 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c7/1b/e5213c5c0ced9d2d92778d30529ad5bb2dcfb6c48c4e2d01b1f302d33d64/grpcio-1.78.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c3f293fdc675ccba4db5a561048cca627b5e7bd1c8a6973ffedabe7d116e22e2", size = 11816533 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/18/37/1ba32dccf0a324cc5ace744c44331e300b000a924bf14840f948c559ede7/grpcio-1.78.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10a9a644b5dd5aec3b82b5b0b90d41c0fa94c85ef42cb42cf78a23291ddb5e7d", size = 6519964 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ed/f5/c0e178721b818072f2e8b6fde13faaba942406c634009caf065121ce246b/grpcio-1.78.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4c5533d03a6cbd7f56acfc9cfb44ea64f63d29091e40e44010d34178d392d7eb", size = 7198058 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/5b/b2/40d43c91ae9cd667edc960135f9f08e58faa1576dc95af29f66ec912985f/grpcio-1.78.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff870aebe9a93a85283837801d35cd5f8814fe2ad01e606861a7fb47c762a2b7", size = 6727212 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ed/88/9da42eed498f0efcfcd9156e48ae63c0cde3bea398a16c99fb5198c885b6/grpcio-1.78.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:391e93548644e6b2726f1bb84ed60048d4bcc424ce5e4af0843d28ca0b754fec", size = 7300845 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/23/3f/1c66b7b1b19a8828890e37868411a6e6925df5a9030bfa87ab318f34095d/grpcio-1.78.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:df2c8f3141f7cbd112a6ebbd760290b5849cda01884554f7c67acc14e7b1758a", size = 8284605 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/94/c4/ca1bd87394f7b033e88525384b4d1e269e8424ab441ea2fba1a0c5b50986/grpcio-1.78.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bd8cb8026e5f5b50498a3c4f196f57f9db344dad829ffae16b82e4fdbaea2813", size = 7726672 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/41/09/f16e487d4cc65ccaf670f6ebdd1a17566b965c74fc3d93999d3b2821e052/grpcio-1.78.0-cp310-cp310-win32.whl", hash = "sha256:f8dff3d9777e5d2703a962ee5c286c239bf0ba173877cc68dc02c17d042e29de", size = 4076715 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/2a/32/4ce60d94e242725fd3bcc5673c04502c82a8e87b21ea411a63992dc39f8f/grpcio-1.78.0-cp310-cp310-win_amd64.whl", hash = "sha256:94f95cf5d532d0e717eed4fc1810e8e6eded04621342ec54c89a7c2f14b581bf", size = 4799157 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/86/c7/d0b780a29b0837bf4ca9580904dfb275c1fc321ded7897d620af7047ec57/grpcio-1.78.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2777b783f6c13b92bd7b716667452c329eefd646bfb3f2e9dabea2e05dbd34f6", size = 5951525 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c5/b1/96920bf2ee61df85a9503cb6f733fe711c0ff321a5a697d791b075673281/grpcio-1.78.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9dca934f24c732750389ce49d638069c3892ad065df86cb465b3fa3012b70c9e", size = 11830418 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/83/0c/7c1528f098aeb75a97de2bae18c530f56959fb7ad6c882db45d9884d6edc/grpcio-1.78.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:459ab414b35f4496138d0ecd735fed26f1318af5e52cb1efbc82a09f0d5aa911", size = 6524477 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/8d/52/e7c1f3688f949058e19a011c4e0dec973da3d0ae5e033909677f967ae1f4/grpcio-1.78.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:082653eecbdf290e6e3e2c276ab2c54b9e7c299e07f4221872380312d8cf395e", size = 7198266 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e5/61/8ac32517c1e856677282c34f2e7812d6c328fa02b8f4067ab80e77fdc9c9/grpcio-1.78.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85f93781028ec63f383f6bc90db785a016319c561cc11151fbb7b34e0d012303", size = 6730552 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/bd/98/b8ee0158199250220734f620b12e4a345955ac7329cfd908d0bf0fda77f0/grpcio-1.78.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f12857d24d98441af6a1d5c87442d624411db486f7ba12550b07788f74b67b04", size = 7304296 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/bd/0f/7b72762e0d8840b58032a56fdbd02b78fc645b9fa993d71abf04edbc54f4/grpcio-1.78.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5397fff416b79e4b284959642a4e95ac4b0f1ece82c9993658e0e477d40551ec", size = 8288298 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/24/ae/ae4ce56bc5bb5caa3a486d60f5f6083ac3469228faa734362487176c15c5/grpcio-1.78.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fbe6e89c7ffb48518384068321621b2a69cab509f58e40e4399fdd378fa6d074", size = 7730953 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b5/6e/8052e3a28eb6a820c372b2eb4b5e32d195c661e137d3eca94d534a4cfd8a/grpcio-1.78.0-cp311-cp311-win32.whl", hash = "sha256:6092beabe1966a3229f599d7088b38dfc8ffa1608b5b5cdda31e591e6500f856", size = 4076503 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/08/62/f22c98c5265dfad327251fa2f840b591b1df5f5e15d88b19c18c86965b27/grpcio-1.78.0-cp311-cp311-win_amd64.whl", hash = "sha256:1afa62af6e23f88629f2b29ec9e52ec7c65a7176c1e0a83292b93c76ca882558", size = 4799767 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/05/a9/8f75894993895f361ed8636cd9237f4ab39ef87fd30db17467235ed1c045/grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b", size = 5920143 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/55/06/0b78408e938ac424100100fd081189451b472236e8a3a1f6500390dc4954/grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a", size = 11803926 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/88/93/b59fe7832ff6ae3c78b813ea43dac60e295fa03606d14d89d2e0ec29f4f3/grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84", size = 6478628 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ed/df/e67e3734527f9926b7d9c0dde6cd998d1d26850c3ed8eeec81297967ac67/grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb", size = 7173574 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/a6/62/cc03fffb07bfba982a9ec097b164e8835546980aec25ecfa5f9c1a47e022/grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5", size = 6692639 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/bf/9a/289c32e301b85bdb67d7ec68b752155e674ee3ba2173a1858f118e399ef3/grpcio-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2045397e63a7a0ee7957c25f7dbb36ddc110e0cfb418403d110c0a7a68a844e9", size = 7268838 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/0e/79/1be93f32add280461fa4773880196572563e9c8510861ac2da0ea0f892b6/grpcio-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9f136fbafe7ccf4ac7e8e0c28b31066e810be52d6e344ef954a3a70234e1702", size = 8251878 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/65/65/793f8e95296ab92e4164593674ae6291b204bb5f67f9d4a711489cd30ffa/grpcio-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:748b6138585379c737adc08aeffd21222abbda1a86a0dca2a39682feb9196c20", size = 7695412 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/1c/9f/1e233fe697ecc82845942c2822ed06bb522e70d6771c28d5528e4c50f6a4/grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670", size = 4064899 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/4d/27/d86b89e36de8a951501fb06a0f38df19853210f341d0b28f83f4aa0ffa08/grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4", size = 4797393 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/29/f2/b56e43e3c968bfe822fa6ce5bca10d5c723aa40875b48791ce1029bb78c7/grpcio-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:e87cbc002b6f440482b3519e36e1313eb5443e9e9e73d6a52d43bd2004fcfd8e", size = 5920591 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/5d/81/1f3b65bd30c334167bfa8b0d23300a44e2725ce39bba5b76a2460d85f745/grpcio-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c41bc64626db62e72afec66b0c8a0da76491510015417c127bfc53b2fe6d7f7f", size = 11813685 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/0e/1c/bbe2f8216a5bd3036119c544d63c2e592bdf4a8ec6e4a1867592f4586b26/grpcio-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfffba826efcf366b1e3ccc37e67afe676f290e13a3b48d31a46739f80a8724", size = 6487803 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/16/5c/a6b2419723ea7ddce6308259a55e8e7593d88464ce8db9f4aa857aba96fa/grpcio-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:74be1268d1439eaaf552c698cdb11cd594f0c49295ae6bb72c34ee31abbe611b", size = 7173206 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/df/1e/b8801345629a415ea7e26c83d75eb5dbe91b07ffe5210cc517348a8d4218/grpcio-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be63c88b32e6c0f1429f1398ca5c09bc64b0d80950c8bb7807d7d7fb36fb84c7", size = 6693826 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/34/84/0de28eac0377742679a510784f049738a80424b17287739fc47d63c2439e/grpcio-1.78.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c586ac70e855c721bda8f548d38c3ca66ac791dc49b66a8281a1f99db85e452", size = 7277897 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ca/9c/ad8685cfe20559a9edb66f735afdcb2b7d3de69b13666fdfc542e1916ebd/grpcio-1.78.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:35eb275bf1751d2ffbd8f57cdbc46058e857cf3971041521b78b7db94bdaf127", size = 8252404 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/3c/05/33a7a4985586f27e1de4803887c417ec7ced145ebd069bc38a9607059e2b/grpcio-1.78.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:207db540302c884b8848036b80db352a832b99dfdf41db1eb554c2c2c7800f65", size = 7696837 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/73/77/7382241caf88729b106e49e7d18e3116216c778e6a7e833826eb96de22f7/grpcio-1.78.0-cp314-cp314-win32.whl", hash = "sha256:57bab6deef2f4f1ca76cc04565df38dc5713ae6c17de690721bdf30cb1e0545c", size = 4142439 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/48/b2/b096ccce418882fbfda4f7496f9357aaa9a5af1896a9a7f60d9f2b275a06/grpcio-1.78.0-cp314-cp314-win_amd64.whl", hash = "sha256:dce09d6116df20a96acfdbf85e4866258c3758180e8c49845d6ba8248b6d0bbb", size = 4929852 },
-]
-
-[[package]]
-name = "grpcio-health-checking"
-version = "1.78.0"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "grpcio" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/8e/ac/8eb871f4e47b11abfe45497e6187a582ec680ccd7232706d228474a8c7a5/grpcio_health_checking-1.78.0.tar.gz", hash = "sha256:78526d5c60b9b99fd18954b89f86d70033c702e96ad6ccc9749baf16136979b3", size = 17008 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/8e/30/dbaf47e2210697e2923b49eb62a6a2c07d5ee55bb40cff1e6cc0c5bb22e1/grpcio_health_checking-1.78.0-py3-none-any.whl", hash = "sha256:309798c098c5de72a9bff7172d788fdf309d246d231db9955b32e7c1c773fbeb", size = 19010 },
-]
-
-[[package]]
-name = "grpcio-status"
-version = "1.78.0"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/8a/cd/89ce482a931b543b92cdd9b2888805518c4620e0094409acb8c81dd4610a/grpcio_status-1.78.0.tar.gz", hash = "sha256:a34cfd28101bfea84b5aa0f936b4b423019e9213882907166af6b3bddc59e189", size = 13808 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/83/8a/1241ec22c41028bddd4a052ae9369267b4475265ad0ce7140974548dc3fa/grpcio_status-1.78.0-py3-none-any.whl", hash = "sha256:b492b693d4bf27b47a6c32590701724f1d3b9444b36491878fb71f6208857f34", size = 14523 },
 ]
 
 [[package]]
@@ -627,67 +370,12 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "9.0.0"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789 },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
 sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
 wheels = [
     { url = "https://mirrors.ustc.edu.cn/pypi/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
-]
-
-[[package]]
-name = "joblib"
-version = "1.5.3"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071 },
-]
-
-[[package]]
-name = "jpype1"
-version = "1.6.0"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/34/49/6090a131d84b22c6aae13b1853092028b060fd17da1af87c0e42ad69d50f/jpype1-1.6.0.tar.gz", hash = "sha256:2d46b2a14f8f0e6f17d8aa22b4fc3a64b2790851ebf1409ad79a37c698fd6e9a", size = 1057888 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/8e/95/524c67e2aafa301d6ffd21747847c5e9c9785ff8b39d90275ead2877dd0c/jpype1-1.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:533cf7ced58a4b74272f3d1e962fe33f305184d2fcb3856ca79867d5b6f0fb8b", size = 583402 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/13/61/88288a341292d3b76967587e59b674b5445678dcf60e8c921507bd70baa6/jpype1-1.6.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:597063698c074e5bf34e696626423a528cdf099989e22a837e889a0d671fd9e4", size = 468810 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/08/ed/18a16c6ae0ac5978fe93ad5c265719a311a613ba3dd4d96bd89e93fd2444/jpype1-1.6.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2f0cd698d160ba825952393b4d87911e7eedcbf5af381bb6438126de863f66b6", size = 512880 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e2/da/9854e41f4b301a52210254d24d5d62792e0700527f7940445d763d0d64c6/jpype1-1.6.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fcabb8cce3be16528bd26e4b73e41d7b8c778111f14de52c33c25e2a9d4c9a9f", size = 496509 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/74/85/2975be78a88678c9048d39141f39f1ced1b55e937e7854bfd824282ee176/jpype1-1.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f02c419d6cdd45ed5576d95f0ab4732371c760ba4b01ea9bd646b98b3c21a16f", size = 356591 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/7c/ff/688b8ecbce3c4fa8ee34bc364d447f372d2dcc9597742e7331a328b07f20/jpype1-1.6.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:40b523e11b22398a8ddb777f1e6e8d55108a631311f35b48b0ed0f4c9198d025", size = 583485 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/4b/2a/997c0381028998522ef9103a1730be40eee2c8eb5ca244a295f9d5c6a6e2/jpype1-1.6.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ae5927e441894d41b65e08390a0ea6a6512fe222c07aa33fbab623512092fdbd", size = 468977 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/2d/f9/e3b0a467b3ac2c4eeac5ca57764bf49a859b10f08f43e5179e1a283d2a9b/jpype1-1.6.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:9d85c2077172a32dd8ffde8711cb57c5bc351378ceb44dd8c3bdd80f27fa8caf", size = 512946 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b2/b4/1167be1572704fc365f31038a862afae26dda5006c7f4178f44c27779e37/jpype1-1.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5a02cbba4022a0aa47ee617bc12349457988c653491484a988dc8f4e6269dfc", size = 496609 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/25/a9/3ed33c24c86d234cb6fd5c6701b64f0a39ed4fd63fd5bd45ad8ce6ac72d9/jpype1-1.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:966daa892e6cd9ec3b2b92fd7a6d572687b29021e6d28fb73995a62ddd0a11eb", size = 356597 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/38/88/2156a27251492169f947850293d9870d49d784f1355fad7e920095636721/jpype1-1.6.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:5454322887505097c46f41521becf31cda2303f54e35cb42e20f1a180055a558", size = 582187 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/6b/5d/51bde8695cc3eabcc465779f6dc23b149194bbcdcb8d221a9572422053f4/jpype1-1.6.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cf646459023a0dd71b3cc3aeeb977225a93f94c97839bb4e6146977b166c7caf", size = 468341 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/7a/a1/50cdc2bf9e51c0828faabec6fad50d61aada5a57d0bc435f4db0c16eb2ca/jpype1-1.6.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:7a98b34bc68a117881382dffa9b02d5e1d0d94325f85d7f564c33cc9e9d2916b", size = 511724 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c4/a4/6038228e44cbcdb8f96ff2518cd6c577730f31fb62e9f46de7efdfabc2de/jpype1-1.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b56d7b662ce353c7f876e9ff3d4e775918348340795801e1f00c3b6241006264", size = 495897 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/8c/e4/af69d43779da0e49d37d7fd8a4a01bede03f6a3bab450eab1c10cf48e20e/jpype1-1.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:cf41134bc59c28de2721614ed00a34f76f69f2b525583a5c42fee5c7bae05d40", size = 355702 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/3f/1b/7167cfb702cfbcb17b0973150608f9cb92c3f409ebaaff655f7389617766/jpype1-1.6.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ce1da9ff01010a4529de194aecc053bfc8ab25440ea6b63579ef8c8d381da21d", size = 582384 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c0/48/8ae425d8842bc76eb51052bbea5941dac230c8f6b58614ef2b7cb2da1a74/jpype1-1.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4a387430cd4f3f68761013dca7f71b79d8d64b47dfd56eedcbd44c894d98d7f2", size = 468237 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ef/2f/dbdc15aa99404dda0315a9883add7422c9ac7acce28ce24b66c89052c2fb/jpype1-1.6.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:6c9d99f41a5d05a8a2b6aeda796f646904c1c2b68aed0cc9a3bbc165483d9e1e", size = 511905 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/00/0d/50fcdd6d3bb42a87cbda8b04fc72283a9c6d955ada0d011190ce31e0e027/jpype1-1.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:55ba7257988a69bee84f7cd1444131725d5447999149fdafdba25bf46e4b1a3f", size = 496001 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/4f/b8/25214a9ebecbd31447b685500dca5fe2ac070df38358d6823f591a8ce52e/jpype1-1.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:ef8dd72442d91cde7e5eefef24ab71323cdd4137283a59f79d265a6620f7d0ab", size = 355727 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/29/a0/b2347572998020de8ce3ee0a285a1b84b052b522e8d452ee9ad330570918/jpype1-1.6.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dc0c1c8b989b9857f87648980a746084b323858b0450225eab3642bb674645d6", size = 471150 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/7c/62/5e0f64a185f37303d0dd07e7b7a927cd5237fdc3c8176add949ed8cafaa2/jpype1-1.6.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:cbbba16381ccd23530ad4ef09f7b2b1b12bd7fd0f6ca9fe4c7b4e3da8fe4cf63", size = 514015 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/72/68/84050ed2679e2d2ee2030a60d3e5a59a29d0533cd03fd8d9891e36592b0f/jpype1-1.6.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1a3814e4f65d67e36bdb03b8851d5ece8d7a408aa3a24251ea0609bb8fba77dd", size = 497229 },
 ]
 
 [[package]]
@@ -809,25 +497,6 @@ wheels = [
 ]
 
 [[package]]
-name = "matlabengine"
-version = "25.2.2"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/ff/80/20ea22fc5483b14c7136231b3d71d01510a8bdb57c2a4fb1dad334013701/matlabengine-25.2.2.tar.gz", hash = "sha256:c7c92cb402628bf289ac3c53630d1c5a42544da8ce423dc2f423cc375ac95be8", size = 18813 }
-
-[[package]]
-name = "mph"
-version = "1.3.1"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "jpype1" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }, marker = "python_full_version >= '3.11'" },
-]
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/71/bf/ff27a123ef0b8121cba0db63f00ba680c0fb6a3001831fc182c460afd980/mph-1.3.1-py3-none-any.whl", hash = "sha256:4aa1e0fefbee537aff8a5932dc8436e156d99cff578a9992f26bb7c44179bad5", size = 65891 },
-]
-
-[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
@@ -843,21 +512,6 @@ source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
 sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343 }
 wheels = [
     { url = "https://mirrors.ustc.edu.cn/pypi/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963 },
-]
-
-[[package]]
-name = "nltk"
-version = "3.9.4"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "joblib" },
-    { name = "regex" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087 },
 ]
 
 [[package]]
@@ -1233,21 +887,6 @@ dependencies = [
 sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/10/48/dcb39417e903af8bc08e144a6adc594178ee42f276a858d570d3164c4262/posthog-7.10.3.tar.gz", hash = "sha256:dc624a07306dc2618dcfa9f9a706086db2efea33bb7ad0048625e5cf60e5401b", size = 187265 }
 wheels = [
     { url = "https://mirrors.ustc.edu.cn/pypi/packages/2c/ec/d0050e82b4be2126f4769612f0ef9734348cb736a23754ea238202285343/posthog-7.10.3-py3-none-any.whl", hash = "sha256:bbaeb45dbfd56143343cf93bf091eb500f9996b95b797f4bf99b42905da54fe7", size = 217019 },
-]
-
-[[package]]
-name = "protobuf"
-version = "6.33.6"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656 },
 ]
 
 [[package]]
@@ -1631,127 +1270,6 @@ wheels = [
 ]
 
 [[package]]
-name = "regex"
-version = "2026.3.32"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/81/93/5ab3e899c47fa7994e524447135a71cd121685a35c8fe35029005f8b236f/regex-2026.3.32.tar.gz", hash = "sha256:f1574566457161678297a116fa5d1556c5a4159d64c5ff7c760e7c564bf66f16", size = 415605 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/6f/87/ae29a505fdfcec85978f35d30e6de7c0ae37eaf7c287f6e88abd04be27b3/regex-2026.3.32-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:462a041d2160090553572f6bb0be417ab9bb912a08de54cb692829c871ee88c1", size = 489575 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/f9/fd/7a56c6a86213e321a309161673667091991630287d7490c5e9ec3db29607/regex-2026.3.32-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c3c6f6b027d10f84bfe65049028892b5740878edd9eae5fea0d1710b09b1d257", size = 291288 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/48/2f/ac2b481011b23f79994d4d80df03d9feccb64fbfc7bbe8dad2c3e8efc50c/regex-2026.3.32-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:879ae91f2928a13f01a55cfa168acedd2b02b11b4cd8b5bb9223e8cde777ca52", size = 289336 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/6e/a2/cf7dfef7a4182e84acbe8919ce7ff50e3545007c2743219e92271b2fbc1c/regex-2026.3.32-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:887a9fa74418d74d645281ee0edcf60694053bd1bc2ebc49eb5e66bfffc6d107", size = 786358 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/fb/cb/42bfeb4597206e3171e70c973ca1d39190b48f6cda7546c25f9cb283285f/regex-2026.3.32-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d571f0b2eec3513734ea31a16ce0f7840c0b85a98e7edfa0e328ed144f9ef78f", size = 854179 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/90/d8/9f4a7d7edffe7117de23b94696c52065b68e70267d71576d74429d598d9b/regex-2026.3.32-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ada7bd5bb6511d12177a7b00416ce55caee49fbf8c268f26b909497b534cacb", size = 898810 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/05/e6/80335c06ddf7fd7a28b97402ebe1ea4fe80a3aa162fba0f7364175f625d1/regex-2026.3.32-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:918db4e34a7ef3d0beee913fa54b34231cc3424676f1c19bdb85f01828d3cd37", size = 790605 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/38/0e/91436a89c1636090903d753d90b076784b11b8c67b79b3bde9851a45c4d7/regex-2026.3.32-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:69a847a6ffaa86e8af7b9e7037606e05a6f663deec516ad851e8e05d9908d16a", size = 786550 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/2b/fc/ea7364b5e9abd220cebf547f2f8a42044878e9d8b02b3a652f8b807c0cbc/regex-2026.3.32-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2c8d402ea3dfe674288fe3962016affd33b5b27213d2b5db1823ffa4de524c57", size = 770223 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/3b/86/aff4ad741e914cc493e7500431cdf14e51bc808b14f1f205469d353a970b/regex-2026.3.32-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d6b39a2cc5625bbc4fda18919a891eab9aab934eecf83660a90ce20c53621a9a", size = 774436 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/bf/e7/060779f504c92320f75b90caab4e57324816020986c27f57414b0a1ebcc9/regex-2026.3.32-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:f7cc00089b4c21847852c0ad76fb3680f9833b855a0d30bcec94211c435bff6b", size = 849400 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c8/8e/6544b27f70bfd14e9c50ff5527027acc9b8f9830d352a746f843da7b0627/regex-2026.3.32-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:fd03e38068faeef937cc6761a250a4aaa015564bd0d61481fefcf15586d31825", size = 757934 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/bc/6f/abf2234b3f51da1e693f13bb85e7dbb3bbdd07c04e12e0e105b9bc6006a6/regex-2026.3.32-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e006ea703d5c0f3d112b51ba18af73b58209b954acfe3d8da42eacc9a00e4be6", size = 838479 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/db/3c/653f43c3a3643fd221bfaf61ed4a4c8f0ccc25e31a8faa8f1558a892c22c/regex-2026.3.32-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6980ceb5c1049d4878632f08ba0bf7234c30e741b0dc9081da0f86eca13189d3", size = 778478 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/88/dd/5e6bd702d7efc3f2a29bf65dfa46f5159653b3c6f846ddf693e1a7f9a739/regex-2026.3.32-cp310-cp310-win32.whl", hash = "sha256:6128dd0793a87287ea1d8bf16b4250dd96316c464ee15953d5b98875a284d41e", size = 266343 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c4/89/39d04329e858956d2db1d08a10f02be8f6837c964663513ac4393158bef9/regex-2026.3.32-cp310-cp310-win_amd64.whl", hash = "sha256:5aa78c857c1731bdd9863923ffadc816d823edf475c7db6d230c28b53b7bdb5e", size = 278632 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b6/d8/c7e9ff3c2648408f4cda7224e195ad7a0d68724225d8d9a55eca9055504f/regex-2026.3.32-cp310-cp310-win_arm64.whl", hash = "sha256:34c905a721ddee0f84c99e3e3b59dd4a5564a6fe338222bc89dd4d4df166115c", size = 270593 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/92/c1/c68163a6ce455996db71e249a65234b1c9f79a914ea2108c6c9af9e1812a/regex-2026.3.32-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0d7855f5e59fcf91d0c9f4a51dc5d8847813832a2230c3e8e35912ccf20baaa2", size = 489568 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/96/9c/0bdd47733b832b5caa11e63df14dccdb311b41ab33c1221e249af4421f8f/regex-2026.3.32-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:18eb45f711e942c27dbed4109830bd070d8d618e008d0db39705f3f57070a4c6", size = 291287 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e1/ff/1977a595f15f8dc355f9cebd875dab67f3faeca1f36b905fe53305bbcaed/regex-2026.3.32-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ed3b8281c5d0944d939c82db4ec2300409dd69ee087f7a75a94f2e301e855fb4", size = 289325 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/0a/68/dfa21aef5af4a144702befeb5ff20ea9f9fbe40a4dfd08d56148b5b48b0a/regex-2026.3.32-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad5c53f2e8fcae9144009435ebe3d9832003508cf8935c04542a1b3b8deefa15", size = 790898 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/36/26/9424e43e0e31ac3ce1ba0e7232ee91e113a04a579c53331bc0f16a4a5bf7/regex-2026.3.32-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70c634e39c5cda0da05c93d6747fdc957599f7743543662b6dbabdd8d3ba8a96", size = 862462 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/63/a8/06573154ac891c6b55b74a88e0fb7c10081c20916b82dd0abc8cef938e13/regex-2026.3.32-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1e0f6648fd48f4c73d801c55ab976cd602e2da87de99c07bff005b131f269c6a", size = 906522 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e7/26/46673bb18448c51222c6272c850484a0092f364fae8d0315be9aa1e4baa7/regex-2026.3.32-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5e0fdb5744caf1036dec5510f543164f2144cb64932251f6dfd42fa872b7f9c", size = 798289 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/4d/cb/804f1bd5ff08687258e6a92b040aba9b770e626b8d3ba21fffdfa21db2db/regex-2026.3.32-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dab4178a0bc1ef13178832b12db7bc7f562e8f028b2b5be186e370090dc50652", size = 774823 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e5/94/28a58258f8d822fb949c8ff87fc7e5f2a346922360ec084c193b3c95e51c/regex-2026.3.32-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f95bd07f301135771559101c060f558e2cf896c7df00bec050ca7f93bf11585a", size = 781381 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c4/f3/71e69dbe0543586a3e3532cf36e8c9b38d6d93033161a9799c1e9090eb78/regex-2026.3.32-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:2dcca2bceb823c9cc610e57b86a265d7ffc30e9fe98548c609eba8bd3c0c2488", size = 855968 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/6d/99/850feec404a02b62e048718ec1b4b98b5c3848cd9ca2316d0bdb65a53f6a/regex-2026.3.32-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:567b57eb987547a23306444e4f6f85d4314f83e65c71d320d898aa7550550443", size = 762785 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/40/04/808ab0462a2d19b295a3b42134f5183692f798addfe6a8b6aa5f7c7a35b2/regex-2026.3.32-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:b6acb765e7c1f2fa08ac9057a33595e26104d7d67046becae184a8f100932dd9", size = 845797 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/06/53/8afcf0fd4bd55440b48442c86cddfe61b0d21c92d96e384c0c47d769f4c3/regex-2026.3.32-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c1ed17104d1be7f807fdec35ec99777168dd793a09510d753f8710590ba54cdd", size = 785200 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/99/4d/23d992ab4115456fec520d6c3aae39e0e33739b244ddb39aa4102a0f7ef0/regex-2026.3.32-cp311-cp311-win32.whl", hash = "sha256:c60f1de066eb5a0fd8ee5974de4194bb1c2e7692941458807162ffbc39887303", size = 266351 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/62/74/27c3cdb3a3fbbf67f7231b872877416ec817ae84271573d2fd14bf8723d3/regex-2026.3.32-cp311-cp311-win_amd64.whl", hash = "sha256:8fe14e24124ef41220e5992a0f09432f890037df6f93fd3d6b7a0feff2db16b2", size = 278639 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/0a/12/6a67bd509f38aec021d63096dbc884f39473e92adeb1e35d6fb6d89cbd59/regex-2026.3.32-cp311-cp311-win_arm64.whl", hash = "sha256:ded4fc0edf3de792850cb8b04bbf3c5bd725eeaf9df4c27aad510f6eed9c4e19", size = 270594 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/38/94/69492c45b0e61b027109d8433a5c3d4f7a90709184c057c7cfc60acb1bfa/regex-2026.3.32-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ad8d372587e659940568afd009afeb72be939c769c552c9b28773d0337251391", size = 490572 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/92/0a/7dcffeebe0fcac45a1f9caf80712002d3cbd66d7d69d719315ee142b280f/regex-2026.3.32-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3f5747501b69299c6b0b047853771e4ed390510bada68cb16da9c9c2078343f7", size = 292078 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e3/ec/988486058ef49eb931476419bae00f164c4ceb44787c45dc7a54b7de0ea4/regex-2026.3.32-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:db976be51375bca900e008941639448d148c655c9545071965d0571ecc04f5d0", size = 289786 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/4a/cf/1955bb5567bc491bd63068e17f75ab0c9ff5e9d08466beec7e347f5e768d/regex-2026.3.32-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66a5083c3ffe5a5a95f8281ea47a88072d4f24001d562d1d9d28d4cdc005fec5", size = 796431 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/27/8a/67fcbca511b792107540181ee0690df6de877bfbcb41b7ecae7028025ca5/regex-2026.3.32-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e83ce8008b48762be296f1401f19afd9ea29f3d035d1974e0cecb74e9afbd1df", size = 865785 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c2/59/0677bc44f2c28305edcabc11933777b9ad34e9e8ded7ba573d24e4bc3ee7/regex-2026.3.32-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3aa21bad31db904e0b9055e12c8282df62d43169c4a9d2929407060066ebc74", size = 913593 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/0a/fe/661043d1c263b0d9d10c6ff4e9c9745f3df9641c62b51f96a3473638e7ce/regex-2026.3.32-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f54840bea73541652f1170dc63402a5b776fc851ad36a842da9e5163c1f504a0", size = 801512 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ff/27/74c986061380e1811a46cf04cdf9c939db9f8c0e63953eddfe37ffd633ea/regex-2026.3.32-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2ffbadc647325dd4e3118269bda93ded1eb5f5b0c3b7ba79a3da9fbd04f248e9", size = 776182 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b6/c8/d833397b70cd1bacfcdc0a611f0e2c1f5b91fee8eedd88affcee770cbbb6/regex-2026.3.32-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:66d3126afe7eac41759cd5f0b3b246598086e88e70527c0d68c9e615b81771c4", size = 785837 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e0/53/fa226b72989b5b93db6926fab5478115e085dfcf077e18d2cb386be0fd23/regex-2026.3.32-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f785f44a44702dea89b28bce5bc82552490694ce4e144e21a4f0545e364d2150", size = 860612 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/04/28/bdd2fc0c055a1b15702bd4084829bbb6b06095f27990e5bee52b2898ea03/regex-2026.3.32-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:b7836aa13721dbdef658aebd11f60d00de633a95726521860fe1f6be75fa225a", size = 765285 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b4/da/21f5e2a35a191b27e5a47cccb3914c99e139b49b1342d3f36e64e8cc60f7/regex-2026.3.32-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5336b1506142eb0f23c96fb4a34b37c4fefd4fed2a7042069f3c8058efe17855", size = 851963 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/18/f4/04ed04ebf335a44083695c22772be6a42efa31900415555563acf02cb4de/regex-2026.3.32-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b56993a7aeb4140c4770f4f7965c9e5af4f024457d06e23c01b0d47501cb18ed", size = 788332 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/21/25/5355908f479d0dc13d044f88270cdcabc8723efc12e4c2b19e5a94ff1a96/regex-2026.3.32-cp312-cp312-win32.whl", hash = "sha256:d363660f9ef8c734495598d2f3e527fb41f745c73159dc0d743402f049fb6836", size = 266847 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/00/e5/3be71c781a031db5df00735b613895ad5fdbf86c6e3bbea5fbbd7bfb5902/regex-2026.3.32-cp312-cp312-win_amd64.whl", hash = "sha256:c9f261ad3cd97257dc1d9355bfbaa7dd703e06574bffa0fa8fe1e31da915ee38", size = 278034 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/31/5f/27f1e0b1eea4faa99c66daca34130af20c44fae0237bbc98b87999dbc4a8/regex-2026.3.32-cp312-cp312-win_arm64.whl", hash = "sha256:89e50667e7e8c0e7903e4d644a2764fffe9a3a5d6578f72ab7a7b4205bf204b7", size = 270673 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/bd/ba/9c1819f302b42b5fbd4139ead6280e9ec37d19bbe33379df0039b2a57bb4/regex-2026.3.32-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c6d9c6e783b348f719b6118bb3f187b2e138e3112576c9679eb458cc8b2e164b", size = 490394 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/5b/0b/f62b0ce79eb83ca82fffea1736289d29bc24400355968301406789bcebd2/regex-2026.3.32-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0f21ae18dfd15752cdd98d03cbd7a3640be826bfd58482a93f730dbd24d7b9fb", size = 291993 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e7/d8/ba0f8f81f88cd20c0b27acc123561ac5495ea33f800f0b8ebed2038b23eb/regex-2026.3.32-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:844d88509c968dd44b30daeefac72b038b1bf31ac372d5106358ab01d393c48b", size = 289618 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/fd/0d/b47a0e68bc511c195ff129c0311a4cd79b954b8676193a9d03a97c623a91/regex-2026.3.32-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8fc918cd003ba0d066bf0003deb05a259baaaab4dc9bd4f1207bbbe64224857a", size = 796427 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/51/d7/32b05aa8fde7789ba316533c0f30e87b6b5d38d6d7f8765eadc5aab84671/regex-2026.3.32-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbc458a292aee57d572075f22c035fa32969cdb7987d454e3e34d45a40a0a8b4", size = 865850 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/dc/67/828d8095501f237b83f630d4069eea8c0e5cb6a204e859cf0b67c223ce12/regex-2026.3.32-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:987cdfcfb97a249abc3601ad53c7de5c370529f1981e4c8c46793e4a1e1bfe8e", size = 913578 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/0f/f8/acf1eb80f58852e85bd39a6ddfa78ce2243ddc8de8da7582e6ba657da593/regex-2026.3.32-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5d88fa37ba5e8a80ca8d956b9ea03805cfa460223ac94b7d4854ee5e30f3173", size = 801536 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/9f/05/986cdf8d12693451f5889aaf4ea4f65b2c49b1152ae814fa1fb75439e40b/regex-2026.3.32-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d082be64e51671dd5ee1c208c92da2ddda0f2f20d8ef387e57634f7e97b6aae", size = 776226 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/32/02/945a6a2348ca1c6608cb1747275c8affd2ccd957d4885c25218a86377912/regex-2026.3.32-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c1d7fa44aece1fa02b8927441614c96520253a5cad6a96994e3a81e060feed55", size = 785933 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/53/12/c5bab6cc679ad79a45427a98c4e70809586ac963c5ad54a9217533c4763e/regex-2026.3.32-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d478a2ca902b6ef28ffc9521e5f0f728d036abe35c0b250ee8ae78cfe7c5e44e", size = 860671 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/bf/68/8d85f98c2443469facabef62b82b851d369b13f92bec2ca7a3808deaa47b/regex-2026.3.32-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2820d2231885e97aff0fcf230a19ebd5d2b5b8a1ba338c20deb34f16db1c7897", size = 765335 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/89/a7/d8a9c270916107a501fca63b748547c6c77e570d19f16a29b557ce734f3d/regex-2026.3.32-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc8ced733d6cd9af5e412f256a32f7c61cd2d7371280a65c689939ac4572499f", size = 851913 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/f4/8e/03d392b26679914ccf21f83d18ad4443232d2f8c3e2c30a962d4e3918d9c/regex-2026.3.32-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:847087abe98b3c1ebf1eb49d6ef320dbba75a83ee4f83c94704580f1df007dd4", size = 788447 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/cf/df/692227d23535a50604333068b39eb262626db780ab1e1b19d83fc66853aa/regex-2026.3.32-cp313-cp313-win32.whl", hash = "sha256:d21a07edddb3e0ca12a8b8712abc8452481c3d3db19ae87fc94e9842d005964b", size = 266834 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b9/37/13e4e56adc16ba607cffa1fe880f233eb9ded8ab8a8580619683c9e4ce48/regex-2026.3.32-cp313-cp313-win_amd64.whl", hash = "sha256:3c054e39a9f85a3d76c62a1d50c626c5e9306964eaa675c53f61ff7ec1204bbb", size = 277972 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ab/1c/80a86dbb2b416fec003b1801462bdcebbf1d43202ed5acb176e99c1ba369/regex-2026.3.32-cp313-cp313-win_arm64.whl", hash = "sha256:b2e9c2ea2e93223579308263f359eab8837dc340530b860cb59b713651889f14", size = 270649 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/58/08/e38372da599dc1c39c599907ec535016d110034bd3701ce36554f59767ef/regex-2026.3.32-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5d86e3fb08c94f084a625c8dc2132a79a3a111c8bf6e2bc59351fa61753c2f6e", size = 494495 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/5f/27/6e29ece8c9ce01001ece1137fa21c8707529c2305b22828f63623b0eb262/regex-2026.3.32-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:b6f366a5ef66a2df4d9e68035cfe9f0eb8473cdfb922c37fac1d169b468607b0", size = 293988 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e1/98/8752e18bb87a2fe728b73b0f83c082eb162a470766063f8028759fb26844/regex-2026.3.32-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b8fca73e16c49dd972ce3a88278dfa5b93bf91ddef332a46e9443abe21ca2f7c", size = 292634 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/7f/7b/d7729fe294e23e9c7c3871cb69d49059fa7d65fd11e437a2cbea43f6615d/regex-2026.3.32-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b953d9d496d19786f4d46e6ba4b386c6e493e81e40f9c5392332458183b0599d", size = 810532 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/fd/49/4dae7b000659f611b17b9c1541fba800b0569e4060debc4635ef1b23982c/regex-2026.3.32-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b565f25171e04d4fad950d1fa837133e3af6ea6f509d96166eed745eb0cf63bc", size = 871919 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/83/85/aa8ad3977b9399861db3df62b33fe5fef6932ee23a1b9f4f357f58f2094b/regex-2026.3.32-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f28eac18a8733a124444643a66ac96fef2c0ad65f50034e0a043b90333dc677f", size = 916550 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c8/c0/6379d7f5b59ff0656ba49cf666d5013ecee55e83245275b310b0ffc79143/regex-2026.3.32-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7cdd508664430dd51b8888deb6c5b416d8de046b2e11837254378d31febe4a98", size = 814988 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/2c/af/2dfddc64074bd9b70e27e170ee9db900542e2870210b489ad4471416ba86/regex-2026.3.32-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5c35d097f509cf7e40d20d5bee548d35d6049b36eb9965e8d43e4659923405b9", size = 786337 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/eb/2f/4eb8abd705236402b4fe0e130971634deffb1855e2028bf02a2b7c0e841c/regex-2026.3.32-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:85c9b0c131427470a6423baa0a9330be6fd8c3630cc3ee6fdee03360724cbec5", size = 800029 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/3e/2c/77d9ca2c9df483b51b4b1291c96d79c9ae301077841c4db39bc822f6b4c6/regex-2026.3.32-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:e50af656c15e2723eeb7279c0837e07accc594b95ec18b86821a4d44b51b24bf", size = 865843 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/48/10/306f477a509f4eed699071b1f031d89edd5a2b5fa28c8ede5b2638eaba82/regex-2026.3.32-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:4bc32b4dbdb4f9f300cf9f38f8ea2ce9511a068ffaa45ac1373ee7a943f1d810", size = 772473 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/f4/f6/54bd83ec46ac037de2beb049afc9dd5d2769c6ecaadf7856254ce610e62a/regex-2026.3.32-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e3e5d1802cba785210a4a800e63fcee7a228649a880f3bf7f2aadccb151a834b", size = 856805 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/37/e8/ee0e7d14de1fc6582d5782f072db6c61465a38a4142f88e175dda494b536/regex-2026.3.32-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ef250a3f5e93182193f5c927c5e9575b2cb14b80d03e258bc0b89cc5de076b60", size = 801875 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/8a/06/0fa9daca59d07b6aabd8e0468d3b86fd578576a157206fbcddbfc2298f7d/regex-2026.3.32-cp313-cp313t-win32.whl", hash = "sha256:9cf7036dfa2370ccc8651521fcbb40391974841119e9982fa312b552929e6c85", size = 269892 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/13/47/77f16b5ad9f10ca574f03d84a354b359b0ac33f85054f2f2daafc9f7b807/regex-2026.3.32-cp313-cp313t-win_amd64.whl", hash = "sha256:c940e00e8d3d10932c929d4b8657c2ea47d2560f31874c3e174c0d3488e8b865", size = 281318 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c6/47/db4446faaea8d01c8315c9c89c7dc6abbb3305e8e712e9b23936095c4d58/regex-2026.3.32-cp313-cp313t-win_arm64.whl", hash = "sha256:ace48c5e157c1e58b7de633c5e257285ce85e567ac500c833349c363b3df69d4", size = 272366 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/32/68/ff024bf6131b7446a791a636dbbb7fa732d586f33b276d84b3460ea49393/regex-2026.3.32-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a416ee898ecbc5d8b283223b4cf4d560f93244f6f7615c1bd67359744b00c166", size = 490430 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/61/72/039d9164817ee298f2a2d0246001afe662241dcbec0eedd1fe03e2a2555e/regex-2026.3.32-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d76d62909bfb14521c3f7cfd5b94c0c75ec94b0a11f647d2f604998962ec7b6c", size = 291948 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/06/9d/77f684d90ffe3e99b828d3cabb87a0f1601d2b9decd1333ff345809b1d02/regex-2026.3.32-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:631f7d95c83f42bccfe18946a38ad27ff6b6717fb4807e60cf24860b5eb277fc", size = 289786 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/83/70/bd76069a0304e924682b2efd8683a01617a7e1da9b651af73039d8da76a4/regex-2026.3.32-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12917c6c6813ffcdfb11680a04e4d63c5532b88cf089f844721c5f41f41a63ad", size = 796672 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/80/31/c2d7d9a5671e111a2c16d57e0cb03e1ce35b28a115901590528aa928bb5b/regex-2026.3.32-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3e221b615f83b15887636fcb90ed21f1a19541366f8b7ba14ba1ad8304f4ded4", size = 866556 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/d7/b9/9921a31931d0bc3416ac30205471e0e2ed60dcbd16fc922bbd69b427322b/regex-2026.3.32-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4f9ae4755fa90f1dc2d0d393d572ebc134c0fe30fcfc0ab7e67c1db15f192041", size = 912787 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/41/ab/2c1bc8ab99f63cdabdbc7823af8f4cfcd6ddbb2babf01861826c3f1ad44d/regex-2026.3.32-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a094e9dcafedfb9d333db5cf880304946683f43a6582bb86688f123335122929", size = 800879 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/49/e5/0be716eb2c0b2ae3a439e44432534e82b2f81848af64cb21c0473ad8ae46/regex-2026.3.32-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c1cecea3e477af105f32ef2119b8d895f297492e41d317e60d474bc4bffd62ff", size = 776332 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/26/80/114a61bd25dec7d1070930eaef82aadf9b05961a37629e7cca7bc3fc2257/regex-2026.3.32-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f26262900edd16272b6360014495e8d68379c6c6e95983f9b7b322dc928a1194", size = 786384 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/0c/78/be0a6531f8db426e8e60d6356aeef8e9cc3f541655a648c4968b63c87a88/regex-2026.3.32-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1cb22fa9ee6a0acb22fc9aecce5f9995fe4d2426ed849357d499d62608fbd7f9", size = 861381 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/45/b1/e5076fbe45b8fb39672584b1b606d512f5bd3a43155be68a95f6b88c1fc5/regex-2026.3.32-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:9b9118a78e031a2e4709cd2fcc3028432e89b718db70073a8da574c249b5b249", size = 765434 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/a3/da/fd65d68b897f8b52b1390d20d776fa753582484724a9cb4f4c26de657ae5/regex-2026.3.32-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:b193ed199848aa96618cd5959c1582a0bf23cd698b0b900cb0ffe81b02c8659c", size = 851501 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e8/d6/1e9c991c32022a9312e9124cc974961b3a2501338de2cd1cce75a3612d7a/regex-2026.3.32-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:10fb2aaae1aaadf7d43c9f3c2450404253697bf8b9ce360bd5418d1d16292298", size = 788076 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/f0/5b/b23c72f6d607cbb24ef42acf0c7c2ef4eee1377a9f7ba43b312f889edfbb/regex-2026.3.32-cp314-cp314-win32.whl", hash = "sha256:110ba4920721374d16c4c8ea7ce27b09546d43e16aea1d7f43681b5b8f80ba61", size = 272255 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/2a/ec/32bbcc42366097a8cea2c481e02964be6c6fa5ccfb0fa9581686af0bec5f/regex-2026.3.32-cp314-cp314-win_amd64.whl", hash = "sha256:245667ad430745bae6a1e41081872d25819d86fbd9e0eec485ba00d9f78ad43d", size = 281160 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/6c/e4/89038a028cb68e719fa03ab1ad603649fc199bcda12270d2ac7b471b8f5d/regex-2026.3.32-cp314-cp314-win_arm64.whl", hash = "sha256:1ca02ff0ef33e9d8276a1fcd6d90ff6ea055a32c9149c0050b5b67e26c6d2c51", size = 273688 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/30/6e/87caccd608837a1fa4f8c7edc48e206103452b9bbc94fc724fa39340e807/regex-2026.3.32-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:51fb7e26f91f9091fd8ec6a946f99b15d3bc3667cb5ddc73dd6cb2222dd4a1cc", size = 494506 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/16/53/a922e6b24694d70bdd68fc3fd076950e15b1b418cff9d2cc362b3968d86f/regex-2026.3.32-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:51a93452034d671b0e21b883d48ea66c5d6a05620ee16a9d3f229e828568f3f0", size = 293986 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/60/e4/0cb32203c1aebad0577fcd5b9af1fe764869e617d5234bc6a0ad284299ea/regex-2026.3.32-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:03c2ebd15ff51e7b13bb3dc28dd5ac18cd39e59ebb40430b14ae1a19e833cff1", size = 292677 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/f0/f8/5006b70291469d4174dd66ad162802e2f68419c0f2a7952d0c76c1288cfa/regex-2026.3.32-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5bf2f3c2c5bd8360d335c7dcd4a9006cf1dabae063ee2558ee1b07bbc8a20d88", size = 810661 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b2/9b/438763a20d22cd1f65f95c8f030dd25df2d80a941068a891d21a5f240456/regex-2026.3.32-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a4a3189a99ecdd1c13f42513ab3fc7fa8311b38ba7596dd98537acb8cd9acc3", size = 872156 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/6c/5b/1341287887ac982ed9f5f60125e440513ffe354aa7e3681940495af7c12a/regex-2026.3.32-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3c0bbfbd38506e1ea96a85da6782577f06239cb9fcf9696f1ea537c980c0680b", size = 916749 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/42/e2/1d2b48b8e94debfffc6fefb84d2a86a178cc208652a1d6493d5f29821c70/regex-2026.3.32-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8aaf8ee8f34b677f90742ca089b9c83d64bdc410528767273c816a863ed57327", size = 814788 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/a6/d9/7dacb34c43adaeb954518d851f3e5d3ce495ac00a9d6010e3b4b59917c4a/regex-2026.3.32-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3ea568832eca219c2be1721afa073c1c9eb8f98a9733fdedd0a9747639fc22a5", size = 786594 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ea/72/28295068c92dbd6d3ce4fd22554345cf504e957cc57dadeda4a64fa86a57/regex-2026.3.32-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e4c8fa46aad1a11ae2f8fcd1c90b9d55e18925829ac0d98c5bb107f93351745", size = 800167 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ca/17/b10745adeca5b8d52da050e7c746137f5d01dabc6dbbe6e8d9d821dc65c1/regex-2026.3.32-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0cec365d44835b043d7b3266487797639d07d621bec9dc0ea224b00775797cc1", size = 865906 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/45/9d/1acbcce765044ac0c87f453f4876e0897f7a61c10315262f960184310798/regex-2026.3.32-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:09e26cad1544d856da85881ad292797289e4406338afe98163f3db9f7fac816c", size = 772642 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/24/41/1ef8b4811355ad7b9d7579d3aeca00f18b7bc043ace26c8c609b9287346d/regex-2026.3.32-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:6062c4ef581a3e9e503dccf4e1b7f2d33fdc1c13ad510b287741ac73bc4c6b27", size = 856927 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/97/b1/0dc1d361be80ec1b8b707ada041090181133a7a29d438e432260a4b26f9a/regex-2026.3.32-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88ebc0783907468f17fca3d7821b30f9c21865a721144eb498cb0ff99a67bcac", size = 801910 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b5/db/1a23f767fa250844772a9464306d34e0fafe2c317303b88a1415096b6324/regex-2026.3.32-cp314-cp314t-win32.whl", hash = "sha256:e480d3dac06c89bc2e0fd87524cc38c546ac8b4a38177650745e64acbbcfdeba", size = 275714 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c2/2b/616d31b125ca76079d74d6b1d84ec0860ffdb41c379151135d06e35a8633/regex-2026.3.32-cp314-cp314t-win_amd64.whl", hash = "sha256:67015a8162d413af9e3309d9a24e385816666fbf09e48e3ec43342c8536f7df6", size = 285722 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/7e/91/043d9a00d6123c5fa22a3dc96b10445ce434a8110e1d5e53efb01f243c8b/regex-2026.3.32-cp314-cp314t-win_arm64.whl", hash = "sha256:1a6ac1ed758902e664e0d95c1ee5991aa6fb355423f378ed184c6ec47a1ec0e9", size = 275700 },
-]
-
-[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
@@ -1926,30 +1444,21 @@ wheels = [
 ]
 
 [[package]]
-name = "scooby"
-version = "0.11.0"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/d1/d1/a28f3be1503a9c474a4878424bbeb93a55a2ec7d0cb66559aa258e690aea/scooby-0.11.0.tar.gz", hash = "sha256:3dfacc6becf2d6558efa4b625bae3b844ced5d256f3143ebf774e005367e712a", size = 22102 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/a3/bb/bbae36d06c0fd670e8373da67096cd57058b57c9bad7d92969b5e3b730af/scooby-0.11.0-py3-none-any.whl", hash = "sha256:a79663d1a7711eb104e4b2935988ea1ed5f7be6b7288fad23b4fba7462832f9d", size = 19877 },
-]
-
-[[package]]
 name = "sim-ltspice"
 version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/fc/888eb1b6cab101663944fd74c16b3b42552b913a5a0e657432727f9a46cf/sim_ltspice-0.2.2.tar.gz", hash = "sha256:dd01409560b717fd7938e28a41335cb3b82dfc947a4413972e5fda963c590f92", size = 179553 }
+sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/d0/fc/888eb1b6cab101663944fd74c16b3b42552b913a5a0e657432727f9a46cf/sim_ltspice-0.2.2.tar.gz", hash = "sha256:dd01409560b717fd7938e28a41335cb3b82dfc947a4413972e5fda963c590f92", size = 179553 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/35/1e7aa4a4d9ba6324facb21f311b0f0d6591c089f47f436663e3d7dc44104/sim_ltspice-0.2.2-py3-none-any.whl", hash = "sha256:98269dc1964da4741e5b299257e1e25391b90cf7d30bd64cc91b54a5c345855d", size = 45837 },
+    { url = "https://mirrors.ustc.edu.cn/pypi/packages/5c/35/1e7aa4a4d9ba6324facb21f311b0f0d6591c089f47f436663e3d7dc44104/sim_ltspice-0.2.2-py3-none-any.whl", hash = "sha256:98269dc1964da4741e5b299257e1e25391b90cf7d30bd64cc91b54a5c345855d", size = 45837 },
 ]
 
 [[package]]
 name = "sim-runtime"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1965,18 +1474,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-comsol = [
-    { name = "mph" },
-]
 dev = [
     { name = "pytest" },
     { name = "ruff" },
-]
-fluent = [
-    { name = "ansys-fluent-core" },
-]
-matlab = [
-    { name = "matlabengine" },
 ]
 pybamm = [
     { name = "pybamm" },
@@ -1984,13 +1484,10 @@ pybamm = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ansys-fluent-core", marker = "extra == 'fluent'", specifier = ">=0.37,<0.39" },
     { name = "click", specifier = ">=8.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "lxml", specifier = ">=5.0" },
-    { name = "matlabengine", marker = "extra == 'matlab'" },
-    { name = "mph", marker = "extra == 'comsol'", specifier = ">=1.2,<2.0" },
     { name = "pillow", specifier = ">=10" },
     { name = "pybamm", marker = "extra == 'pybamm'", specifier = ">=24.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -2001,7 +1498,7 @@ requires-dist = [
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "uvicorn", specifier = ">=0.34" },
 ]
-provides-extras = ["fluent", "matlab", "comsol", "pybamm", "dev"]
+provides-extras = ["pybamm", "dev"]
 
 [[package]]
 name = "six"
@@ -2092,18 +1589,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tqdm"
-version = "4.67.3"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374 },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
@@ -2157,92 +1642,6 @@ wheels = [
 ]
 
 [[package]]
-name = "wrapt"
-version = "2.1.2"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/da/d2/387594fb592d027366645f3d7cc9b4d7ca7be93845fbaba6d835a912ef3c/wrapt-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b7a86d99a14f76facb269dc148590c01aaf47584071809a70da30555228158c", size = 60669 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c9/18/3f373935bc5509e7ac444c8026a56762e50c1183e7061797437ca96c12ce/wrapt-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a819e39017f95bf7aede768f75915635aa8f671f2993c036991b8d3bfe8dbb6f", size = 61603 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c2/7a/32758ca2853b07a887a4574b74e28843919103194bb47001a304e24af62f/wrapt-2.1.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5681123e60aed0e64c7d44f72bbf8b4ce45f79d81467e2c4c728629f5baf06eb", size = 113632 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/1d/d5/eeaa38f670d462e97d978b3b0d9ce06d5b91e54bebac6fbed867809216e7/wrapt-2.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8b28e97a44d21836259739ae76284e180b18abbb4dcfdff07a415cf1016c3e", size = 115644 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e3/09/2a41506cb17affb0bdf9d5e2129c8c19e192b388c4c01d05e1b14db23c00/wrapt-2.1.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cef91c95a50596fcdc31397eb6955476f82ae8a3f5a8eabdc13611b60ee380ba", size = 112016 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/64/15/0e6c3f5e87caadc43db279724ee36979246d5194fa32fed489c73643ba59/wrapt-2.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dad63212b168de8569b1c512f4eac4b57f2c6934b30df32d6ee9534a79f1493f", size = 114823 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/56/b2/0ad17c8248f4e57bedf44938c26ec3ee194715f812d2dbbd9d7ff4be6c06/wrapt-2.1.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d307aa6888d5efab2c1cde09843d48c843990be13069003184b67d426d145394", size = 111244 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ff/04/bcdba98c26f2c6522c7c09a726d5d9229120163493620205b2f76bd13c01/wrapt-2.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c87cf3f0c85e27b3ac7d9ad95da166bf8739ca215a8b171e8404a2d739897a45", size = 113307 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/0e/1b/5e2883c6bc14143924e465a6fc5a92d09eeabe35310842a481fb0581f832/wrapt-2.1.2-cp310-cp310-win32.whl", hash = "sha256:d1c5fea4f9fe3762e2b905fdd67df51e4be7a73b7674957af2d2ade71a5c075d", size = 57986 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/42/5a/4efc997bccadd3af5749c250b49412793bc41e13a83a486b2b54a33e240c/wrapt-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:d8f7740e1af13dff2684e4d56fe604a7e04d6c94e737a60568d8d4238b9a0c71", size = 60336 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c1/f5/a2bb833e20181b937e87c242645ed5d5aa9c373006b0467bfe1a35c727d0/wrapt-2.1.2-cp310-cp310-win_arm64.whl", hash = "sha256:1c6cc827c00dc839350155f316f1f8b4b0c370f52b6a19e782e2bda89600c7dc", size = 58757 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554 },
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993 },
-]
-
-[[package]]
 name = "xarray"
 version = "2025.6.1"
 source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
@@ -2275,13 +1674,4 @@ dependencies = [
 sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/0f/03/e3353b72e518574b32993989d8f696277bf878e9d508c7dd22e86c0dab5b/xarray-2026.2.0.tar.gz", hash = "sha256:978b6acb018770554f8fd964af4eb02f9bcc165d4085dbb7326190d92aa74bcf", size = 3111388 }
 wheels = [
     { url = "https://mirrors.ustc.edu.cn/pypi/packages/99/92/545eb2ca17fc0e05456728d7e4378bfee48d66433ae3b7e71948e46826fb/xarray-2026.2.0-py3-none-any.whl", hash = "sha256:e927d7d716ea71dea78a13417970850a640447d8dd2ceeb65c5687f6373837c9", size = 1405358 },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://mirrors.ustc.edu.cn/pypi/simple" }
-sdist = { url = "https://mirrors.ustc.edu.cn/pypi/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547 }
-wheels = [
-    { url = "https://mirrors.ustc.edu.cn/pypi/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276 },
 ]


### PR DESCRIPTION
Phase 0 of the plugin extraction refactor. No driver code moves yet; this lays every piece of plumbing the rest of the refactor depends on. Tracking issues live in the private planning repo.

## What lands

### CLI surface

* **`sim plugin {list, info, install, uninstall, update, bundle, sync-skills, doctor}`** — the new top-level group for managing solver plugins. `install` accepts six source types: bare name (HTTPS-only via the public index), `name@version`, direct wheel/sdist URL, local wheel/sdist file, local source directory, and `git+https://...`. `bundle` and `--offline` give air-gapped flows. `sync-skills` materializes installed plugins' bundled skill dirs into `.claude/skills/`.
* **`sim init` + `sim setup [--dry-run] [--offline]`** — file-based bootstrap. `init` writes a starter `sim.toml`; `setup` reads it and installs every declared plugin in one shot. `[[sim.plugins]]` entries can pin via `wheel = ...`, `git = ...`, or `version = ...`.
* **`sim config validate`** — schema check against `sim.toml`.
* **`sim describe [--json] [<command>] [--schema X] [--error-codes]`** — full CLI manifest for agent discovery. One call returns every command, flag, example invocation, output schema, and the closed enum of error codes. Click introspection means no docs/runtime drift.
* **Top-level `--no-interactive`** flag (auto-on when stdin is not a TTY). The current command surface has no interactive prompts; flag is forward-compat.

### Library surface

* **`sim.compat.load_compatibility_by_name(name)`** — plugin-aware loader; reads `compatibility.yaml` via `importlib.resources` from each driver's package. Works identically for built-ins (`sim.drivers.<name>`) and external plugins (`sim_plugin_<name>`). The old path-based `load_compatibility(driver_dir)` stays for tests.
* **`sim.testing.assert_protocol_conformance(driver_cls)`** — pytest harness every plugin's CI imports. Catches missing methods, wrong signatures, unsafe `detect_installed`, type-mismatched returns.
* **Three new entry-point groups consumed**: `sim.drivers` (driver class — already used), `sim.skills` (Traversable to bundled `_skills/` dir), `sim.plugins` (lightweight `plugin_info` metadata for `sim plugin list` without importing the driver).

### Docs + tooling

* **`docs/agent-readability.md`** — formalized three-pillar contract: stable flags + JSON envelope + closed `error_code` enum, `sim.toml` schema, `sim describe` manifest.
* **`docs/plugin-install.md`** — every install path with concrete commands.
* **`tools/lint-public-corpus.py`** — vendor-name corpus audit. Currently runs in WARN mode (185 occurrences across the existing source — see umbrella issue for inventory). Promoted to FAIL after Phase 3.

## What's intentionally NOT in this PR

* Driver extraction (Phase 1+).
* PyPI rename `sim-runtime` → `sim-cli-core` (Phase 4).
* Standardizing every existing driver's `launch`/`run`/`disconnect` shape — Phase 0 documents the contract; drivers migrate at their own pace as part of their extraction PRs.

## Verification

```
sim plugin list                                # 27 built-ins
sim plugin doctor --all --json | jq .ok        # true
sim describe --json | jq '.commands | length'  # ≥ 22
sim describe --error-codes | jq 'length'       # 9
sim init && sim setup --dry-run                # works in empty dir
sim config validate                            # OK
python tools/lint-public-corpus.py             # WARN (whitelist `ltspice`)
pytest tests/base                              # 187 pass; 2 pre-existing failures unrelated
```

## Test plan

- [ ] `sim plugin list/info/doctor` works against all 27 built-ins.
- [ ] `sim plugin install ./tests/fixtures/<some>.whl` installs a fake plugin in a sandbox.
- [ ] `sim init && sim setup --dry-run` in an empty dir prints the right manifest.
- [ ] `sim describe --json | jq` parses cleanly.
- [ ] `pytest tests/base` passes (modulo the 2 pre-existing unrelated failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)