### PR TITLE
docs(README): document private-plugin install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ sim plugin install <name>        # e.g. sim plugin install ltspice
 
 The index is served from [`sim-plugin-index`](https://github.com/svd-ai-lab/sim-plugin-index); reference plugins to read for shape: [`sim-plugin-coolprop`](https://github.com/svd-ai-lab/sim-plugin-coolprop) (one-shot, no SDK gate), [`sim-plugin-ltspice`](https://github.com/svd-ai-lab/sim-plugin-ltspice) (one-shot with vendor binary), [`sim-plugin-pybamm`](https://github.com/svd-ai-lab/sim-plugin-pybamm) (heavy SDK).
 
+**Private plugins** (vendor-IP-sensitive backends not in the public index) install directly by URL — same `sim plugin install` flow:
+
+```bash
+sim plugin install git+https://github.com/<org>/sim-plugin-<name>
+# (you need read-access to the repo; without it, git clone returns 401)
+```
+
 Per-solver protocols, snippets, and demo workflows live in [`sim-skills`](https://github.com/svd-ai-lab/sim-skills) and the per-plugin repos.
 
 ---


### PR DESCRIPTION
## Summary

One-liner addition to the Solver registry section of the README documenting how to install private plugins (vendor-IP-sensitive ones that intentionally don't appear in the public sim-plugin-index).

## Why

Phase 2B/2C of the plugin-extraction refactor (svd-ai-lab/sim-proj#69) chose **Option A**: keep commercial plugins (fluent / comsol / flotherm / matlab / abaqus / cfx / mapdl / mechanical / workbench / cantera / ansa / hypermesh / icem / starccm / lsdyna) entirely off the public index to avoid IP-audit signal leakage. Code is in 15 private \`sim-plugin-<name>\` repos; users with read-access install via direct git URL.

This documents the install pattern so users with access aren't left guessing.

Tracking: svd-ai-lab/sim-proj#74

🤖 Generated with [Claude Code](https://claude.com/claude-code)