### PR TITLE
plugin install/uninstall: --python flag for explicit interpreter pinning

### DIFF
--- a/src/sim/_plugin_install.py
+++ b/src/sim/_plugin_install.py
@@ -199,15 +199,27 @@ def resolve_source(source: str, *, offline: bool = False, index_url: str = DEFAU
 
 
 def _pip_install(target: str, *, editable: bool = False, upgrade: bool = False,
-                 extra_args: list[str] | None = None) -> subprocess.CompletedProcess:
-    """Run ``pip install`` (or ``uv pip install`` if uv is on PATH)."""
+                 extra_args: list[str] | None = None,
+                 python: str | None = None) -> subprocess.CompletedProcess:
+    """Run ``pip install`` (or ``uv pip install`` if uv is on PATH).
+
+    ``python`` lets the caller pin which interpreter receives the install.
+    Defaults to ``sys.executable`` (the interpreter running ``sim``), which
+    is the right choice in 90% of cases. The canary verification proved
+    that without an explicit pin, ``uv pip install`` resolves the active
+    venv via ``$VIRTUAL_ENV`` / ``$CONDA_PREFIX`` / cwd discovery, which
+    can target the *wrong* interpreter when the user's terminal has no
+    venv activated.
+    """
     use_uv = shutil.which("uv") is not None
+
+    target_python = python or sys.executable
 
     cmd: list[str]
     if use_uv:
-        cmd = ["uv", "pip", "install"]
+        cmd = ["uv", "pip", "install", "--python", target_python]
     else:
-        cmd = [sys.executable, "-m", "pip", "install"]
+        cmd = [target_python, "-m", "pip", "install"]
 
     if upgrade:
         cmd.append("--upgrade")
@@ -259,12 +271,16 @@ def install_plugin(
     offline: bool = False,
     sync_target: Path | None = None,
     skip_sync: bool = False,
+    python: str | None = None,
 ) -> InstallReport:
     """High-level installer used by ``sim plugin install``.
 
     Returns an InstallReport — never raises for normal failures (bad source,
     pip non-zero, sync failure). Catches and reports cleanly so the CLI
     layer can render either JSON or human output without try/except.
+
+    ``python`` overrides the install-target interpreter. Defaults to
+    ``sys.executable`` (the interpreter running ``sim``).
     """
     try:
         resolved = resolve_source(source, offline=offline)
@@ -276,7 +292,10 @@ def install_plugin(
             message=str(e),
         )
 
-    proc = _pip_install(resolved.pip_target, editable=editable, upgrade=upgrade)
+    proc = _pip_install(
+        resolved.pip_target,
+        editable=editable, upgrade=upgrade, python=python,
+    )
     ok = proc.returncode == 0
 
     if not ok:
@@ -322,12 +341,14 @@ def _default_skills_target() -> Path:
 # ── Uninstall ───────────────────────────────────────────────────────────────
 
 
-def uninstall_plugin(name: str, *, sync: bool = True) -> dict[str, Any]:
+def uninstall_plugin(name: str, *, sync: bool = True,
+                      python: str | None = None) -> dict[str, Any]:
     """Best-effort plugin uninstall.
 
     Tries the canonical PyPI distribution name (``sim-plugin-<name>``)
     first, then falls back to whatever package the registry says owns
-    that driver.
+    that driver. ``python`` pins the target interpreter (defaults to
+    ``sys.executable``).
     """
     from sim.plugins import list_installed_plugins
 
@@ -341,9 +362,10 @@ def uninstall_plugin(name: str, *, sync: bool = True) -> dict[str, Any]:
                            "or remove from sim-cli's _BUILTIN_REGISTRY."}
 
     package = rows[name].package or f"sim-plugin-{name}"
+    target_python = python or sys.executable
     use_uv = shutil.which("uv") is not None
-    cmd = (["uv", "pip", "uninstall", package] if use_uv
-           else [sys.executable, "-m", "pip", "uninstall", "-y", package])
+    cmd = (["uv", "pip", "uninstall", "--python", target_python, package] if use_uv
+           else [target_python, "-m", "pip", "uninstall", "-y", package])
     proc = subprocess.run(cmd, capture_output=True, text=True)
 
     if proc.returncode != 0:

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -1021,8 +1021,13 @@ def plugin_info_cmd(ctx, name):
 @click.option("--target", "sync_target", type=click.Path(file_okay=False, path_type=Path),
               default=None,
               help="Override sync-skills target dir (default: ./.claude/skills or ~/.claude/skills).")
+@click.option("--python", "python_exe", default=None,
+              help="Pin the target Python interpreter for the install. "
+                   "Defaults to the interpreter running sim — use this "
+                   "when sim is on PATH but the desired venv isn't activated.")
 @click.pass_context
-def plugin_install(ctx, source, editable, upgrade, offline, no_sync, sync_target):
+def plugin_install(ctx, source, editable, upgrade, offline, no_sync, sync_target,
+                    python_exe):
     """Install a plugin from any supported source.
 
     \b
@@ -1033,6 +1038,7 @@ def plugin_install(ctx, source, editable, upgrade, offline, no_sync, sync_target
       sim plugin install ./sim-plugin-coolprop -e          # editable, for authors
       sim plugin install git+https://github.com/svd-ai-lab/sim-plugin-coolprop
       sim plugin install --offline coolprop                # use cached index only
+      sim plugin install coolprop --python /path/to/venv/bin/python
     """
     from sim._plugin_install import install_plugin
 
@@ -1040,6 +1046,7 @@ def plugin_install(ctx, source, editable, upgrade, offline, no_sync, sync_target
         source,
         editable=editable, upgrade=upgrade, offline=offline,
         sync_target=sync_target, skip_sync=no_sync,
+        python=python_exe,
     )
 
     if ctx.obj["json"]:
@@ -1063,12 +1070,14 @@ def plugin_install(ctx, source, editable, upgrade, offline, no_sync, sync_target
 
 @plugin.command("uninstall")
 @click.argument("name")
+@click.option("--python", "python_exe", default=None,
+              help="Pin the target Python interpreter for the uninstall.")
 @click.pass_context
-def plugin_uninstall(ctx, name):
+def plugin_uninstall(ctx, name, python_exe):
     """Uninstall a plugin and remove its synced skill directory."""
     from sim._plugin_install import uninstall_plugin
 
-    result = uninstall_plugin(name)
+    result = uninstall_plugin(name, python=python_exe)
     if ctx.obj["json"]:
         click.echo(json_mod.dumps(result, indent=2))
     else:

--- a/tests/base/test_plugin_install.py
+++ b/tests/base/test_plugin_install.py
@@ -230,3 +230,78 @@ def test_install_report_dict_includes_all_keys():
               "pip_returncode", "pip_stdout", "pip_stderr",
               "sync_skills", "error_code", "message"):
         assert k in d
+
+
+# ── --python flag plumbing ─────────────────────────────────────────────────
+
+
+class _FakeProc:
+    def __init__(self):
+        self.returncode = 0
+        self.stdout = ""
+        self.stderr = ""
+
+
+def test_pip_install_pins_python_via_uv(monkeypatch):
+    """When uv is on PATH, _pip_install must pass ``--python <exe>``."""
+    from sim import _plugin_install
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc()
+
+    monkeypatch.setattr(_plugin_install.shutil, "which",
+                        lambda exe: "/usr/bin/uv" if exe == "uv" else None)
+    monkeypatch.setattr(_plugin_install.subprocess, "run", fake_run)
+
+    _plugin_install._pip_install("sim-plugin-foo", python="/tmp/myvenv/bin/python")
+
+    cmd = captured["cmd"]
+    assert cmd[0] == "uv"
+    assert "--python" in cmd
+    assert "/tmp/myvenv/bin/python" in cmd
+    assert cmd[-1] == "sim-plugin-foo"
+
+
+def test_pip_install_pins_python_via_pip(monkeypatch):
+    """When uv is NOT on PATH, _pip_install must invoke ``<exe> -m pip``."""
+    from sim import _plugin_install
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc()
+
+    monkeypatch.setattr(_plugin_install.shutil, "which", lambda exe: None)
+    monkeypatch.setattr(_plugin_install.subprocess, "run", fake_run)
+
+    _plugin_install._pip_install("sim-plugin-foo", python="/tmp/myvenv/bin/python")
+
+    cmd = captured["cmd"]
+    assert cmd[0] == "/tmp/myvenv/bin/python"
+    assert cmd[1:4] == ["-m", "pip", "install"]
+
+
+def test_pip_install_defaults_to_sys_executable(monkeypatch):
+    """Without an explicit ``python``, fall back to ``sys.executable``."""
+    import sys
+    from sim import _plugin_install
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc()
+
+    monkeypatch.setattr(_plugin_install.shutil, "which",
+                        lambda exe: "/usr/bin/uv" if exe == "uv" else None)
+    monkeypatch.setattr(_plugin_install.subprocess, "run", fake_run)
+
+    _plugin_install._pip_install("sim-plugin-foo")
+
+    cmd = captured["cmd"]
+    assert "--python" in cmd
+    assert sys.executable in cmd


### PR DESCRIPTION
**Tracker:** [svd-ai-lab/sim-proj#73](https://github.com/svd-ai-lab/sim-proj/issues/73). Discovered during the Phase 1 coolprop canary verification — `sim plugin install` shells out to `uv pip install` without `--python`, which resolves the active venv via env / cwd discovery and can hit the wrong interpreter when no venv is activated.

Adds `--python <exe>` to `sim plugin install` and `sim plugin uninstall`. Defaults to `sys.executable`. 3 new tests; 692 passed in full suite (was 689).