### PR TITLE
docs: simplify commercial plugin wording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ The server supports multiple concurrent sessions keyed by session_id. Each `Sess
 Drivers are resolved lazily through two channels:
 
 - **`_BUILTIN_REGISTRY`** — an ordered list of `(name, "module:Class")` tuples for the open-source drivers that ship with `sim-cli-core` itself (PyBaMM, OpenFOAM, CalculiX, gmsh, SU2, LAMMPS, Elmer, scikit-fem, MFEM, OpenSeesPy, SfePy, OpenMDAO, FiPy, pymoo, Pyomo, SimPy, Trimesh, Devito, CoolProp, scikit-rf, pandapower, ParaView, meshio, PyVista, Newton, Isaac Sim, LTspice). The canonical list lives in `src/sim/drivers/__init__.py`.
-- **`sim.drivers` entry-point group** — external/closed-source drivers register themselves via standard Python entry points and are discovered at import time, validated, and appended after the built-ins. Built-ins win on name collisions. This is the path used by every commercial-solver plugin (each lives in its own out-of-tree package with its own `compatibility.yaml`).
+- **`sim.drivers` entry-point group** — external drivers register themselves via standard Python entry points and are discovered at import time, validated, and appended after the built-ins. Built-ins win on name collisions. Each plugin lives in its own out-of-tree package with its own `compatibility.yaml`.
 
 A driver may set `supports_session = True` to implement the persistent-session lifecycle (`launch`/`run`/`query`/`disconnect`); the rest are one-shot only. `get_driver(name)` looks up by `.name` attribute and lazily imports the implementation module on first use, so a broken plugin does not crash the CLI.
 

--- a/NOTICE
+++ b/NOTICE
@@ -5,68 +5,31 @@ This product is licensed under the Apache License, Version 2.0 (the "License");
 see the accompanying LICENSE file for the full text.
 
 ================================================================================
-Third-party solver SDKs (runtime, optional — not bundled)
+Plugin and runtime dependency notice
 ================================================================================
 
-sim-cli integrates with commercial and open-source solvers by dynamically
-importing their Python SDKs at runtime. No vendor SDK, solver binary, or vendor
-example/tutorial material is redistributed as part of this repository. Users
-install each SDK separately (via `sim env install`, optional extras in
-pyproject.toml, or their own package manager) and are responsible for
-complying with the license, copyright, and end-user agreement that ships
-with each SDK and each underlying solver.
+sim-cli is a solver-agnostic runtime. Solver and tool integrations are provided
+by separately installed plugins. Plugins may depend on third-party software,
+services, SDKs, or local executables that are not bundled with this repository.
+Users are responsible for complying with the license, copyright, and end-user
+terms that apply to any third-party software they install or use with a plugin.
 
-The drivers in `src/sim/drivers/` reference, but do not bundle, the following
-third-party Python SDKs. This list is informational and may lag the code —
-see `src/sim/drivers/<name>/compatibility.yaml` and `pyproject.toml` for the
-current version pins.
-
-  Ansys / PyAnsys family (© ANSYS, Inc.)
-    - ansys-fluent-core        https://github.com/ansys/pyfluent
-    - ansys-workbench-core     https://github.com/ansys/pyworkbench
-    - ansys-mechanical-core    https://github.com/ansys/pymechanical
-    - ansys-mapdl-core         https://github.com/ansys/pymapdl
-    - ansys-dyna-core          https://github.com/ansys/pydyna
-    - ansys-dpf-core           https://github.com/ansys/pydpf-core
-
-  COMSOL (© COMSOL AB)
-    - mph                       https://github.com/MPh-py/MPh
-      (third-party Python wrapper around COMSOL's Java API; requires a COMSOL
-      Multiphysics license)
-
-  MathWorks (© The MathWorks, Inc.)
-    - matlabengine              https://pypi.org/project/matlabengine/
-      (distributed by MathWorks; requires a MATLAB license)
-
-  Dassault Systèmes / Abaqus, Siemens STAR-CCM+ / Flotherm, BETA CAE ANSA,
-  Altair HyperMesh, Ansys ICEM CFD, Ansys CFX
-    - Driven via vendor CLIs / journal files / Python-in-solver interpreters.
-      No additional Python SDK is redistributed by sim-cli.
-
-  Open-source solvers and libraries
-    - PyBaMM, OpenFOAM, SU2, LAMMPS, CalculiX, Elmer FEM, Gmsh, meshio,
-      pyvista, PyMFEM, scikit-fem, SfePy, OpenSeesPy, Cantera, OpenMDAO,
-      FiPy, pymoo, Pyomo, SimPy, Trimesh, Devito, CoolProp, scikit-rf,
-      pandapower, ParaView (pvpython/pvbatch).
-      Each retains its own upstream license; consult the corresponding project
-      for terms.
+Commercial plugin availability depends on third-party license conditions.
+Contact <contact@svd-ai-lab.com> to discuss commercial plugin access.
 
 ================================================================================
 Direct runtime dependencies (see pyproject.toml)
 ================================================================================
 
   click, httpx, fastapi, uvicorn, pyyaml, Pillow, lxml
-    — each distributed under its own open-source license (BSD / MIT / Apache-2.0
-      family); consult the respective package for terms.
+    - each distributed under its own open-source license (BSD / MIT /
+      Apache-2.0 family); consult the respective package for terms.
 
 ================================================================================
 Trademarks
 ================================================================================
 
-Product, solver, and company names referenced in this repository (including
-Ansys®, Fluent®, Workbench®, Mechanical®, MAPDL, CFX®, LS-DYNA®, ICEM CFD™,
-Abaqus®, SIMULIA®, COMSOL Multiphysics®, MATLAB®, Simcenter™ STAR-CCM+,
-Simcenter Flotherm™, ANSA®, HyperMesh®, Altair®, ParaView®, OpenFOAM®) are
-trademarks or registered trademarks of their respective owners and are used
-solely for identification. sim-cli is an independent open-source project and
-is not affiliated with, endorsed by, or sponsored by any of these vendors.
+Product, solver, tool, and company names may be trademarks or registered
+trademarks of their respective owners. sim-cli is an independent open-source
+project and is not affiliated with, endorsed by, or sponsored by any third-party
+vendor unless explicitly stated.

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -60,10 +60,10 @@
       <rect x="730" y="110" width="210" height="270" rx="12" fill="#0f172a" stroke="#334155"/>
       <text x="835" y="135" text-anchor="middle" fill="#cbd5e1" font-size="13" font-weight="600">DriverProtocol</text>
       <g font-size="12" fill="#e2e8f0">
-        <text x="745" y="162">• fluent     (PyFluent · sessions)</text>
-        <text x="745" y="182">• comsol     (JPype)</text>
-        <text x="745" y="202">• openfoam   (Linux subprocess)</text>
-        <text x="745" y="222">• matlab     (matlabengine)</text>
+        <text x="745" y="162">• plugin_a   (persistent session)</text>
+        <text x="745" y="182">• plugin_b   (batch process)</text>
+        <text x="745" y="202">• plugin_c   (remote host)</text>
+        <text x="745" y="222">• plugin_d   (GUI-capable)</text>
         <text x="745" y="242">• …  more in the registry</text>
         <text x="745" y="270" fill="#cbd5e1">• + your driver here</text>
         <text x="745" y="288" font-size="11" fill="#94a3b8">  (~200 LOC, register in</text>
@@ -78,8 +78,8 @@
       <!-- live solver -->
       <rect x="490" y="240" width="220" height="140" rx="12" fill="#0f172a" stroke="#334155"/>
       <text x="600" y="265" text-anchor="middle" fill="#cbd5e1" font-size="13" font-weight="600">Live solver process</text>
-      <text x="600" y="290" text-anchor="middle" fill="#86efac" font-size="13">Fluent GUI · COMSOL · MATLAB</text>
-      <text x="600" y="310" text-anchor="middle" fill="#86efac" font-size="13">ANSA · Flotherm · OpenFOAM</text>
+      <text x="600" y="290" text-anchor="middle" fill="#86efac" font-size="13">CLI · GUI · batch</text>
+      <text x="600" y="310" text-anchor="middle" fill="#86efac" font-size="13">local or remote execution</text>
       <text x="600" y="332" text-anchor="middle" fill="#94a3b8" font-size="12">engineer can watch in real time</text>
       <text x="600" y="358" text-anchor="middle" fill="#94a3b8" font-size="11">launched once, snippets at will</text>
 

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -51,16 +51,16 @@
     <text x="430" y="248" font-size="18" font-weight="400" fill="#94a3b8">One CLI. One HTTP protocol. An open driver registry.</text>
     <text x="430" y="276" font-size="18" font-weight="400" fill="#94a3b8">So AI agents can launch, drive, and observe CAD/CAE jobs.</text>
 
-    <!-- chiplets — sample of supported solvers, NOT an exhaustive list -->
+    <!-- chiplets — generic plugin capabilities, NOT an exhaustive list -->
     <g font-size="14" font-weight="600">
       <rect x="430" y="298" width="78"  height="26" rx="13" fill="#1e293b" stroke="#334155"/>
-      <text x="469" y="316" text-anchor="middle" fill="#93c5fd">Fluent</text>
+      <text x="469" y="316" text-anchor="middle" fill="#93c5fd">CLI</text>
       <rect x="516" y="298" width="78"  height="26" rx="13" fill="#1e293b" stroke="#334155"/>
-      <text x="555" y="316" text-anchor="middle" fill="#c4b5fd">COMSOL</text>
+      <text x="555" y="316" text-anchor="middle" fill="#c4b5fd">GUI</text>
       <rect x="602" y="298" width="84"  height="26" rx="13" fill="#1e293b" stroke="#334155"/>
-      <text x="644" y="316" text-anchor="middle" fill="#86efac">OpenFOAM</text>
+      <text x="644" y="316" text-anchor="middle" fill="#86efac">Batch</text>
       <rect x="694" y="298" width="78"  height="26" rx="13" fill="#1e293b" stroke="#334155"/>
-      <text x="733" y="316" text-anchor="middle" fill="#fda4af">MATLAB</text>
+      <text x="733" y="316" text-anchor="middle" fill="#fda4af">Remote</text>
       <rect x="780" y="298" width="60"  height="26" rx="13" fill="#0f172a" stroke="#334155" stroke-dasharray="3 3"/>
       <text x="810" y="316" text-anchor="middle" fill="#94a3b8">…</text>
       <rect x="848" y="298" width="120" height="26" rx="13" fill="#1e293b" stroke="#475569"/>

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -110,7 +110,7 @@ sim --host <server-ip> disconnect
 
 ## 🎬 演示
 
-> 📺 **早期预览：** [【agent驱动 ansys fluent 进行芯片热仿真】](https://www.bilibili.com/video/BV15RD7BTE21/) —— 粗剪版本（B 站），仍欢迎贡献更精致的录制（见下文）。
+> 📺 **早期预览：** 一段 agent 驱动真实求解器会话的粗剪版本正在整理中，仍欢迎贡献更精致的录制（见下文）。
 
 > **录制中。** 即将放置一段终端 capture：`sim connect → exec → inspect → screenshot` 驱动一个真实的求解器会话。
 >

--- a/docs/agent-readability.md
+++ b/docs/agent-readability.md
@@ -102,8 +102,8 @@ git = "https://github.com/svd-ai-lab/sim-plugin-gmsh"
 rev = "v0.1.0"
 
 [[sim.plugins]]
-name = "fluent"   # <!-- allow-vendor-name: doc example of pinning a commercial plugin -->
-wheel = "./vendor/sim_plugin_fluent-1.2.0-py3-none-any.whl"   # local, air-gapped
+name = "local_plugin"
+wheel = "./vendor/sim_plugin_local-1.2.0-py3-none-any.whl"   # local, air-gapped
 ```
 
 `sim init` creates a starter `sim.toml`. `sim setup` reads it and ensures

--- a/docs/architecture/version-compat.md
+++ b/docs/architecture/version-compat.md
@@ -4,7 +4,7 @@
 > **Audience:** sim-cli maintainers, plugin authors.
 > **Last reviewed:** 2026-04-27.
 
-This document used to carry a long, driver-specific compatibility-matrix design. Most of that material now lives **inside individual plugin packages** — every commercial-solver driver ships as its own out-of-tree plugin, and each plugin owns the version-compat data for its own SDK and solver releases. The design intent is preserved here in summary form so the public `sim-cli-core` repo still describes the contract that plugins implement.
+This document used to carry a long, driver-specific compatibility-matrix design. Most of that material now lives **inside individual plugin packages**. Each plugin owns the version-compat data for its own runtime dependencies. The design intent is preserved here in summary form so the public `sim-cli-core` repo still describes the contract that plugins implement.
 
 If you are looking for the per-plugin compatibility data, read each plugin's own `compatibility.yaml` and its own architecture notes.
 

--- a/docs/plugin-install.md
+++ b/docs/plugin-install.md
@@ -13,7 +13,6 @@ covers every way to install one.
 | Offline (you have a wheel file) | `sim plugin install ./sim_plugin_coolprop-0.1.0-py3-none-any.whl` |
 | Air-gapped (you have a bundle dir) | `sim plugin install --offline --from-dir ./bundle/ --all` |
 | Editable (you author plugins) | `sim plugin install -e ./sim-plugin-coolprop` |
-| Commercial plugin (private) | `sim plugin install fluent --include-commercial` <!-- allow-vendor-name: user-facing install example for licensed users --> |
 
 ## How `sim plugin install <source>` resolves
 
@@ -111,33 +110,10 @@ Equivalent to `pip install -e ./sim-plugin-coolprop`, plus syncing skills.
 Code edits take effect on next process; you never need to reinstall during
 development.
 
-## Commercial plugins (private repos)
+## Commercial plugins
 
-Commercial plugins live in private repos because their existence in a
-public listing would reveal that maintainers have access to that paid
-tool. They are not in the public index.
-
-For licensed users:
-
-```sh
-gh auth login                                  # one-time
-sim plugin install fluent --include-commercial   # <!-- allow-vendor-name: example, plugin name is the user-facing identifier -->
-```
-
-`--include-commercial` consults a private commercial index. Without GitHub
-auth, the command fails clean (no leak).
-
-Direct install also works:
-
-```sh
-sim plugin install git+ssh://git@github.com/svd-ai-lab/sim-plugin-<x>.git
-```
-
-Or, if a teammate sent you the wheel out-of-band:
-
-```sh
-sim plugin install ./sim_plugin_<x>-1.0.0-py3-none-any.whl
-```
+Commercial plugin availability depends on third-party license conditions.
+Contact <contact@svd-ai-lab.com> to discuss commercial plugin access.
 
 ## Surviving `uv sync`
 
@@ -151,7 +127,7 @@ anything else. To keep installed plugins across `uv sync` invocations,
 [tool.sim.plugins]
 coolprop = { name = "coolprop", source = "index", version = ">=0.1.0" }
 gmsh     = { git = "https://github.com/svd-ai-lab/sim-plugin-gmsh", rev = "v0.1.0" }
-fluent   = { wheel = "./vendor/sim_plugin_fluent-1.2.0-py3-none-any.whl" }   # <!-- allow-vendor-name: example showing how a commercial plugin is recorded in pyproject -->
+local_plugin = { wheel = "./vendor/sim_plugin_local-1.2.0-py3-none-any.whl" }
 ```
 
 `sim setup` (or `uv sync && sim plugin install --reapply`) restores them


### PR DESCRIPTION
## Summary
- Replace commercial plugin install mechanics with contact/license-safe wording
- Remove named commercial examples from public docs and assets
- Simplify NOTICE to generic plugin/runtime dependency language

## Verification
- Searched public docs/assets/NOTICE/CLAUDE for private-index mechanics and named commercial examples
- Ran git diff --check