### PR TITLE
cleanup: drop stale [pybamm] extra from optional-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-pybamm  = ["pybamm>=24.0"]
 dev     = ["pytest>=8.0", "ruff>=0.4"]
 
 [project.urls]


### PR DESCRIPTION
## Summary

`pybamm = ["pybamm>=24.0"]` in `[project.optional-dependencies]` is a leftover from when PyBaMM was an in-tree built-in driver. Phase 2 extracted it to `sim-plugin-pybamm`; the registry on main now contains only `openfoam` and `coolprop`. The extra only pulled the bare PyBaMM SDK (no driver), so `pip install sim-cli-core[pybamm]` is not a useful install path.

## Why now

Spotted while reviewing the post-rename pyproject. Two-line cleanup, no behavior change for any current consumer (the extra has been dead since Phase 2).

## Out of scope

No version bump unless you want one — this doesn't affect the install surface for anyone using `sim-cli-core` or `sim-cli-core[dev]`. Happy to bump to 0.2.5 if you'd rather have a release line in PyPI noting the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)