### PR TITLE
[codex] Add generic driver launch options

### DIFF
--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -496,6 +496,47 @@ def _print_followup_hints(run_id, stdout_path, stderr_path, delta):
         click.echo(f"        cat {delta[0]['path']}     # likely solver log (largest write)")
 
 
+def _parse_driver_option_value(value: str):
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _parse_driver_options(items: tuple[str, ...]) -> dict:
+    """Parse generic driver launch passthrough options from KEY=VALUE pairs."""
+    parsed: dict = {}
+    for item in items:
+        if "=" not in item:
+            raise click.BadParameter(
+                f"{item!r} is not KEY=VALUE",
+                param_hint="--driver-option",
+            )
+        key, value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise click.BadParameter(
+                f"{item!r} has an empty key",
+                param_hint="--driver-option",
+            )
+        if key in parsed:
+            raise click.BadParameter(
+                f"{key!r} was provided more than once",
+                param_hint="--driver-option",
+            )
+        parsed[key] = _parse_driver_option_value(value)
+    return parsed
+
+
 # ── connect (persistent session) ────────────────────────────────────────────
 
 @main.command()
@@ -505,10 +546,18 @@ def _print_followup_hints(run_id, stdout_path, stderr_path, delta):
 @click.option("--processors", default=1, type=int)
 @click.option("--workspace", default=None,
               help="Solver-specific working dir (e.g. flotherm FLOUSERDIR).")
+@click.option("--driver-option", "driver_options", multiple=True,
+              metavar="KEY=VALUE",
+              help="Generic driver launch option passthrough. Repeat as needed.")
 @click.pass_context
-def connect(ctx, solver, mode, ui_mode, processors, workspace):
+def connect(ctx, solver, mode, ui_mode, processors, workspace, driver_options):
     """Launch a solver and hold a persistent session."""
     from sim.session import SessionClient
+
+    try:
+        parsed_driver_options = _parse_driver_options(driver_options)
+    except click.BadParameter as exc:
+        raise click.ClickException(str(exc)) from exc
 
     client = SessionClient(host=ctx.obj["host"], port=ctx.obj["port"],
                            session_id=ctx.obj.get("session"))
@@ -518,6 +567,7 @@ def connect(ctx, solver, mode, ui_mode, processors, workspace):
         ui_mode=ui_mode,
         processors=processors,
         workspace=workspace,
+        driver_options=parsed_driver_options,
     )
 
     if ctx.obj["json"]:

--- a/src/sim/server.py
+++ b/src/sim/server.py
@@ -16,7 +16,7 @@ per-session endpoints return 400. See
 `docs/architecture/multi-session-and-config.md` for the full contract.
 
 Endpoints:
-    POST /connect     {solver, mode, ui_mode, processors}     → header-less
+    POST /connect     {solver, mode, ui_mode, processors, ...} → header-less
     POST /exec        {code, label}                           → header-routed
     POST /run         {script, solver}                        → header-less (one-shot)
     GET  /inspect/<name>                                      → header-routed
@@ -38,7 +38,7 @@ from typing import Any
 
 from fastapi import BackgroundTasks, FastAPI, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 def _sanitize_for_json(obj):
@@ -76,7 +76,16 @@ class ConnectRequest(BaseModel):
     mode: str = "meshing"
     ui_mode: str = "gui"
     processors: int = 2
-    workspace: str | None = None  # passed through to driver.launch(workspace=...)
+    workspace: str | None = None
+    driver_options: dict[str, Any] = Field(default_factory=dict)
+
+
+def _connect_reserved_driver_option_keys() -> set[str]:
+    """Return connect request fields that cannot be overridden by driver options."""
+    fields = getattr(ConnectRequest, "model_fields", None)
+    if fields is None:
+        fields = getattr(ConnectRequest, "__fields__", {})
+    return set(fields) - {"driver_options"}
 
 
 class ExecRequest(BaseModel):
@@ -98,6 +107,9 @@ class SessionState:
     mode: str | None = None
     ui_mode: str | None = None
     processors: int = 1
+    workspace: str | None = None
+    driver_options: dict = field(default_factory=dict)
+    launch_options: dict = field(default_factory=dict)
     connected_at: float | None = None
     run_count: int = 0
     driver: Any = None
@@ -273,13 +285,23 @@ def connect(req: ConnectRequest):
                     "two concurrent sessions on the same driver aren't supported yet",
                 )
 
+    reserved_seen = _connect_reserved_driver_option_keys() & set(req.driver_options)
+    if reserved_seen:
+        names = ", ".join(sorted(reserved_seen))
+        raise HTTPException(
+            400,
+            f"driver_options may not override reserved connect keys: {names}",
+        )
+
     launch_kwargs: dict = {
         "mode": req.mode,
         "ui_mode": req.ui_mode,
         "processors": req.processors,
+        **req.driver_options,
     }
     if req.workspace is not None:
         launch_kwargs["workspace"] = req.workspace
+        launch_kwargs.setdefault("cwd", req.workspace)
     try:
         info = driver.launch(**launch_kwargs)
     except HTTPException:
@@ -297,6 +319,9 @@ def connect(req: ConnectRequest):
         mode=req.mode,
         ui_mode=req.ui_mode,
         processors=req.processors,
+        workspace=req.workspace,
+        driver_options=req.driver_options,
+        launch_options=info.get("launch_options") or {},
         connected_at=time.time(),
         run_count=0,
         driver=driver,
@@ -323,6 +348,9 @@ def connect(req: ConnectRequest):
             "solver": req.solver,
             "mode": state.mode,
             "ui_mode": state.ui_mode,
+            "workspace": state.workspace,
+            "driver_options": state.driver_options,
+            "launch_options": state.launch_options,
             "connected_at": state.connected_at,
             "run_count": 0,
             "profile": state.profile,
@@ -395,6 +423,9 @@ def inspect(
                 "solver": state.solver,
                 "mode": state.mode,
                 "ui_mode": state.ui_mode,
+                "workspace": state.workspace,
+                "driver_options": state.driver_options,
+                "launch_options": state.launch_options,
                 "connected_at": state.connected_at,
                 "run_count": state.run_count,
                 "profile": state.profile,
@@ -442,6 +473,9 @@ def ps():
             "mode": s.mode,
             "ui_mode": s.ui_mode,
             "processors": s.processors,
+            "workspace": s.workspace,
+            "driver_options": s.driver_options,
+            "launch_options": s.launch_options,
             "connected_at": s.connected_at,
             "run_count": s.run_count,
             "profile": s.profile,

--- a/src/sim/session.py
+++ b/src/sim/session.py
@@ -152,7 +152,8 @@ class SessionClient:
 
     def connect(self, solver: str, mode: str = "meshing",
                 ui_mode: str = "no_gui", processors: int = 1,
-                workspace: str | None = None) -> dict:
+                workspace: str | None = None,
+                driver_options: dict | None = None) -> dict:
         # Auto-start local server if needed
         if self._is_local() and not self._server_reachable():
             if not self._auto_start_server():
@@ -164,6 +165,8 @@ class SessionClient:
         }
         if workspace is not None:
             body["workspace"] = workspace
+        if driver_options:
+            body["driver_options"] = driver_options
         resp = self._request("post", "/connect", timeout=CONNECT_TIMEOUT_S, json=body)
         # Remember the new session_id so subsequent calls on this client
         # route to it even if another session shows up later.

--- a/tests/base/test_cli.py
+++ b/tests/base/test_cli.py
@@ -6,7 +6,7 @@ import sys
 
 from click.testing import CliRunner
 
-from sim.cli import main
+from sim.cli import _parse_driver_options, main
 
 
 def test_version():
@@ -23,6 +23,29 @@ def test_help():
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
     assert "sim" in result.output
+
+
+def test_connect_help_exposes_driver_options():
+    runner = CliRunner()
+    result = runner.invoke(main, ["connect", "--help"])
+    assert result.exit_code == 0
+    assert "--driver-option" in result.output
+
+
+def test_parse_driver_options():
+    assert _parse_driver_options((
+        "worker_count=2",
+        "mode_hint=fast",
+        "enable_cache=false",
+        "relaxation=0.25",
+        "cwd=C:/tmp/solver-case",
+    )) == {
+        "worker_count": 2,
+        "mode_hint": "fast",
+        "enable_cache": False,
+        "relaxation": 0.25,
+        "cwd": "C:/tmp/solver-case",
+    }
 
 
 def test_python_m_sim_invocation():

--- a/tests/base/test_multi_session.py
+++ b/tests/base/test_multi_session.py
@@ -26,10 +26,12 @@ class FakeDriver:
         self.name = name
         self._launched = False
         self._disconnected = False
+        self.launch_kwargs = None
 
     def launch(self, **kwargs):
         self._launched = True
-        return {"ok": True}
+        self.launch_kwargs = kwargs
+        return {"ok": True, "launch_options": kwargs}
 
     def run(self, code: str, label: str = "snippet"):
         return {
@@ -99,6 +101,44 @@ class TestMultiSession:
         assert body["default_session"] is None
         solvers = {s["solver"] for s in body["sessions"]}
         assert solvers == {"alpha", "beta"}
+
+    def test_connect_forwards_launch_options(self, client, fake_drivers):
+        r = client.post("/connect", json={
+            "solver": "alpha",
+            "mode": "solver",
+            "ui_mode": "no_gui",
+            "processors": 2,
+            "workspace": "C:/tmp/solver-case",
+            "driver_options": {
+                "worker_count": 2,
+                "mode_hint": "fast",
+            },
+        })
+        assert r.status_code == 200, r.text
+        assert fake_drivers["alpha"].launch_kwargs == {
+            "mode": "solver",
+            "ui_mode": "no_gui",
+            "processors": 2,
+            "worker_count": 2,
+            "mode_hint": "fast",
+            "workspace": "C:/tmp/solver-case",
+            "cwd": "C:/tmp/solver-case",
+        }
+        data = r.json()["data"]
+        assert data["driver_options"] == {
+            "worker_count": 2,
+            "mode_hint": "fast",
+        }
+        assert data["workspace"] == "C:/tmp/solver-case"
+        assert data["launch_options"]["cwd"] == "C:/tmp/solver-case"
+
+    def test_connect_rejects_reserved_driver_options(self, client, fake_drivers):
+        r = client.post("/connect", json={
+            "solver": "alpha",
+            "driver_options": {"mode": "solver"},
+        })
+        assert r.status_code == 400
+        assert "reserved connect keys" in r.json()["detail"]
 
     def test_exec_routes_by_header(self, client, fake_drivers):
         sid_a = _connect(client, "alpha")


### PR DESCRIPTION
## Summary

Adds a solver-agnostic launch option passthrough for persistent sessions:

- introduces repeated `sim connect --driver-option KEY=VALUE`
- forwards parsed values through `SessionClient` and `/connect` as `driver_options`
- derives core-owned reserved keys from the connect request schema instead of maintaining a separate hand-written list
- surfaces `driver_options` and driver-returned `launch_options` in session responses

This keeps sim-cli core generic while allowing plugins to validate and translate their own launch settings.

## Validation

- `python -m pytest tests/base/test_multi_session.py::TestMultiSession::test_connect_forwards_launch_options tests/base/test_multi_session.py::TestMultiSession::test_connect_rejects_reserved_driver_options tests/base/test_cli.py::test_connect_help_exposes_driver_options tests/base/test_cli.py::test_parse_driver_options --basetemp=.pytest_basetemp`
- `python -m sim connect --help` shows `--driver-option` and keeps solver-specific launch settings out of the top-level CLI.
