### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sim-cli-core"
-version = "0.3.0"
+version = "0.3.1"
 description = "Make every engineering tool agent-native — a CLI runtime that lets LLM agents launch, drive, and observe CAD/CAE software"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cut release 0.3.1, rolling up changes since v0.3.0:

- `ba6e1e9` plugin install: default `--upgrade`; resolve `name@version` on R2 by filename convention (#88)
- `2abfe24` fix(cli, inspect): UTF-8 stdout + per-process screenshot/dialog targeting (#81)
- `8e6b76f` resolve bundled plugin skills
- `668b497` add generic driver launch options (#83)
- `77b15be` README cleanup + chain plugin index resolver (#86)
- `4797b26` README: PowerShell quick-start + curated plugin CDN docs (#85)
- `68f8134` docs/DEVELOPMENT: drop in-tree driver references (#87)
- `669543dd` / `3530d55` docs polish

After merge, tag `v0.3.1` to trigger the PyPI publish workflow.