### PR TITLE
ltspice: Phase 2A canary prep — registry note

### DIFF
--- a/src/sim/drivers/__init__.py
+++ b/src/sim/drivers/__init__.py
@@ -67,6 +67,9 @@ _BUILTIN_REGISTRY: list[tuple[str, str]] = [
     ("scikit_rf", "sim.drivers.scikitrf:ScikitRfDriver"),
     ("pandapower", "sim.drivers.pandapower:PandapowerDriver"),
     ("paraview", "sim.drivers.paraview:ParaViewDriver"),
+    # ltspice: Phase 2A plugin-extraction canary. Held in the registry as
+    # the safety net during the soak; sim-plugin-ltspice ships the
+    # external counterpart. Removal lands in a follow-up PR after soak.
     ("ltspice", "sim.drivers.ltspice:LTspiceDriver"),
 ]
 


### PR DESCRIPTION
**Tracker:** Phase 2A in the priority-restructured plugin-extraction refactor. Umbrella [svd-ai-lab/sim-proj#69](https://github.com/svd-ai-lab/sim-proj/issues/69).

Companion PRs:
- [sim-plugin-ltspice#1](https://github.com/svd-ai-lab/sim-plugin-ltspice/pull/1) — initial scaffold (already merged)
- sim-plugin-index entry (incoming)

## Scope

Single comment annotating ltspice's row in \`_BUILTIN_REGISTRY\` as the canary safety net for the soak window. Built-in driver code is otherwise untouched in this PR; the registry stays put. Removal lands in a separate follow-up after soak.

The session-method stub work that needed a separate sim-cli prep for coolprop ([#64](https://github.com/svd-ai-lab/sim-cli/pull/64)) already landed for every built-in in [#65](https://github.com/svd-ai-lab/sim-cli/pull/65), so this PR is much smaller than the coolprop canary's prep.

## Tests

38 ltspice + protocol-conformance tests pass on this branch.