### PR TITLE
phase-3a: mark openfoam as plugin-extraction canary

### DIFF
--- a/src/sim/drivers/__init__.py
+++ b/src/sim/drivers/__init__.py
@@ -38,8 +38,12 @@ _ENTRY_POINT_GROUP = "sim.drivers"
 # (driver_name, "module:Class") — order controls `solvers list` output order
 # and `lint` first-match priority.
 _BUILTIN_REGISTRY: list[tuple[str, str]] = [
-    # openfoam stays as a built-in: it has a real session implementation
-    # (sim-server bridge) so it isn't a drop-in extraction candidate yet.
+    # openfoam: Phase 3a plugin-extraction canary (2026-04-28). Held as the
+    # soak safety net while sim-plugin-openfoam ships the external counter-
+    # part. Earlier "has a real session implementation, not a drop-in
+    # extraction candidate" framing was wrong — the driver is a generic
+    # HTTP client over sim-server's normal endpoints, structurally identical
+    # to coolprop. Empty-registry cut tracked in svd-ai-lab/sim-proj#69.
     ("openfoam", "sim.drivers.openfoam:OpenFOAMDriver"),
     # coolprop: Phase 1 plugin-extraction canary. Held in the registry as
     # the safety net during the 1-week soak; sim-plugin-coolprop ships the


### PR DESCRIPTION
## Summary

Mirrors the coolprop Phase 1 pattern for openfoam — sim-plugin-openfoam now exists as the canonical home; sim-cli keeps the in-tree driver as the soak safety net until Phase 3b empties \`_BUILTIN_REGISTRY\` (~2026-05-12).

Comment-only change. No registry rows added or removed.

The earlier "openfoam has a real session implementation so it isn't a drop-in extraction candidate" framing was wrong: the driver is a generic httpx client over sim-server's normal /connect, /exec, /inspect, /disconnect endpoints — structurally identical to coolprop / ltspice. The session lives on the *server* side and is solver-agnostic.

## Linked

- New repo: https://github.com/svd-ai-lab/sim-plugin-openfoam
- Index PR: svd-ai-lab/sim-plugin-index#6
- Pure-plugin architecture plan: svd-ai-lab/sim-proj#69

## Test plan

- [x] \`pytest -q\` — same 313 pass / 2 pre-existing failures as before (comment-only change)
- [x] sim-plugin-openfoam wheel builds (28 files, ships SKILL.md + references + solver/ notes)
- [x] sim-plugin-openfoam protocol conformance test passes against the extracted driver
- [x] \`sim plugin list\` from a venv with both sim-cli (editable) + sim-plugin-openfoam (editable) installed shows the entry; safety net suppression policy works (built-in wins, plugin shadowed during soak — by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)