### PR TITLE
coolprop: Phase 1 canary prep — session-method stubs + registry note

### DIFF
--- a/src/sim/drivers/__init__.py
+++ b/src/sim/drivers/__init__.py
@@ -60,6 +60,9 @@ _BUILTIN_REGISTRY: list[tuple[str, str]] = [
     ("simpy", "sim.drivers.simpy:SimpyDriver"),
     ("trimesh", "sim.drivers.trimesh:TrimeshDriver"),
     ("devito", "sim.drivers.devito:DevitoDriver"),
+    # coolprop: Phase 1 plugin-extraction canary. Held in the registry as
+    # the safety net during the 1-week soak; sim-plugin-coolprop ships the
+    # external counterpart. Removal lands in a follow-up PR after soak.
     ("coolprop", "sim.drivers.coolprop:CoolPropDriver"),
     ("scikit_rf", "sim.drivers.scikitrf:ScikitRfDriver"),
     ("pandapower", "sim.drivers.pandapower:PandapowerDriver"),

--- a/src/sim/drivers/coolprop/driver.py
+++ b/src/sim/drivers/coolprop/driver.py
@@ -170,3 +170,14 @@ class CoolPropDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — CoolProp is one-shot, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError("coolprop driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError("coolprop driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/tests/drivers/coolprop/test_coolprop_driver.py
+++ b/tests/drivers/coolprop/test_coolprop_driver.py
@@ -68,3 +68,23 @@ class TestRunFile:
             with pytest.raises(RuntimeError, match="(?i)coolprop"):
                 d.run_file(p)
         finally: os.unlink(p)
+
+
+class TestSessionStubs:
+    """CoolProp is one-shot; DriverProtocol still requires the methods exist."""
+
+    def setup_method(self): self.d = CoolPropDriver()
+
+    def test_supports_session_false(self): assert self.d.supports_session is False
+
+    def test_launch_raises(self):
+        with pytest.raises(NotImplementedError, match="(?i)session"):
+            self.d.launch()
+
+    def test_run_raises(self):
+        with pytest.raises(NotImplementedError, match="(?i)session"):
+            self.d.run("PropsSI('T', 'P', 1e5, 'Q', 0, 'Water')")
+
+    def test_disconnect_idempotent(self):
+        r = self.d.disconnect()
+        assert r == {"ok": True, "disconnected": True}


### PR DESCRIPTION
**Tracker:** [svd-ai-lab/sim-proj#72](https://github.com/svd-ai-lab/sim-proj/issues/72) (canary), umbrella [svd-ai-lab/sim-proj#69](https://github.com/svd-ai-lab/sim-proj/issues/69)

This is the sim-cli-side companion to the Phase 1 canary that extracts the
OSS `coolprop` driver into the new
[`sim-plugin-coolprop`](https://github.com/svd-ai-lab/sim-plugin-coolprop)
repo. Coordinated draft PRs:

- Plugin scaffold: [svd-ai-lab/sim-plugin-coolprop#1](https://github.com/svd-ai-lab/sim-plugin-coolprop/pull/1)
- Public index entry: [svd-ai-lab/sim-plugin-index#1](https://github.com/svd-ai-lab/sim-plugin-index/pull/1)
- This PR: sim-cli prep

## Scope (two minimal changes)

1. **No-op session-lifecycle stubs on `CoolPropDriver`.**
   `DriverProtocol` is `runtime_checkable`, so missing
   `launch`/`run`/`disconnect` methods cause
   `isinstance(driver, DriverProtocol)` to return False — which makes
   `sim plugin doctor coolprop` print `[warn] protocol_conforms` even
   though coolprop is fully functional as a one-shot driver. With the
   stubs the doctor reports clean.

   Mirrors the same change made in `sim-plugin-coolprop/driver.py` so
   the built-in and the plugin stay in lock-step during the soak window.

2. **Registry comment** annotating coolprop's row in
   `_BUILTIN_REGISTRY` as the canary safety net.

The registry entry **stays put** in this PR. Removal lands in a separate
follow-up after the 1-week soak (per the autonomous playbook's HALT step
in Phase 1).

## Tests

- 4 new test cases on `CoolPropDriver` exercising `launch` /
  `run` / `disconnect`.
- All existing coolprop + protocol-conformance + plugins tests still pass
  (44 passed, 1 skipped locally).
- `isinstance(CoolPropDriver(), DriverProtocol)` now returns True.

## Phase 1.5 follow-up (broader, separate PR)

Every other built-in driver fails `isinstance(d, DriverProtocol)` for
the exact same reason — they predate the harness. The codemod step
will sweep all of them, plus add the stubs to the in-tree drivers as
they get extracted. Tracking issue to be opened during Phase 1.5.

## Acceptance gate

This PR stays draft until the plugin scaffold ([sim-plugin-coolprop#1](https://github.com/svd-ai-lab/sim-plugin-coolprop/pull/1)) is reviewable. The trio (plugin / index / sim-cli prep) lands together once approved.