### PR TITLE
plugin install: default --upgrade; resolve name@version on R2 by filename convention

### DIFF
--- a/src/sim/_plugin_install.py
+++ b/src/sim/_plugin_install.py
@@ -234,6 +234,20 @@ def resolve_source(source: str, *, offline: bool = False,
         if entry.get("latest_version") == version and entry.get("latest_wheel_url"):
             return ResolvedSource(kind="name-version", raw=s, name=name, version=version,
                                    pip_target=str(entry["latest_wheel_url"]))
+        # If the entry came from the R2 manifest, all versioned wheels live at a
+        # predictable path — construct the pinned URL by filename convention so
+        # ``name@<old-version>`` resolves without needing every version listed
+        # in the manifest. (R2 keeps every published wheel; manifest only tracks
+        # latest.)
+        latest_url = str(entry.get("latest_wheel_url") or "")
+        if latest_url.startswith("https://cdn.svdailab.com/wheels/"):
+            return ResolvedSource(
+                kind="name-version", raw=s, name=name, version=version,
+                pip_target=(
+                    f"https://cdn.svdailab.com/wheels/"
+                    f"sim_plugin_{name}-{version}-py3-none-any.whl"
+                ),
+            )
         git = entry.get("git")
         if git:
             return ResolvedSource(kind="name-version", raw=s, name=name, version=version,

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -1085,8 +1085,11 @@ def plugin_info_cmd(ctx, name):
 @click.argument("source")
 @click.option("-e", "--editable", is_flag=True,
               help="Editable install (pip install -e). For plugin authors.")
-@click.option("--upgrade", is_flag=True,
-              help="Pass --upgrade to pip.")
+@click.option("--upgrade/--no-upgrade", default=True,
+              help="Pass --upgrade to pip so the install replaces any "
+                   "existing version with whatever the source resolves to. "
+                   "Default: enabled. Use --no-upgrade to keep an existing "
+                   "install if one is already present.")
 @click.option("--offline", is_flag=True,
               help="Use only the local cached index; no network calls.")
 @click.option("--no-sync", "no_sync", is_flag=True,

--- a/tests/base/test_plugin_install.py
+++ b/tests/base/test_plugin_install.py
@@ -226,6 +226,41 @@ def test_resolve_bare_name_falls_back_to_github(tmp_path: Path, monkeypatch):
     assert rs.pip_target == "https://gh.example/pybamm.whl"
 
 
+def test_resolve_name_at_version_uses_r2_filename_convention(tmp_path: Path, monkeypatch):
+    """name@<old-version>: when entry is from R2 manifest, build URL by
+    filename convention so old wheels (kept on R2 but not in manifest) resolve."""
+    _seed_caches(
+        tmp_path, monkeypatch,
+        r2_plugins={"comsol": {"version": "0.1.1",
+                                  "wheel": "https://cdn.svdailab.com/wheels/sim_plugin_comsol-0.1.1-py3-none-any.whl"}},
+    )
+    rs = resolve_source("comsol@0.1.0", offline=True)
+    assert rs.kind == "name-version"
+    assert rs.version == "0.1.0"
+    assert rs.pip_target == (
+        "https://cdn.svdailab.com/wheels/sim_plugin_comsol-0.1.0-py3-none-any.whl"
+    )
+
+
+def test_resolve_name_at_version_github_entry_falls_back_to_git(tmp_path: Path, monkeypatch):
+    """name@<version> with a community-catalogue entry that has a git field
+    still uses git+@v<version> (R2 convention only fires for cdn.svdailab.com URLs)."""
+    _seed_caches(
+        tmp_path, monkeypatch,
+        r2_plugins={},
+        github_plugins=[{
+            "name": "ltspice",
+            "license_class": "oss",
+            "git": "https://github.com/svd-ai-lab/sim-plugin-ltspice",
+            "latest_version": "0.2.1",
+            "latest_wheel_url": "https://github.com/svd-ai-lab/sim-plugin-ltspice/releases/download/v0.2.1/sim_plugin_ltspice-0.2.1-py3-none-any.whl",
+        }],
+    )
+    rs = resolve_source("ltspice@0.1.0", offline=True)
+    assert rs.kind == "name-version"
+    assert rs.pip_target == "git+https://github.com/svd-ai-lab/sim-plugin-ltspice@v0.1.0"
+
+
 def test_resolve_explicit_index_url_skips_chain(tmp_path: Path, monkeypatch):
     """Explicit index_url uses just that source — no R2 fallback."""
     _seed_caches(


### PR DESCRIPTION
## Summary

Two changes so \`sim plugin install <name>\` always converges to the latest wheel the manifest advertises, without an extra \`--upgrade\` flag.

1. **CLI default flips to \`--upgrade/--no-upgrade\` (default True).** Re-running install for an already-installed plugin now actually replaces it (across name, wheel-url, and git+https paths). Pin/freeze use cases use \`--no-upgrade\`.
2. **\`name@<version>\` on R2 resolves via filename convention.** Manifest only tracks latest, but R2 keeps every published wheel. The resolver constructs \`https://cdn.svdailab.com/wheels/sim_plugin_<name>-<version>-py3-none-any.whl\` directly when the entry came from the R2 manifest. Community-catalogue entries (with a \`git\` field) still use \`git+@v<version>\`.

## Why this pairs

The auto-publish flow we're about to enable on R2 is going to bump versions frequently. Without (1), agents need to remember \`--upgrade\` or they stay on the version they first installed. Without (2), pinning would require listing every published version in the manifest.

## Test plan

- [x] \`pytest tests/base/test_plugin_install.py\` — 29 passed (2 new resolver cases).
- [x] Full unit suite — 286 passed; 2 unrelated pre-existing failures on main (\`test_version\`, \`test_logs_field_workspace_returns_delta\`) not introduced by this branch.
- [x] \`sim plugin install --help\` shows \`--upgrade/--no-upgrade\` flag pair with default-enabled wording.