### PR TITLE
fix(cli, inspect): UTF-8 stdout + per-process probe targeting

### DIFF
--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -13,6 +13,19 @@ from sim.drivers import get_driver
 from sim.runner import execute_script
 
 
+# Reconfigure stdout/stderr to UTF-8 so non-ASCII glyphs (arrows, check marks,
+# warning triangles, etc.) survive on Windows consoles that default to cp1252
+# or older codepages. errors="replace" prevents crashes on terminals that
+# can't render a given codepoint — affected glyphs become "?" instead of
+# raising UnicodeEncodeError.
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, OSError):
+        pass
+
+
 # ── Top-level group ──────────────────────────────────────────────────────────
 
 @click.group()

--- a/src/sim/inspect.py
+++ b/src/sim/inspect.py
@@ -787,13 +787,24 @@ def generic_probes() -> list:
 
 def _find_matching_windows(
     process_name_substrings: tuple[str, ...],
+    target_pid: int | None = None,
 ) -> tuple[list[dict], int, list[str]]:
-    """Shared helper: enumerate top-level windows owned by any process whose
-    name contains one of the given substrings. Returns (matches, total_scanned,
-    errors). Each match dict: {window, pid, proc_name, title, rect}.
+    """Shared helper: enumerate top-level windows for a target process.
 
-    `rect` is (left, top, right, bottom) int tuple, or None if rect-fetch
-    failed. `window` is the raw pywinauto wrapper (use it for capture).
+    Two filtering modes:
+      * ``target_pid`` is provided → return only windows whose owning process
+        ID matches ``target_pid``. The substring list is ignored. Use this
+        when the caller knows the exact process (e.g. a driver that just
+        spawned the target solver) — it eliminates foreground races where
+        another window with a generically-matching name happens to be top.
+      * ``target_pid`` is ``None`` → fall back to substring matching against
+        the owning process's name. This is the legacy default for callers
+        that can only describe the target by class.
+
+    Returns (matches, total_scanned, errors). Each match dict:
+    ``{window, pid, proc_name, title, rect}``. ``rect`` is
+    ``(left, top, right, bottom)`` int tuple, or ``None`` if rect-fetch
+    failed. ``window`` is the raw pywinauto wrapper (use it for capture).
 
     Lazy-imports pywinauto + psutil so this module stays importable on Linux
     / in headless environments.
@@ -823,8 +834,12 @@ def _find_matching_windows(
                 proc_name = psutil.Process(pid).name().lower()
             except Exception:
                 proc_name = ""
-            if not any(sub in proc_name for sub in subs):
-                continue
+            if target_pid is not None:
+                if pid != target_pid:
+                    continue
+            else:
+                if not any(sub in proc_name for sub in subs):
+                    continue
             title = w.window_text() or ""
             try:
                 r = w.rectangle()
@@ -881,9 +896,11 @@ class GuiDialogProbe:
         self,
         process_name_substrings: tuple[str, ...] = ("fluent", "ansys", "cx", "cortex"),
         code_prefix: str = "fluent.gui",
+        target_pid: int | None = None,
     ):
         self.process_name_substrings = tuple(s.lower() for s in process_name_substrings)
         self.code_prefix = code_prefix
+        self.target_pid = target_pid
 
     def applies(self, ctx: InspectCtx) -> bool:
         try:
@@ -893,7 +910,9 @@ class GuiDialogProbe:
             return False
 
     def probe(self, ctx: InspectCtx) -> ProbeResult:
-        matches, total, errors = _find_matching_windows(self.process_name_substrings)
+        matches, total, errors = _find_matching_windows(
+            self.process_name_substrings, target_pid=self.target_pid,
+        )
         diags: list[Diagnostic] = []
         if errors:
             for msg in errors:
@@ -957,9 +976,18 @@ class ScreenshotProbe:
     """Channel #8b — per-window screenshot capture via PIL.ImageGrab bbox.
 
     IMPORTANT: this probe captures ONLY the bounding box of each matched
-    Fluent window, NOT the whole desktop. If no Fluent window is found,
+    target window, NOT the whole desktop. If no matching window is found,
     emits a single warning diag and nothing else — we never fall back to
     full-screen capture (that creates noisy / PII-risky artifacts).
+
+    Two ways to identify the target:
+      * ``target_pid`` (preferred when known): bind to the exact process
+        the caller spawned. Eliminates foreground races where another
+        window whose process name happens to substring-match the legacy
+        list wins z-order at probe time.
+      * ``process_name_substrings`` (default): match any process whose
+        name contains one of the given substrings. Used when the caller
+        can only describe the target by class.
 
     Every matched window produces:
       - one Artifact  (role="screenshot", path=<png>)
@@ -974,9 +1002,11 @@ class ScreenshotProbe:
         self,
         filename_prefix: str = "shot",
         process_name_substrings: tuple[str, ...] = ("fluent", "ansys", "cx", "cortex"),
+        target_pid: int | None = None,
     ):
         self.filename_prefix = filename_prefix
         self.process_name_substrings = tuple(s.lower() for s in process_name_substrings)
+        self.target_pid = target_pid
 
     def applies(self, ctx: InspectCtx) -> bool:
         try:
@@ -999,7 +1029,9 @@ class ScreenshotProbe:
                 message=f"PIL.ImageGrab unavailable: {exc}",
             )])
 
-        matches, _, errors = _find_matching_windows(self.process_name_substrings)
+        matches, _, errors = _find_matching_windows(
+            self.process_name_substrings, target_pid=self.target_pid,
+        )
         if errors:
             return ProbeResult(diagnostics=[Diagnostic(
                 severity="warning", source="gui:screenshot",
@@ -1008,10 +1040,14 @@ class ScreenshotProbe:
             )])
 
         if not matches:
+            target_desc = (
+                f"pid={self.target_pid}" if self.target_pid is not None
+                else f"{self.process_name_substrings}"
+            )
             return ProbeResult(diagnostics=[Diagnostic(
                 severity="info", source="gui:screenshot",
                 code="sim.screenshot.no_window",
-                message=(f"no window matched {self.process_name_substrings}; "
+                message=(f"no window matched {target_desc}; "
                          f"no screenshot taken (full-screen fallback disabled)"),
             )])
 

--- a/tests/inspect/test_gui_probes.py
+++ b/tests/inspect/test_gui_probes.py
@@ -216,3 +216,116 @@ def test_gui_dialog_error_hints_minimal_and_english_only():
         "Plan A's _DIALOG_HINTS should be removed; probe now uses "
         "_ERROR_SIGNAL_HINTS + _WARNING_SIGNAL_HINTS"
     )
+
+
+# ── target_pid filter — mock-based, works cross-platform ────────────────────
+#
+# `_find_matching_windows` lazy-imports pywinauto + psutil, so we can stub
+# them via sys.modules without needing the real packages on the test host.
+# These tests verify the new `target_pid` parameter selects by PID and
+# ignores the substring fallback when set.
+
+
+def _install_fake_desktop_psutil(monkeypatch, windows: list[tuple[int, str, str]]):
+    """Stub pywinauto.Desktop and psutil so _find_matching_windows can run
+    without a real GUI. `windows` is a list of (pid, proc_name, title).
+    """
+    import sys
+    import types
+
+    class _Rect:
+        def __init__(self, l, t, r, b):
+            self.left, self.top, self.right, self.bottom = l, t, r, b
+
+    class _W:
+        def __init__(self, pid, title):
+            self._pid, self._title = pid, title
+
+        def process_id(self):
+            return self._pid
+
+        def window_text(self):
+            return self._title
+
+        def rectangle(self):
+            return _Rect(0, 0, 100, 100)
+
+    class _Desktop:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def windows(self):
+            return [_W(pid, title) for pid, _proc, title in windows]
+
+    pywin = types.ModuleType("pywinauto")
+    pywin.Desktop = _Desktop  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pywinauto", pywin)
+
+    name_by_pid = {pid: proc for pid, proc, _title in windows}
+
+    class _Proc:
+        def __init__(self, pid):
+            self._pid = pid
+
+        def name(self):
+            return name_by_pid.get(self._pid, "")
+
+    psutil_mod = types.ModuleType("psutil")
+    psutil_mod.Process = _Proc  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "psutil", psutil_mod)
+
+
+def test_find_matching_windows_pid_filter_wins_over_substring(monkeypatch):
+    """When target_pid is supplied, only that PID's windows are returned —
+    other windows whose process name substring-matches the legacy list
+    must be ignored. Closes the foreground-race gap where a generic
+    name-substring match could capture the wrong window."""
+    from sim.inspect import _find_matching_windows
+
+    _install_fake_desktop_psutil(monkeypatch, [
+        (1111, "target.exe", "Target App"),
+        (2222, "ansys-helper.exe", "Helper that substring-matches 'ansys'"),
+    ])
+
+    matches, _, errors = _find_matching_windows(
+        ("ansys", "fluent"), target_pid=1111,
+    )
+    assert errors == []
+    assert len(matches) == 1
+    assert matches[0]["pid"] == 1111
+    assert matches[0]["title"] == "Target App"
+
+
+def test_find_matching_windows_falls_back_to_substring_when_no_pid(monkeypatch):
+    """target_pid=None preserves the legacy substring-match behavior."""
+    from sim.inspect import _find_matching_windows
+
+    _install_fake_desktop_psutil(monkeypatch, [
+        (1111, "unrelated.exe", "Some unrelated tool"),
+        (2222, "myapp.exe", "MyApp window"),
+    ])
+
+    matches, _, errors = _find_matching_windows(("myapp",))
+    assert errors == []
+    assert [m["pid"] for m in matches] == [2222]
+
+
+def test_screenshot_probe_accepts_target_pid_kwarg():
+    """API contract: ScreenshotProbe stores target_pid on the instance."""
+    from sim.inspect import ScreenshotProbe
+
+    p = ScreenshotProbe(target_pid=4242)
+    assert p.target_pid == 4242
+    # Default stays None for callers that don't supply it.
+    p2 = ScreenshotProbe()
+    assert p2.target_pid is None
+
+
+def test_gui_dialog_probe_accepts_target_pid_kwarg():
+    """API contract: GuiDialogProbe stores target_pid on the instance."""
+    from sim.inspect import GuiDialogProbe
+
+    p = GuiDialogProbe(target_pid=4242)
+    assert p.target_pid == 4242
+    p2 = GuiDialogProbe()
+    assert p2.target_pid is None


### PR DESCRIPTION
## Summary

- **UTF-8 stdout reconfigure** — `sim check` / lint output / `sim plugin install` print Unicode glyphs (`→`, `✓`, `⚠`, `✗`, `←`). On Windows consoles defaulting to cp1252 these crashed with `UnicodeEncodeError`. CLI now reconfigures stdout/stderr to UTF-8 on import (`errors="replace"` so exotic terminals degrade gracefully instead of crashing).
- **`target_pid` on GuiDialogProbe / ScreenshotProbe** — when the caller knows which process they want to observe, they can now bind to it by PID. Eliminates a foreground-race class where another window whose process name happens to substring-match the legacy list wins z-order and gets captured. Substring matching remains the default; no behavior change for existing callers.

## Test plan

- [x] 4 new unit tests in `tests/inspect/test_gui_probes.py` covering both filter modes and both probes' API contract. Mock-based (`sys.modules` stubs for `pywinauto` + `psutil`), no GUI dependency.
- [x] Local smoke: `python -c "import sim.cli; click.echo('foo → bar')"` prints clean (verified `→ ✓ ⚠ ✗ ←` all survive).
- [x] Full `tests/inspect/test_gui_probes.py` passes (27/27).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)