### PR TITLE
drivers: lift session-lifecycle stubs into every one-shot built-in

### DIFF
--- a/src/sim/drivers/calculix/driver.py
+++ b/src/sim/drivers/calculix/driver.py
@@ -280,3 +280,14 @@ class CalculixDriver:
             script=str(script), solver=self.name,
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/devito/driver.py
+++ b/src/sim/drivers/devito/driver.py
@@ -173,3 +173,14 @@ class DevitoDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/elmer/driver.py
+++ b/src/sim/drivers/elmer/driver.py
@@ -266,3 +266,14 @@ class ElmerDriver:
             script=str(script), solver=self.name,
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/fipy/driver.py
+++ b/src/sim/drivers/fipy/driver.py
@@ -173,3 +173,14 @@ class FipyDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/gmsh/driver.py
+++ b/src/sim/drivers/gmsh/driver.py
@@ -329,3 +329,14 @@ class GmshDriver:
             script=str(script), solver=self.name,
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/isaac/driver.py
+++ b/src/sim/drivers/isaac/driver.py
@@ -291,3 +291,14 @@ class IsaacDriver:
             script=str(script), solver=self.name,
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/lammps/driver.py
+++ b/src/sim/drivers/lammps/driver.py
@@ -284,3 +284,14 @@ class LammpsDriver:
             script=str(script), solver=self.name,
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/ltspice/driver.py
+++ b/src/sim/drivers/ltspice/driver.py
@@ -267,3 +267,14 @@ class LTspiceDriver:
             timestamp=datetime.now(timezone.utc).isoformat(),
             errors=errors,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/meshio/driver.py
+++ b/src/sim/drivers/meshio/driver.py
@@ -164,3 +164,14 @@ class MeshioDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/newton/driver.py
+++ b/src/sim/drivers/newton/driver.py
@@ -359,3 +359,14 @@ class NewtonDriver:
             script=str(script), solver=self.name,
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/openmdao/driver.py
+++ b/src/sim/drivers/openmdao/driver.py
@@ -177,3 +177,14 @@ class OpenMDAODriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/openseespy/driver.py
+++ b/src/sim/drivers/openseespy/driver.py
@@ -209,3 +209,14 @@ class OpenSeesPyDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/pandapower/driver.py
+++ b/src/sim/drivers/pandapower/driver.py
@@ -175,3 +175,14 @@ class PandapowerDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/paraview/driver.py
+++ b/src/sim/drivers/paraview/driver.py
@@ -332,3 +332,14 @@ class ParaViewDriver:
         return run_subprocess(
             [exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/pybamm/driver.py
+++ b/src/sim/drivers/pybamm/driver.py
@@ -209,3 +209,14 @@ class PyBaMMLDriver:
             script=script,
             solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/pymfem/driver.py
+++ b/src/sim/drivers/pymfem/driver.py
@@ -182,3 +182,14 @@ class PymfemDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/pymoo/driver.py
+++ b/src/sim/drivers/pymoo/driver.py
@@ -171,3 +171,14 @@ class PymooDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/pyomo/driver.py
+++ b/src/sim/drivers/pyomo/driver.py
@@ -176,3 +176,14 @@ class PyomoDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/pyvista/driver.py
+++ b/src/sim/drivers/pyvista/driver.py
@@ -169,3 +169,14 @@ class PyvistaDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/scikit_fem/driver.py
+++ b/src/sim/drivers/scikit_fem/driver.py
@@ -165,3 +165,14 @@ class ScikitFemDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/scikitrf/driver.py
+++ b/src/sim/drivers/scikitrf/driver.py
@@ -172,3 +172,14 @@ class ScikitRfDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/sfepy/driver.py
+++ b/src/sim/drivers/sfepy/driver.py
@@ -171,3 +171,14 @@ class SfepyDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/simpy/driver.py
+++ b/src/sim/drivers/simpy/driver.py
@@ -173,3 +173,14 @@ class SimpyDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/su2/driver.py
+++ b/src/sim/drivers/su2/driver.py
@@ -256,3 +256,14 @@ class Su2Driver:
             script=str(script), solver=self.name,
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/src/sim/drivers/trimesh/driver.py
+++ b/src/sim/drivers/trimesh/driver.py
@@ -171,3 +171,14 @@ class TrimeshDriver:
         return run_subprocess(
             [python_exe, str(script)], script=script, solver=self.name,
         )
+
+    # Session lifecycle stubs — one-shot driver, but DriverProtocol is
+    # runtime_checkable so every method must exist. See `sim.driver`.
+    def launch(self, **kwargs) -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def run(self, code: str, label: str = "") -> dict:
+        raise NotImplementedError(f"{self.name} driver does not support sessions")
+
+    def disconnect(self) -> dict:
+        return {"ok": True, "disconnected": True}

--- a/tests/base/test_protocol_conformance.py
+++ b/tests/base/test_protocol_conformance.py
@@ -183,3 +183,40 @@ def test_built_in_coolprop_driver_check_runs():
     from sim.drivers.coolprop.driver import CoolPropDriver
     failures = check_driver(CoolPropDriver)
     assert isinstance(failures, list)
+
+
+def test_every_built_in_driver_matches_protocol():
+    """Every driver in ``_BUILTIN_REGISTRY`` must satisfy
+    ``isinstance(driver, DriverProtocol)``.
+
+    Why this is a hard assertion (unlike the smoke test above): plugins
+    extracted out of the registry are required to pass
+    :func:`assert_protocol_conformance` to ship. If built-ins drift below
+    that bar — by missing one of the runtime-checkable methods — every
+    extraction has to relitigate the contract. Keep parity.
+    """
+    import importlib
+
+    from sim.driver import DriverProtocol
+    from sim.drivers import _BUILTIN_REGISTRY
+
+    failures: list[tuple[str, str]] = []
+    for name, spec in _BUILTIN_REGISTRY:
+        mod_path, cls_name = spec.split(":", 1)
+        try:
+            mod = importlib.import_module(mod_path)
+            cls = getattr(mod, cls_name)
+            instance = cls()
+        except Exception as e:  # noqa: BLE001 — surface as a single failure line
+            failures.append((name, f"{type(e).__name__}: {e}"))
+            continue
+        if not isinstance(instance, DriverProtocol):
+            missing = [
+                m for m in ("launch", "run", "disconnect")
+                if not callable(getattr(instance, m, None))
+            ]
+            failures.append((name, f"missing methods: {missing}"))
+
+    assert not failures, "drivers failing DriverProtocol structural check:\n" + "\n".join(
+        f"  - {n}: {msg}" for n, msg in failures
+    )


### PR DESCRIPTION
**Tracker:** Phase 1.5 prep, ahead of soak. Umbrella [svd-ai-lab/sim-proj#69](https://github.com/svd-ai-lab/sim-proj/issues/69), Phase 1 canary [svd-ai-lab/sim-proj#72](https://github.com/svd-ai-lab/sim-proj/issues/72) discovered the parity gap.

## Problem

`DriverProtocol` is `@runtime_checkable` and declares `launch` / `run` / `disconnect` on its structural surface (see `sim/driver.py`). The Phase 1 canary discovered that **every** existing built-in driver fails `isinstance(d, DriverProtocol)` because none of them implement those methods — even one-shot drivers where `supports_session` returns False.

That made `sim plugin doctor coolprop` print `[warn] protocol_conforms` even though coolprop is fully functional. The same warning would appear for every other built-in if the doctor were pointed at it. It also means every plugin extracted out of the registry has to add the stubs *and* re-run conformance against the new contract — Phase 1 had to do that for coolprop in two places.

## What this lands

A single sweep that adds the three stub methods to every one-shot built-in:

```python
def launch(self, **kwargs) -> dict:
    raise NotImplementedError(f"{self.name} driver does not support sessions")

def run(self, code: str, label: str = "") -> dict:
    raise NotImplementedError(f"{self.name} driver does not support sessions")

def disconnect(self) -> dict:
    return {"ok": True, "disconnected": True}
```

Pattern is identical to the change made on `coolprop` in [#64](https://github.com/svd-ai-lab/sim-cli/pull/64).

| | |
|---|---|
| Modified | `pybamm`, `isaac`, `newton`, `calculix`, `gmsh`, `su2`, `lammps`, `scikit_fem`, `elmer`, `meshio`, `pyvista`, `pymfem`, `openseespy`, `sfepy`, `openmdao`, `fipy`, `pymoo`, `pyomo`, `simpy`, `trimesh`, `devito`, `scikit_rf`, `pandapower`, `paraview`, `ltspice` (25 of 27 built-ins) |
| Skipped | `openfoam` (real session implementation already), `coolprop` (already lifted in #64) |

## Tests

Added `tests/base/test_protocol_conformance.py::test_every_built_in_driver_matches_protocol` — walks `_BUILTIN_REGISTRY` and asserts `isinstance(driver, DriverProtocol)` for every entry. Without this test the parity drift would resurface silently the next time someone adds a one-shot driver.

Full suite: 689 passed (was 688 — the new test), no regressions on this branch. The two pre-existing `tests/base/test_cli.py` failures (`test_version`, `test_logs_field_workspace_returns_delta`) are unrelated and predate this branch.

## Codemod

The codemod that produced these diffs lives at `tmp/apply_session_stubs.py` (gitignored). It's idempotent — rerunning it is a no-op once the stubs are in place. A polished version of this is part of the upcoming Phase 1.5 `tools/extract-driver.sh` codemod.