### PR TITLE
refactor: separate plugin discovery from explicit installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,11 @@ That's the full loop: **detect → bootstrap → launch → drive → observe �
 Discovery is separate from installation:
 
 ```bash
-sim plugin catalog              # available plugins from the community catalogue
-sim plugin search ltspice       # show package name + explicit install command
+sim plugin catalog              # official plugins (display + copy-paste install string)
 sim plugin list                 # installed/registered plugins on this machine
 ```
 
-Short solver aliases such as `ltspice` are catalogue names, not install sources. Use `sim plugin search <name>` to discover the package, then run the explicit install command it prints.
+Short solver aliases such as `ltspice` are catalogue names, not install sources. Run `sim plugin catalog` to find the recommended install string for each plugin, then pass it to `sim plugin install`.
 
 ---
 
@@ -175,7 +174,7 @@ Short solver aliases such as `ltspice` are catalogue names, not install sources.
 Install from a discovered package, then list what is installed locally:
 
 ```bash
-sim plugin search ltspice       # discover package + explicit install command
+sim plugin catalog              # discover what's available + install strings
 sim plugin install sim-plugin-ltspice
 sim plugin list                 # show installed plugins
 ```

--- a/README.md
+++ b/README.md
@@ -83,9 +83,8 @@ Prereq: [`uv`](https://docs.astral.sh/uv/) — install with `curl -LsSf https://
 #    — no driver choice yet:
 uv pip install sim-cli-core
 
-# 2. Install the plugin for the solver you actually want (browse the
-#    index with `sim plugin list`):
-sim plugin install <solver>     # e.g. ltspice
+# 2. Install the plugin for the solver you actually want:
+sim plugin install sim-plugin-ltspice
 
 # 3. Tell sim to look at this machine and pick the right SDK profile:
 sim check <solver>
@@ -113,9 +112,8 @@ sim --host <server-ip> disconnect
 #    — no driver choice yet:
 uv pip install sim-cli-core
 
-# 2. Install the plugin for the solver you actually want (browse the
-#    index with `sim plugin list`):
-sim plugin install <solver>     # e.g. ltspice
+# 2. Install the plugin for the solver you actually want:
+sim plugin install sim-plugin-ltspice
 
 # 3. Tell sim to look at this machine and pick the right SDK profile:
 sim check <solver>
@@ -146,30 +144,25 @@ That's the full loop: **detect → bootstrap → launch → drive → observe �
 
 ---
 
-## 📦 Plugin index
+## 📦 Plugin sources
 
-`sim plugin install <name>` resolves names against two indexes, in order:
+`sim plugin install <source>` accepts explicit install sources only:
 
-1. **svd-maintained wheel manifest** at `https://cdn.svdailab.com/manifest.json` — pre-built wheels published by the project. Anonymous GET, updated whenever a new wheel ships.
-2. **Community-maintained catalogue** at [`sim-plugin-index`](https://github.com/svd-ai-lab/sim-plugin-index) — broader plugin listing maintained by the community; entries can be OSS or third-party plugins, pointing at GitHub releases or git+https sources.
+- Exact package specs, such as `sim-plugin-ltspice` or `sim-plugin-ltspice==0.2.3`
+- Package specs plus private indexes, such as `sim-plugin-mechanical --extra-index-url https://example.com/simple/`
+- Direct wheel/sdist URLs, such as `https://example.com/sim_plugin_ltspice-0.2.3-py3-none-any.whl`
+- Git URLs, such as `git+https://github.com/<org>/sim-plugin-<name>`
+- Local plugin directories, wheels, and sdists
 
-The first hit wins. Most users never see this distinction — `sim plugin install ltspice` just works.
+Discovery is separate from installation:
 
-svd manifest schema (the community catalogue uses a different shape — see its repo):
-
-```json
-{
-  "updated": "<ISO date>",
-  "plugins": {
-    "<name>": {
-      "version": "<X.Y.Z>",
-      "wheel": "https://cdn.svdailab.com/wheels/<file>.whl"
-    }
-  }
-}
+```bash
+sim plugin catalog              # available plugins from the community catalogue
+sim plugin search ltspice       # show package name + explicit install command
+sim plugin list                 # installed/registered plugins on this machine
 ```
 
-To install a wheel directly without going through the resolver, hand `sim plugin install` the URL — `sim plugin install https://cdn.svdailab.com/wheels/<file>.whl`.
+Short solver aliases such as `ltspice` are catalogue names, not install sources. Use `sim plugin search <name>` to discover the package, then run the explicit install command it prints.
 
 ---
 
@@ -179,20 +172,24 @@ To install a wheel directly without going through the resolver, hand `sim plugin
 
 `sim` is most useful for **GUI-heavy solvers** — COMSOL, ANSYS Mechanical, ANSYS Fluent, MATLAB Simulink, Abaqus, Flotherm — where every agent iteration would otherwise mean clicking through dialog boxes.
 
-Install by name (the resolver chains the svd manifest then the community catalogue — see [Plugin index](#-plugin-index)):
+Install from a discovered package, then list what is installed locally:
 
 ```bash
-sim plugin list                  # show installed plugins
-sim plugin install <name>        # e.g. sim plugin install ltspice
+sim plugin search ltspice       # discover package + explicit install command
+sim plugin install sim-plugin-ltspice
+sim plugin list                 # show installed plugins
 ```
 
 Reference implementation to read for shape: [`sim-plugin-ltspice`](https://github.com/svd-ai-lab/sim-plugin-ltspice).
 
-**Private plugins** (vendor-IP-sensitive backends not in the public index) install directly by URL — same `sim plugin install` flow:
+**Private plugins** (vendor-IP-sensitive backends) install through explicit URLs, private repos, or private Python indexes — same `sim plugin install` flow:
 
 ```bash
 sim plugin install git+https://github.com/<org>/sim-plugin-<name>
 # (you need read-access to the repo; without it, git clone returns 401)
+
+sim plugin install sim-plugin-mechanical --extra-index-url https://example.com/simple/
+# standard PEP 503/private-index path for commercial wrappers
 ```
 
 Per-solver protocols, snippets, and demo workflows live in [`sim-skills`](https://github.com/svd-ai-lab/sim-skills) and the per-plugin repos.
@@ -210,7 +207,7 @@ Per-solver protocols, snippets, and demo workflows live in [`sim-skills`](https:
 ### 🔌 Solver-agnostic
 - **One protocol** (`DriverProtocol`) — every driver is ~200 LOC, shipped as its own `sim-plugin-<name>` package via Python entry points
 - **Persistent + one-shot** from the same CLI — no separate client per mode
-- **Plugin index** — `sim plugin install <name>` chains an [svd-maintained wheel manifest](https://cdn.svdailab.com/manifest.json) and a [community-maintained catalogue](https://github.com/svd-ai-lab/sim-plugin-index)
+- **Plugin discovery + explicit installs** — `sim plugin catalog/search` discovers available plugins; `sim plugin install` accepts exact package specs, private indexes, direct URLs, git URLs, and local artifacts
 - **Companion skills** in [`sim-skills`](https://github.com/svd-ai-lab/sim-skills) so an LLM picks up each new backend without prior context
 
 ### 🌐 Remote-friendly
@@ -224,7 +221,8 @@ Per-solver protocols, snippets, and demo workflows live in [`sim-skills`](https:
 
 | Command | What it does | Analogy |
 |---|---|---|
-| `sim plugin list / install / uninstall` | Manage solver plugins (resolver chains svd → community index) | `npm install` |
+| `sim plugin catalog / search` | Discover available solver plugins | `npm search` |
+| `sim plugin list / install / uninstall` | Manage installed plugins from explicit install sources | `npm install` |
 | `sim check <solver>` | Detect installations + resolve a profile | `docker info` |
 | `sim env install <profile>` | Bootstrap a profile env (venv + pinned SDK) | `pyenv install` |
 | `sim env list [--catalogue]` | Show bootstrapped envs (and the full catalogue) | `pyenv versions` |
@@ -300,7 +298,6 @@ That is the entire setup — same `sim-cli-core` package on both sides, same wir
 
 ## 🔗 Related projects
 
-- **[`sim-plugin-index`](https://github.com/svd-ai-lab/sim-plugin-index)** — community-maintained plugin catalogue; second of two sources `sim plugin install <name>` resolves against (the first is the svd-maintained manifest at `cdn.svdailab.com/manifest.json`)
 - **[`sim-skills`](https://github.com/svd-ai-lab/sim-skills)** — agent skills, snippets, and demo workflows for each supported solver
 - **[`sim-ltspice`](https://github.com/svd-ai-lab/sim-ltspice)** — standalone Python API for LTspice file formats (used by `sim-plugin-ltspice`)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -35,7 +35,8 @@ src/sim/
   driver.py          DriverProtocol + result dataclasses
   compat.py          Version-compat profiles + layered skill resolution
   plugins.py         Plugin discovery, listing, info
-  _plugin_install.py Install / uninstall / index resolution
+  plugin_catalog.py Catalogue/discovery fetch + normalization
+  _plugin_install.py Explicit install / uninstall sources
   drivers/
     __init__.py      Plugin registry — discovers external plugins
                      via the `sim.drivers` entry-point group at

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -148,12 +148,11 @@ sim --host <server-ip> disconnect
 插件发现和安装分开：
 
 ```bash
-sim plugin catalog              # 查看 community catalogue 里的可用插件
-sim plugin search ltspice       # 查看包名和推荐的显式安装命令
+sim plugin catalog              # 查看官方插件目录（含可直接复制的安装命令）
 sim plugin list                 # 查看本机已安装/已注册插件
 ```
 
-`ltspice` 这样的短别名是 catalogue 名称，不是安装来源。先用 `sim plugin search <name>` 发现包名，再执行它打印出来的显式安装命令。
+`ltspice` 这样的短别名是 catalogue 名称，不是安装来源。运行 `sim plugin catalog` 查看每个插件推荐的安装字符串，然后将其传给 `sim plugin install`。
 
 ---
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -135,30 +135,25 @@ sim --host <server-ip> disconnect
 
 ---
 
-## 📦 插件索引
+## 📦 插件来源
 
-`sim plugin install <name>` 按顺序查两个索引：
+`sim plugin install <source>` 只接受显式安装来源：
 
-1. **svd 维护的 wheel manifest**：`https://cdn.svdailab.com/manifest.json` —— 项目自己发布的预构建 wheel。匿名 GET，每次有新 wheel 就更新。
-2. **社区维护的 catalogue**：[`sim-plugin-index`](https://github.com/svd-ai-lab/sim-plugin-index) —— 更广的插件清单，由社区维护；条目可以是 OSS 也可以是第三方插件，指向 GitHub release 或 git+https。
+- 精确 package spec，例如 `sim-plugin-ltspice` 或 `sim-plugin-ltspice==0.2.3`
+- 精确包名加私有索引，例如 `sim-plugin-mechanical --extra-index-url https://example.com/simple/`
+- 直接 wheel/sdist URL，例如 `https://example.com/sim_plugin_ltspice-0.2.3-py3-none-any.whl`
+- git URL，例如 `git+https://github.com/<org>/sim-plugin-<name>`
+- 本地插件目录、wheel 或 sdist
 
-第一个命中的赢。多数用户感知不到这个分层 —— `sim plugin install ltspice` 直接就能装上。
+插件发现和安装分开：
 
-svd manifest 的 schema（社区 catalogue 是另一种 shape，看它仓库里的说明）：
-
-```json
-{
-  "updated": "<ISO date>",
-  "plugins": {
-    "<name>": {
-      "version": "<X.Y.Z>",
-      "wheel": "https://cdn.svdailab.com/wheels/<file>.whl"
-    }
-  }
-}
+```bash
+sim plugin catalog              # 查看 community catalogue 里的可用插件
+sim plugin search ltspice       # 查看包名和推荐的显式安装命令
+sim plugin list                 # 查看本机已安装/已注册插件
 ```
 
-如果想跳过 resolver 直接装某个 wheel，把 URL 直接给 `sim plugin install`：`sim plugin install https://cdn.svdailab.com/wheels/<file>.whl`。
+`ltspice` 这样的短别名是 catalogue 名称，不是安装来源。先用 `sim plugin search <name>` 发现包名，再执行它打印出来的显式安装命令。
 
 ---
 
@@ -173,7 +168,7 @@ svd manifest 的 schema（社区 catalogue 是另一种 shape，看它仓库里�
 ### 🔌 求解器无关
 - **一套协议** (`DriverProtocol`) —— 每个 driver 仅 ~200 行，注册到 `drivers/__init__.py` 即可
 - **持久 + 一次性**两种模式共用同一个 CLI
-- **开放注册表** —— 新求解器持续加入；CFD、多物理场、热、前处理、电池模型都在范围内
+- **插件发现 + 显式安装** —— `sim plugin catalog/search` 用来发现可用插件；`sim plugin install` 只执行精确包名、私有索引、URL、git 或本地 artifact
 - **配套 skills** 在 [`sim-skills`](https://github.com/svd-ai-lab/sim-skills) —— 让大模型立刻知道每个新后端的坑
 
 ### 🌐 远程友好
@@ -187,6 +182,8 @@ svd manifest 的 schema（社区 catalogue 是另一种 shape，看它仓库里�
 
 | 命令 | 功能 | 类比 |
 |---|---|---|
+| `sim plugin catalog / search` | 发现可用插件 | `npm search` |
+| `sim plugin list / install / uninstall` | 管理本机已安装插件 | `npm install` |
 | `sim check <solver>` | 检测安装版本并解析 profile | `docker info` |
 | `sim env install <profile>` | 启动 profile env（venv + 固定 SDK） | `pyenv install` |
 | `sim env list [--catalogue]` | 列出已启动的 env（或全部目录） | `pyenv versions` |

--- a/docs/agent-readability.md
+++ b/docs/agent-readability.md
@@ -58,7 +58,7 @@ top-level keys (`stdout`, `stderr`); never inside `message`.
 | `LINT_FAILED` | `sim lint` produced at least one error-level diagnostic. |
 | `RUN_FAILED` | The solver returned non-zero or the driver detected an error in the output. |
 | `SESSION_NOT_FOUND` | `--session <id>` does not match any active session on the server. |
-| `PLUGIN_NOT_FOUND` | `sim plugin` could not resolve a plugin name (not in the index, no local file). |
+| `PLUGIN_NOT_FOUND` | `sim plugin install` received an invalid explicit source, or a plugin name is not installed. |
 | `PLUGIN_INSTALL_FAILED` | `pip install` for a plugin returned non-zero. |
 | `PROTOCOL_VIOLATION` | A driver returned a value that doesn't match `DriverProtocol`. |
 | `NONINTERACTIVE_INPUT_REQUIRED` | `--no-interactive` is set and the command would otherwise prompt. |

--- a/docs/plugin-install.md
+++ b/docs/plugin-install.md
@@ -8,20 +8,23 @@ covers every way to install one.
 
 | Situation | Command |
 |---|---|
-| Online, named plugin | `sim plugin install coolprop` |
+| Discover available plugins | `sim plugin catalog` / `sim plugin search coolprop` |
+| PyPI package | `sim plugin install sim-plugin-coolprop` |
+| Pinned PyPI package | `sim plugin install sim-plugin-coolprop==0.1.0` |
+| Private package index | `sim plugin install sim-plugin-mechanical --extra-index-url https://example.com/simple/` |
+| Direct URL | `sim plugin install https://example.com/sim_plugin_coolprop-0.1.0-py3-none-any.whl` |
 | Online, plugin you cloned locally | `sim plugin install ./sim-plugin-coolprop` |
 | Offline (you have a wheel file) | `sim plugin install ./sim_plugin_coolprop-0.1.0-py3-none-any.whl` |
-| Air-gapped (you have a bundle dir) | `sim plugin install --offline --from-dir ./bundle/ --all` |
 | Editable (you author plugins) | `sim plugin install -e ./sim-plugin-coolprop` |
 
 ## How `sim plugin install <source>` resolves
 
 `<source>` accepts any of:
 
-1. `<name>` — looks up the plugin in the curated index. Tries the
-   `latest_wheel_url` first (HTTPS, no git or `gh` needed); falls back to
-   `git+https://...` if the wheel URL is unreachable.
-2. `<name>@<version>` — pinned version from the index.
+1. `sim-plugin-<name>` or `sim-plugin-<name>==<version>` — exact package
+   spec passed directly to pip/uv.
+2. `sim-plugin-<name> --extra-index-url https://.../simple/` — exact
+   package spec plus an additional private Python package index.
 3. `https://...whl` or `https://...tar.gz` — direct URL to a wheel or
    sdist. Plain pip + HTTPS, works behind corporate proxies.
 4. `./path/to/dir` — local plugin source directory. `pip install <dir>`.
@@ -29,27 +32,39 @@ covers every way to install one.
    `pip install <path>`.
 6. `git+https://...` or `git+ssh://...` — git URL (when git is available).
 
+Bare short names such as `coolprop` or `ltspice` are catalogue names, not
+install sources. Use `sim plugin search <name>` to discover the package and
+recommended explicit install command, then run that command.
+
 After the package installs, `sim plugin install` runs `sync-skills`
 automatically so the plugin's bundled `_skills/<solver>/` becomes
 discoverable to Claude Code (or any consumer of `.claude/skills/`).
 
-## Online (HTTPS-only)
+## Discovery catalogue
+
+Agents can discover available plugins without installing anything:
 
 ```sh
-sim plugin install coolprop
+sim plugin catalog
+sim plugin search coolprop
+sim plugin search coolprop --json
+```
+
+The catalogue is for discovery only. It may print recommended explicit
+install commands, but `sim plugin install <short-name>` does not silently
+resolve a catalogue name into a URL or package.
+
+## Online
+
+```sh
+sim plugin install sim-plugin-coolprop
 ```
 
 This is enough on a typical developer laptop. Requires:
 
 - `sim-cli-core` already installed.
-- HTTPS access to GitHub Releases (for wheel) or GitHub repo (for git fallback).
+- HTTPS access to the package index, direct URL, or git host you provide.
 - `pip` (it ships with Python).
-
-Does NOT require:
-
-- `git` CLI.
-- `gh` CLI.
-- A GitHub account or auth (for OSS plugins).
 
 ## Offline (single artifact)
 
@@ -63,40 +78,6 @@ sim plugin install ./sim_plugin_coolprop-0.1.0-py3-none-any.whl
 The skill ships *inside* the wheel under `_skills/<solver>/`, so this
 single command brings up both the driver and the skill. No network access
 is required.
-
-## Air-gapped (bundle)
-
-For lab/regulated environments without external network, the bundle flow:
-
-**On a connected machine:**
-
-```sh
-sim plugin bundle coolprop simpy gmsh --output ./plugins-bundle/
-```
-
-This produces:
-
-```
-plugins-bundle/
-  index.json                                         (filtered to bundled plugins,
-                                                       with file:// URLs)
-  sim_plugin_coolprop-0.1.0-py3-none-any.whl
-  sim_plugin_simpy-0.1.0-py3-none-any.whl
-  sim_plugin_gmsh-0.1.0-py3-none-any.whl
-```
-
-**Ship the directory** (USB, secure file transfer, etc.).
-
-**On the air-gapped machine:**
-
-```sh
-sim plugin install --offline --from-dir ./plugins-bundle/ coolprop simpy gmsh
-# or, install everything in the bundle:
-sim plugin install --offline --from-dir ./plugins-bundle/ --all
-```
-
-`--offline` forces the resolver to use the bundle's local `index.json` and
-refuse network calls.
 
 ## Editable (plugin authors)
 
@@ -113,6 +94,13 @@ development.
 ## Commercial plugins
 
 Commercial plugin availability depends on third-party license conditions.
+Private wrappers should be distributed through explicit private repos, direct
+wheel URLs, or a standard private Python package index:
+
+```sh
+sim plugin install sim-plugin-mechanical --extra-index-url https://example.com/simple/
+```
+
 Contact <contact@svd-ai-lab.com> to discuss commercial plugin access.
 
 ## Surviving `uv sync`
@@ -125,7 +113,7 @@ anything else. To keep installed plugins across `uv sync` invocations,
 
 ```toml
 [tool.sim.plugins]
-coolprop = { name = "coolprop", source = "index", version = ">=0.1.0" }
+coolprop = { package = "sim-plugin-coolprop", version = ">=0.1.0" }
 gmsh     = { git = "https://github.com/svd-ai-lab/sim-plugin-gmsh", rev = "v0.1.0" }
 local_plugin = { wheel = "./vendor/sim_plugin_local-1.2.0-py3-none-any.whl" }
 ```

--- a/docs/plugin-install.md
+++ b/docs/plugin-install.md
@@ -8,7 +8,7 @@ covers every way to install one.
 
 | Situation | Command |
 |---|---|
-| Discover available plugins | `sim plugin catalog` / `sim plugin search coolprop` |
+| Discover available plugins | `sim plugin catalog` |
 | PyPI package | `sim plugin install sim-plugin-coolprop` |
 | Pinned PyPI package | `sim plugin install sim-plugin-coolprop==0.1.0` |
 | Private package index | `sim plugin install sim-plugin-mechanical --extra-index-url https://example.com/simple/` |
@@ -33,8 +33,9 @@ covers every way to install one.
 6. `git+https://...` or `git+ssh://...` — git URL (when git is available).
 
 Bare short names such as `coolprop` or `ltspice` are catalogue names, not
-install sources. Use `sim plugin search <name>` to discover the package and
-recommended explicit install command, then run that command.
+install sources. Run `sim plugin catalog` to see the official plugin list
+with the recommended explicit install command for each, then pass that
+command's argument to `sim plugin install`.
 
 After the package installs, `sim plugin install` runs `sync-skills`
 automatically so the plugin's bundled `_skills/<solver>/` becomes
@@ -46,12 +47,12 @@ Agents can discover available plugins without installing anything:
 
 ```sh
 sim plugin catalog
-sim plugin search coolprop
-sim plugin search coolprop --json
+sim plugin catalog --json
 ```
 
-The catalogue is for discovery only. It may print recommended explicit
-install commands, but `sim plugin install <short-name>` does not silently
+The catalogue is for discovery only. Each entry includes a copy-paste
+`install` string that callers pass to `sim plugin install`. The catalogue
+is advisory metadata; `sim plugin install <short-name>` does not silently
 resolve a catalogue name into a URL or package.
 
 ## Online

--- a/src/sim/_plugin_install.py
+++ b/src/sim/_plugin_install.py
@@ -51,10 +51,11 @@ _VERSION_PIN_RE = re.compile(r"(?:==|!=|~=|>=|<=|>|<)\s*(.+)$")
 
 def _short_name_error(name: str) -> str:
     return (
-        f"{name!r} is a catalog name, not an explicit plugin install source. "
-        f"Run 'sim plugin search {name}' to discover the package, then install "
-        "with a local path, direct wheel/sdist URL, git URL, or exact package "
-        f"spec such as 'sim-plugin-{name}' if that package exists."
+        f"{name!r} is not an explicit plugin install source. "
+        "See 'sim plugin catalog' for the official plugin list, or pass an "
+        "explicit pip-installable source: a local wheel/sdist path, a direct "
+        "wheel/sdist URL, a git URL, or a package spec such as "
+        f"'sim-plugin-{name}'."
     )
 
 

--- a/src/sim/_plugin_install.py
+++ b/src/sim/_plugin_install.py
@@ -6,155 +6,25 @@ install pipeline.
 
 A `<source>` argument can be any of:
 
-* ``<name>`` — resolve via the index (HTTPS-only; no git, no gh).
-* ``<name>@<version>`` — pinned from the index.
+* ``sim-plugin-<name>`` / ``sim-plugin-<name>==<version>`` — exact pip
+  package spec.
 * ``https://...whl`` / ``https://...tar.gz`` — direct wheel/sdist URL.
 * ``./path/to/dir`` — local plugin source directory.
 * ``./path/to/wheel.whl`` / ``./path/to/sdist.tar.gz`` — local artifact.
 * ``git+https://...`` / ``git+ssh://...`` — git URL.
 
-The resolver classifies the source with no network calls so we know up
-front what kind of install we're attempting. Then a single ``pip install``
-invocation does the work.
+The resolver classifies the source with no network calls and no plugin
+registry lookup. Then a single ``pip install`` invocation does the work.
 """
 from __future__ import annotations
 
-import json
-import os
 import re
 import shutil
 import subprocess
 import sys
-import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-
-
-# ── Index ───────────────────────────────────────────────────────────────────
-
-# Curated wheels published by the project — primary index. Anonymous GET; updated
-# whenever a new wheel is published via tools/publish-wheel.sh.
-R2_MANIFEST_URL = "https://cdn.svdailab.com/manifest.json"
-
-# Community-maintained OSS plugin catalogue — fallback for entries the curated
-# manifest does not carry. Different schema (array of entries with git+homepage
-# fields), normalized at lookup time.
-DEFAULT_INDEX_URL = (
-    "https://raw.githubusercontent.com/svd-ai-lab/sim-plugin-index/main/index.json"
-)
-
-# How long an index is treated as fresh, before we re-fetch.
-INDEX_CACHE_TTL_SECONDS = 3600
-
-
-def _index_cache_dir() -> Path:
-    return Path.home() / ".sim" / "index-cache"
-
-
-def _index_cache_path() -> Path:
-    """Cache file for the GitHub OSS index (``DEFAULT_INDEX_URL``)."""
-    return _index_cache_dir() / "index.json"
-
-
-def _r2_cache_path() -> Path:
-    """Cache file for the curated R2 manifest (``R2_MANIFEST_URL``)."""
-    return _index_cache_dir() / "manifest-r2.json"
-
-
-def _cache_for(url: str) -> Path:
-    return _r2_cache_path() if url == R2_MANIFEST_URL else _index_cache_path()
-
-
-def fetch_index(url: str = DEFAULT_INDEX_URL, *, force: bool = False, offline: bool = False) -> dict[str, Any]:
-    """Fetch a plugin index by URL. Caches under ``~/.sim/index-cache/`` keyed by URL.
-
-    In ``--offline`` mode, only the local cache is consulted; an empty index
-    is returned if no cache exists.
-    """
-    cache = _cache_for(url)
-    if offline:
-        if cache.is_file():
-            try:
-                return json.loads(cache.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                return {"schema_version": 1, "plugins": []}
-        return {"schema_version": 1, "plugins": []}
-
-    if not force and cache.is_file():
-        try:
-            age = cache.stat().st_mtime
-        except OSError:
-            age = 0
-        import time
-        if time.time() - age < INDEX_CACHE_TTL_SECONDS:
-            try:
-                return json.loads(cache.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                pass
-
-    try:
-        with urllib.request.urlopen(url, timeout=10) as resp:
-            data = resp.read().decode("utf-8")
-    except Exception:  # noqa: BLE001 — degrade if no network
-        if cache.is_file():
-            try:
-                return json.loads(cache.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                pass
-        return {"schema_version": 1, "plugins": []}
-
-    parsed = json.loads(data)
-    cache.parent.mkdir(parents=True, exist_ok=True)
-    cache.write_text(data, encoding="utf-8")
-    return parsed
-
-
-def _normalize_r2_entry(name: str, info: dict[str, Any]) -> dict[str, Any]:
-    """Convert an R2 manifest entry to the GitHub-style entry shape that
-    ``resolve_source`` consumes (``latest_version`` + ``latest_wheel_url``)."""
-    return {
-        "name": name,
-        "latest_version": info.get("version"),
-        "latest_wheel_url": info.get("wheel"),
-    }
-
-
-def _r2_lookup(name: str, *, offline: bool = False) -> dict[str, Any] | None:
-    """Look up ``name`` in the R2 curated manifest, returning a normalized entry."""
-    manifest = fetch_index(url=R2_MANIFEST_URL, offline=offline)
-    plugins = manifest.get("plugins")
-    if not isinstance(plugins, dict):
-        return None
-    info = plugins.get(name)
-    if not isinstance(info, dict) or not info.get("wheel"):
-        return None
-    return _normalize_r2_entry(name, info)
-
-
-def index_entry(name: str, *, offline: bool = False, url: str = DEFAULT_INDEX_URL) -> dict[str, Any] | None:
-    """Look up one plugin by name in a single index URL.
-
-    For ``url == R2_MANIFEST_URL`` the entry is normalized to the GitHub-style
-    shape so callers get a consistent dict regardless of which index served it.
-    """
-    if url == R2_MANIFEST_URL:
-        return _r2_lookup(name, offline=offline)
-    idx = fetch_index(url=url, offline=offline)
-    for entry in idx.get("plugins", []):
-        if entry.get("name") == name:
-            return entry
-    return None
-
-
-def index_entry_chained(name: str, *, offline: bool = False) -> dict[str, Any] | None:
-    """Resolve ``name`` against the curated R2 manifest first, then fall back
-    to the community GitHub OSS index. Returns the first hit, or ``None`` if
-    neither has it."""
-    e = _r2_lookup(name, offline=offline)
-    if e is not None:
-        return e
-    return index_entry(name, offline=offline, url=DEFAULT_INDEX_URL)
 
 
 # ── Source resolution ──────────────────────────────────────────────────────
@@ -163,7 +33,7 @@ def index_entry_chained(name: str, *, offline: bool = False) -> dict[str, Any] |
 @dataclass(frozen=True)
 class ResolvedSource:
     """One install source classified into a canonical kind."""
-    kind: str           # "name" | "wheel-url" | "sdist-url" | "git-url" | "local-wheel" | "local-sdist" | "local-dir" | "name-version"
+    kind: str
     raw: str            # the original argument
     name: str | None = None
     version: str | None = None
@@ -171,26 +41,33 @@ class ResolvedSource:
     extras: dict[str, Any] = field(default_factory=dict)
 
 
-_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
-_NAME_VERSION_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_]*)@([A-Za-z0-9._\-+]+)$")
+_SHORT_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+_SIM_PLUGIN_PACKAGE_RE = re.compile(
+    r"^(sim-plugin-[A-Za-z0-9][A-Za-z0-9_.-]*)(?:\[[A-Za-z0-9_,.-]+\])?"
+    r"(?:\s*(?:==|!=|~=|>=|<=|>|<)\s*[A-Za-z0-9.*+!_.-]+)?$"
+)
+_VERSION_PIN_RE = re.compile(r"(?:==|!=|~=|>=|<=|>|<)\s*(.+)$")
+
+
+def _short_name_error(name: str) -> str:
+    return (
+        f"{name!r} is a catalog name, not an explicit plugin install source. "
+        f"Run 'sim plugin search {name}' to discover the package, then install "
+        "with a local path, direct wheel/sdist URL, git URL, or exact package "
+        f"spec such as 'sim-plugin-{name}' if that package exists."
+    )
 
 
 def resolve_source(source: str, *, offline: bool = False,
                    index_url: str | None = None) -> ResolvedSource:
     """Classify a source argument and choose what to hand to pip.
 
-    For named installs, lookup chains the curated R2 manifest first and falls
-    back to the GitHub OSS index. Pass ``index_url`` to force a single source.
-    Prefers wheel-from-release URL when the index entry has one; falls back to
-    git+https. Raises ``ValueError`` if the name isn't in the index in offline
-    mode.
+    ``offline`` and ``index_url`` are accepted for API compatibility but no
+    longer affect resolution; this resolver never reads a plugin index or maps
+    short names to ``sim-plugin-*`` package names.
     """
     s = source.strip()
-
-    def _lookup(name: str) -> dict[str, Any] | None:
-        if index_url is None:
-            return index_entry_chained(name, offline=offline)
-        return index_entry(name, offline=offline, url=index_url)
+    _ = (offline, index_url)
 
     # Local files / dirs first (cheapest to check).
     p = Path(s)
@@ -201,7 +78,7 @@ def resolve_source(source: str, *, offline: bool = False,
                 return ResolvedSource(kind="local-wheel", raw=s, pip_target=str(target))
             if target.name.endswith(".tar.gz") or target.suffix == ".tar":
                 return ResolvedSource(kind="local-sdist", raw=s, pip_target=str(target))
-            raise ValueError(f"unsupported local file extension: {target.name}")
+            return ResolvedSource(kind="local-file", raw=s, pip_target=str(target))
         if target.is_dir():
             return ResolvedSource(kind="local-dir", raw=s, pip_target=str(target))
         # Path doesn't exist on disk and doesn't look obviously remote — error.
@@ -219,55 +96,20 @@ def resolve_source(source: str, *, offline: bool = False,
         # Generic URL: treat as wheel-url and let pip complain.
         return ResolvedSource(kind="wheel-url", raw=s, pip_target=s)
 
-    # name@version
-    m = _NAME_VERSION_RE.match(s)
-    if m:
-        name, version = m.group(1), m.group(2)
-        entry = _lookup(name)
-        if entry is None and offline:
-            raise ValueError(f"plugin {name!r} not in offline index")
-        if entry is None:
-            # Optimistic: try by-name install; pip will error if it's wrong.
-            return ResolvedSource(kind="name-version", raw=s, name=name, version=version,
-                                   pip_target=f"sim-plugin-{name}=={version}")
-        # Prefer the same wheel as latest if it matches; else fall back to git@version.
-        if entry.get("latest_version") == version and entry.get("latest_wheel_url"):
-            return ResolvedSource(kind="name-version", raw=s, name=name, version=version,
-                                   pip_target=str(entry["latest_wheel_url"]))
-        # If the entry came from the R2 manifest, all versioned wheels live at a
-        # predictable path — construct the pinned URL by filename convention so
-        # ``name@<old-version>`` resolves without needing every version listed
-        # in the manifest. (R2 keeps every published wheel; manifest only tracks
-        # latest.)
-        latest_url = str(entry.get("latest_wheel_url") or "")
-        if latest_url.startswith("https://cdn.svdailab.com/wheels/"):
-            return ResolvedSource(
-                kind="name-version", raw=s, name=name, version=version,
-                pip_target=(
-                    f"https://cdn.svdailab.com/wheels/"
-                    f"sim_plugin_{name}-{version}-py3-none-any.whl"
-                ),
-            )
-        git = entry.get("git")
-        if git:
-            return ResolvedSource(kind="name-version", raw=s, name=name, version=version,
-                                   pip_target=f"git+{git}@v{version}")
-        return ResolvedSource(kind="name-version", raw=s, name=name, version=version,
-                               pip_target=f"sim-plugin-{name}=={version}")
+    package_match = _SIM_PLUGIN_PACKAGE_RE.match(s)
+    if package_match:
+        version_match = _VERSION_PIN_RE.search(s)
+        version = version_match.group(1).strip() if version_match else None
+        return ResolvedSource(
+            kind="package-spec",
+            raw=s,
+            name=package_match.group(1),
+            version=version,
+            pip_target=s,
+        )
 
-    # bare name
-    if _NAME_RE.match(s):
-        entry = _lookup(s)
-        if entry is None and offline:
-            raise ValueError(f"plugin {s!r} not in offline index")
-        if entry is None:
-            # Optimistic: assume sim-plugin-<name> is published; pip will tell us.
-            return ResolvedSource(kind="name", raw=s, name=s, pip_target=f"sim-plugin-{s}")
-        if entry.get("latest_wheel_url"):
-            return ResolvedSource(kind="name", raw=s, name=s, pip_target=str(entry["latest_wheel_url"]))
-        if entry.get("git"):
-            return ResolvedSource(kind="name", raw=s, name=s, pip_target=f"git+{entry['git']}")
-        return ResolvedSource(kind="name", raw=s, name=s, pip_target=f"sim-plugin-{s}")
+    if _SHORT_NAME_RE.match(s):
+        raise ValueError(_short_name_error(s))
 
     raise ValueError(f"could not classify install source: {source!r}")
 
@@ -349,6 +191,7 @@ def install_plugin(
     sync_target: Path | None = None,
     skip_sync: bool = False,
     python: str | None = None,
+    extra_index_urls: list[str] | None = None,
 ) -> InstallReport:
     """High-level installer used by ``sim plugin install``.
 
@@ -369,9 +212,16 @@ def install_plugin(
             message=str(e),
         )
 
+    extra_args: list[str] = []
+    for extra_index_url in extra_index_urls or []:
+        extra_args.extend(["--extra-index-url", extra_index_url])
+
     proc = _pip_install(
         resolved.pip_target,
-        editable=editable, upgrade=upgrade, python=python,
+        editable=editable,
+        upgrade=upgrade,
+        python=python,
+        extra_args=extra_args or None,
     )
     ok = proc.returncode == 0
 
@@ -464,65 +314,36 @@ def uninstall_plugin(name: str, *, sync: bool = True,
 
 
 def bundle_plugins(names: list[str], output_dir: Path, *,
-                    index_url: str = DEFAULT_INDEX_URL) -> dict[str, Any]:
-    """Download wheels for the named plugins into ``output_dir`` for offline use.
+                    index_url: str | None = None) -> dict[str, Any]:
+    """The install-resolver-backed bundle flow was removed.
 
-    Produces ``<output_dir>/index.json`` filtered to just the bundled plugins,
-    rewritten with ``file://`` URLs so ``sim plugin install --offline
-    --from-dir <output_dir>`` works.
+    Use the discovery catalogue to find plugins, then download explicit wheel
+    URLs or install exact package specs. The catalogue itself is not an
+    install-time resolver.
     """
-    output_dir = output_dir.expanduser().resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    idx = fetch_index(url=index_url)
-    by_name = {e["name"]: e for e in idx.get("plugins", [])}
-
-    fetched: list[dict[str, Any]] = []
-    errors: list[dict[str, Any]] = []
-
-    for name in names:
-        entry = by_name.get(name)
-        if entry is None:
-            errors.append({"name": name, "error": "not in index"})
-            continue
-        wheel_url = entry.get("latest_wheel_url")
-        if not wheel_url:
-            errors.append({"name": name, "error": "index entry has no latest_wheel_url"})
-            continue
-        wheel_basename = Path(wheel_url.split("?")[0]).name
-        dest = output_dir / wheel_basename
-        try:
-            with urllib.request.urlopen(wheel_url, timeout=30) as resp, dest.open("wb") as f:
-                shutil.copyfileobj(resp, f)
-        except Exception as e:  # noqa: BLE001 — surface fetch errors
-            errors.append({"name": name, "error": f"download failed: {e}"})
-            continue
-
-        rewritten = dict(entry)
-        rewritten["latest_wheel_url"] = f"file://{dest}"
-        fetched.append(rewritten)
-
-    bundle_idx = {"schema_version": 1, "plugins": fetched}
-    (output_dir / "index.json").write_text(
-        json.dumps(bundle_idx, indent=2) + "\n", encoding="utf-8",
-    )
-
+    _ = (names, output_dir, index_url)
     return {
-        "ok": not errors,
+        "ok": False,
         "output": str(output_dir),
-        "fetched": [e["name"] for e in fetched],
-        "errors": errors,
+        "fetched": [],
+        "errors": [
+            {
+                "name": name,
+                "error": (
+                    "bundle no longer resolves catalogue names; use "
+                    "sim plugin catalog/search to discover plugins, then pass "
+                    "explicit wheel URLs, local artifacts, git URLs, or exact "
+                    "package specs"
+                ),
+            }
+            for name in names
+        ],
     }
 
 
 __all__ = [
-    "DEFAULT_INDEX_URL",
-    "R2_MANIFEST_URL",
     "ResolvedSource",
     "InstallReport",
-    "fetch_index",
-    "index_entry",
-    "index_entry_chained",
     "resolve_source",
     "install_plugin",
     "uninstall_plugin",

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -1034,49 +1034,14 @@ def plugin_catalog_cmd(ctx, offline, refresh, catalog_url):
 
     click.echo(f"[sim] {len(rows)} available plugin(s) in catalog:")
     for r in rows:
-        ver = f" {r.latest_version}" if r.latest_version else ""
+        ver = f" {r.version}" if r.version else ""
         license_class = f" ({r.license_class})" if r.license_class else ""
-        click.echo(f"  {r.name:20s} {r.package}{ver}{license_class}")
+        dist = f" [{r.distribution}]" if r.distribution else ""
+        click.echo(f"  {r.id:20s} {r.name}{ver}{dist}{license_class}")
         if r.summary:
             click.echo(f"    {r.summary}")
-        click.echo(f"    install: {r.install_command}")
-
-
-@plugin.command("search")
-@click.argument("query")
-@click.option("--offline", is_flag=True,
-              help="Use the cached discovery catalogue only.")
-@click.option("--refresh", is_flag=True,
-              help="Refresh the cached discovery catalogue.")
-@click.option("--catalog-url", default=None,
-              help="Override the discovery catalogue URL.")
-@click.pass_context
-def plugin_search_cmd(ctx, query, offline, refresh, catalog_url):
-    """Search available plugins in the discovery catalogue."""
-    from sim.plugin_catalog import DEFAULT_CATALOG_URL, list_catalog
-
-    rows = list_catalog(
-        query=query,
-        url=catalog_url or DEFAULT_CATALOG_URL,
-        offline=offline,
-        force=refresh,
-    )
-    if ctx.obj["json"]:
-        click.echo(json_mod.dumps([r.to_dict() for r in rows], indent=2))
-        return
-
-    if not rows:
-        click.echo(f"[sim] plugin search: no catalog matches for {query!r}")
-        return
-
-    click.echo(f"[sim] {len(rows)} catalog match(es):")
-    for r in rows:
-        ver = f" {r.latest_version}" if r.latest_version else ""
-        license_class = f" ({r.license_class})" if r.license_class else ""
-        click.echo(f"  {r.name:20s} {r.package}{ver}{license_class}")
-        if r.summary:
-            click.echo(f"    {r.summary}")
-        click.echo(f"    install: {r.install_command}")
+        if r.install:
+            click.echo(f"    install: sim plugin install {r.install}")
 
 
 @plugin.command("list")

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -341,7 +341,7 @@ def lint(ctx, script):
                 level="error",
                 message=(
                     f"No registered driver claims {script_path.name!r}. "
-                    "Install the matching plugin (e.g. `sim plugin install <solver>`) "
+                    "Install the matching plugin (e.g. `sim plugin install sim-plugin-<solver>`) "
                     "or pass `sim run` if you want to attempt execution anyway."
                 ),
             )],
@@ -921,7 +921,7 @@ def init(ctx, force):
 @click.option("--config", "config_path", type=click.Path(exists=True, dir_okay=False, path_type=Path),
               default=None, help="Override the sim.toml location.")
 @click.option("--offline", is_flag=True,
-              help="Resolve plugins from the cached index only (no network).")
+              help="Accepted for compatibility; plugin install no longer uses an index.")
 @click.option("--dry-run", is_flag=True,
               help="Print what would happen without installing anything.")
 @click.pass_context
@@ -999,8 +999,84 @@ def plugin():
 
     Plugins extend sim with additional solvers. Each plugin ships its
     driver + skill in one wheel; see docs/plugin-install.md for the install
-    flows (online by name, local wheel, air-gapped bundle, etc.).
+    flows (package spec, direct URL, local wheel, git URL, etc.).
     """
+
+
+@plugin.command("catalog")
+@click.option("--offline", is_flag=True,
+              help="Use the cached discovery catalogue only.")
+@click.option("--refresh", is_flag=True,
+              help="Refresh the cached discovery catalogue.")
+@click.option("--catalog-url", default=None,
+              help="Override the discovery catalogue URL.")
+@click.pass_context
+def plugin_catalog_cmd(ctx, offline, refresh, catalog_url):
+    """List available plugins from the discovery catalogue.
+
+    This is discovery only. Install commands remain explicit and pip-native;
+    the catalogue is not used to silently resolve short names during install.
+    """
+    from sim.plugin_catalog import DEFAULT_CATALOG_URL, list_catalog
+
+    rows = list_catalog(
+        url=catalog_url or DEFAULT_CATALOG_URL,
+        offline=offline,
+        force=refresh,
+    )
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps([r.to_dict() for r in rows], indent=2))
+        return
+
+    if not rows:
+        click.echo("[sim] plugin catalog: no available plugins found")
+        return
+
+    click.echo(f"[sim] {len(rows)} available plugin(s) in catalog:")
+    for r in rows:
+        ver = f" {r.latest_version}" if r.latest_version else ""
+        license_class = f" ({r.license_class})" if r.license_class else ""
+        click.echo(f"  {r.name:20s} {r.package}{ver}{license_class}")
+        if r.summary:
+            click.echo(f"    {r.summary}")
+        click.echo(f"    install: {r.install_command}")
+
+
+@plugin.command("search")
+@click.argument("query")
+@click.option("--offline", is_flag=True,
+              help="Use the cached discovery catalogue only.")
+@click.option("--refresh", is_flag=True,
+              help="Refresh the cached discovery catalogue.")
+@click.option("--catalog-url", default=None,
+              help="Override the discovery catalogue URL.")
+@click.pass_context
+def plugin_search_cmd(ctx, query, offline, refresh, catalog_url):
+    """Search available plugins in the discovery catalogue."""
+    from sim.plugin_catalog import DEFAULT_CATALOG_URL, list_catalog
+
+    rows = list_catalog(
+        query=query,
+        url=catalog_url or DEFAULT_CATALOG_URL,
+        offline=offline,
+        force=refresh,
+    )
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps([r.to_dict() for r in rows], indent=2))
+        return
+
+    if not rows:
+        click.echo(f"[sim] plugin search: no catalog matches for {query!r}")
+        return
+
+    click.echo(f"[sim] {len(rows)} catalog match(es):")
+    for r in rows:
+        ver = f" {r.latest_version}" if r.latest_version else ""
+        license_class = f" ({r.license_class})" if r.license_class else ""
+        click.echo(f"  {r.name:20s} {r.package}{ver}{license_class}")
+        if r.summary:
+            click.echo(f"    {r.summary}")
+        click.echo(f"    install: {r.install_command}")
 
 
 @plugin.command("list")
@@ -1091,7 +1167,7 @@ def plugin_info_cmd(ctx, name):
                    "Default: enabled. Use --no-upgrade to keep an existing "
                    "install if one is already present.")
 @click.option("--offline", is_flag=True,
-              help="Use only the local cached index; no network calls.")
+              help="Accepted for compatibility; plugin install no longer uses an index.")
 @click.option("--no-sync", "no_sync", is_flag=True,
               help="Skip sync-skills after install.")
 @click.option("--target", "sync_target", type=click.Path(file_okay=False, path_type=Path),
@@ -1101,20 +1177,23 @@ def plugin_info_cmd(ctx, name):
               help="Pin the target Python interpreter for the install. "
                    "Defaults to the interpreter running sim — use this "
                    "when sim is on PATH but the desired venv isn't activated.")
+@click.option("--extra-index-url", "extra_index_urls", multiple=True,
+              help="Additional Python package index for private plugins. "
+                   "Passed through to pip/uv pip install.")
 @click.pass_context
 def plugin_install(ctx, source, editable, upgrade, offline, no_sync, sync_target,
-                    python_exe):
+                    python_exe, extra_index_urls):
     """Install a plugin from any supported source.
 
     \b
     Examples:
-      sim plugin install coolprop                          # by name (online index)
-      sim plugin install coolprop@0.1.0                    # pinned version
+      sim plugin install sim-plugin-coolprop               # exact package spec
+      sim plugin install sim-plugin-coolprop==0.1.0        # pinned package spec
       sim plugin install ./sim_plugin_coolprop-0.1.0-py3-none-any.whl
       sim plugin install ./sim-plugin-coolprop -e          # editable, for authors
       sim plugin install git+https://github.com/svd-ai-lab/sim-plugin-coolprop
-      sim plugin install --offline coolprop                # use cached index only
-      sim plugin install coolprop --python /path/to/venv/bin/python
+      sim plugin install sim-plugin-coolprop --python /path/to/venv/bin/python
+      sim plugin install sim-plugin-mechanical --extra-index-url https://example.com/simple/
     """
     from sim._plugin_install import install_plugin
 
@@ -1123,6 +1202,7 @@ def plugin_install(ctx, source, editable, upgrade, offline, no_sync, sync_target
         editable=editable, upgrade=upgrade, offline=offline,
         sync_target=sync_target, skip_sync=no_sync,
         python=python_exe,
+        extra_index_urls=list(extra_index_urls),
     )
 
     if ctx.obj["json"]:
@@ -1171,12 +1251,11 @@ def plugin_uninstall(ctx, name, python_exe):
               help="Output directory for wheels + filtered index.json.")
 @click.pass_context
 def plugin_bundle(ctx, names, output):
-    """Download wheels for the named plugins into a directory for offline install.
+    """Deprecated: index-backed plugin bundles are no longer supported.
 
     \b
     Examples:
-      sim plugin bundle coolprop simpy gmsh -o ./plugins-bundle/
-      sim plugin install --offline --from-dir ./plugins-bundle/ coolprop
+      sim plugin install ./vendor/sim_plugin_coolprop-0.1.0-py3-none-any.whl
     """
     from sim._plugin_install import bundle_plugins
 

--- a/src/sim/compat.py
+++ b/src/sim/compat.py
@@ -185,7 +185,7 @@ def load_compatibility_by_name(driver_name: str) -> "Compatibility | None":
         if not traversable.is_file():
             return None
         text = traversable.read_text(encoding="utf-8")
-    except (FileNotFoundError, ModuleNotFoundError, OSError):
+    except (FileNotFoundError, ModuleNotFoundError, OSError, TypeError):
         return None
     return _parse_compatibility_text(driver_name, text)
 

--- a/src/sim/config.py
+++ b/src/sim/config.py
@@ -271,11 +271,12 @@ SIM_TOML_STUB = """\
 # workspace = "./workspace"
 
 # Each entry under [[sim.plugins]] declares one plugin to install.
-# Sources accepted: name (resolved via the public index), git+https://...,
+# Sources accepted: package = "sim-plugin-...", git+https://...,
 # wheel = "./path/to/file.whl", or version = "==X.Y.Z" / ">=X".
 #
 # [[sim.plugins]]
 # name = "coolprop"
+# package = "sim-plugin-coolprop"
 # version = ">=0.1.0"
 """
 
@@ -311,6 +312,7 @@ def validate_sim_toml(path: Path) -> list[str]:
 
         [[sim.plugins]]
         name    = <string>           # required
+        package = <string>?          # exact pip package name/spec
         version = <string>?
         git     = <string>?
         wheel   = <string>?          # local path
@@ -351,7 +353,7 @@ def validate_sim_toml(path: Path) -> list[str]:
             if "name" not in p or not isinstance(p["name"], str):
                 errors.append(f"[[sim.plugins]] entry #{i} missing required 'name'")
                 continue
-            for k in ("version", "git", "wheel"):
+            for k in ("package", "version", "git", "wheel"):
                 if k in p and not isinstance(p[k], str):
                     errors.append(f"[[sim.plugins]] {p['name']!r} field {k!r} must be a string")
 
@@ -362,19 +364,14 @@ def derive_install_source(plugin_entry: dict[str, Any]) -> str:
     """Translate one [[sim.plugins]] entry to an install-source string.
 
     Resolution priority: explicit ``wheel`` path > explicit ``git`` URL
-    > ``name@version`` if version set > bare ``name``.
+    > explicit ``package`` plus optional version > ``name``.
     """
     if "wheel" in plugin_entry:
         return plugin_entry["wheel"]
     if "git" in plugin_entry:
         return f"git+{plugin_entry['git']}"
-    name = plugin_entry["name"]
+    package = plugin_entry.get("package") or plugin_entry["name"]
     version = plugin_entry.get("version")
     if version:
-        # Strip leading == / >= so it composes with our @ form.
-        v = version.lstrip(">=<! ")
-        if version.startswith("=="):
-            return f"{name}@{v}"
-        # Range constraints: fall back to bare name and let pip resolve.
-        return name
-    return name
+        return f"{package}{version}"
+    return package

--- a/src/sim/describe.py
+++ b/src/sim/describe.py
@@ -119,13 +119,21 @@ _EXAMPLES: dict[str, list[dict[str, str]]] = {
         {"cmd": "sim plugin list --json",
          "summary": "List every registered plugin (built-in + external)."},
     ],
+    "plugin catalog": [
+        {"cmd": "sim plugin catalog --json",
+         "summary": "List available plugins from the discovery catalogue."},
+    ],
+    "plugin search": [
+        {"cmd": "sim plugin search ltspice --json",
+         "summary": "Search the discovery catalogue for package and install guidance."},
+    ],
     "plugin info": [
         {"cmd": "sim plugin info coolprop",
          "summary": "Show one plugin's metadata and compatibility profiles."},
     ],
     "plugin install": [
-        {"cmd": "sim plugin install coolprop",
-         "summary": "Install a plugin by name (resolves via the index)."},
+        {"cmd": "sim plugin install sim-plugin-coolprop",
+         "summary": "Install from an exact package spec."},
         {"cmd": "sim plugin install ./sim_plugin_coolprop-0.1.0-py3-none-any.whl",
          "summary": "Install from a local wheel (offline-friendly)."},
         {"cmd": "sim plugin install ./sim-plugin-coolprop -e",
@@ -168,7 +176,7 @@ ERROR_CODES: dict[str, str] = {
     "SESSION_NOT_FOUND":
         "--session <id> does not match any active session on the server.",
     "PLUGIN_NOT_FOUND":
-        "sim plugin could not resolve a plugin name (not in the index, no local file).",
+        "sim plugin install received an invalid explicit source, or a plugin name is not installed.",
     "PLUGIN_INSTALL_FAILED":
         "pip install for a plugin returned non-zero.",
     "PROTOCOL_VIOLATION":

--- a/src/sim/history.py
+++ b/src/sim/history.py
@@ -31,6 +31,7 @@ SCHEMA_FIELDS = (
     "duration_ms",
     "error",
     "parsed_output",
+    "workspace_delta",
 )
 
 
@@ -63,6 +64,11 @@ def _normalize(record: dict[str, Any]) -> dict[str, Any]:
     # Parsed output is optional but commonly present for one-shot runs.
     if "parsed_output" in record:
         out["parsed_output"] = record["parsed_output"]
+    # Workspace delta is optional for older records, but new one-shot runs
+    # persist it so `sim logs <id> --field workspace` can drill into files
+    # written by solver processes.
+    if "workspace_delta" in record:
+        out["workspace_delta"] = record["workspace_delta"]
     # Preserve script path for one-shot runs so `sim logs` can show it.
     if "script" in record:
         out["script"] = record["script"]

--- a/src/sim/plugin_catalog.py
+++ b/src/sim/plugin_catalog.py
@@ -2,8 +2,29 @@
 
 The catalogue answers "what plugins exist?" for users and agents. It is
 intentionally separate from ``sim plugin install`` source resolution: catalogue
-entries may suggest explicit install commands, but installing still requires a
-pip-native package spec, URL, git URL, or local path.
+entries advertise an explicit install string, but installing still requires the
+caller to pass that string (or any other pip-native source) to
+``sim plugin install``. The catalogue is advisory metadata, not a trust
+boundary or a runtime resolver.
+
+Schema (sim-plugin-index ``index.json``, ``schema_version: 2``):
+
+    {
+      "id":           "ltspice",                  # short slug
+      "name":         "LTspice",                  # display name
+      "distribution": "pypi" | "wheel" | "git",   # advisory tag
+      "install":      "sim-plugin-ltspice==0.2.3" # literal arg to `sim plugin install`
+                      | "https://.../foo.whl#sha256=..."
+                      | "git+https://...",
+      "version":      "0.2.3",
+      "summary":      "...",                      # optional, display only
+      "homepage":     "...",                      # optional, display only
+      "license_class": "oss" | "commercial"       # optional, display only
+    }
+
+The reader also accepts the legacy ``schema_version: 1`` shape (``name`` as
+slug, ``latest_version``, ``latest_wheel_url``/``git``/``package``) so the
+catalogue can migrate independently of sim-cli releases.
 """
 from __future__ import annotations
 
@@ -26,26 +47,28 @@ def _catalog_cache_path() -> Path:
 
 @dataclass(frozen=True)
 class CatalogEntry:
-    """One available plugin as shown by the discovery catalogue."""
+    """One available plugin as advertised by the discovery catalogue."""
 
-    name: str
-    package: str
+    id: str                     # short slug, e.g. "ltspice"
+    name: str = ""              # display name, e.g. "LTspice"
+    distribution: str = ""      # "pypi" | "wheel" | "git" | ""
+    install: str = ""           # literal arg to `sim plugin install`
+    version: str = ""           # advertised current version
     summary: str = ""
     homepage: str = ""
     license_class: str = ""
-    latest_version: str = ""
-    install_command: str = ""
     source: str = "catalog"
 
     def to_dict(self) -> dict[str, str]:
         return {
+            "id": self.id,
             "name": self.name,
-            "package": self.package,
+            "distribution": self.distribution,
+            "install": self.install,
+            "version": self.version,
             "summary": self.summary,
             "homepage": self.homepage,
             "license_class": self.license_class,
-            "latest_version": self.latest_version,
-            "install_command": self.install_command,
             "source": self.source,
         }
 
@@ -58,8 +81,7 @@ def fetch_catalog(
 ) -> dict[str, Any]:
     """Fetch the plugin discovery catalogue with a small local cache.
 
-    The cache is only for discovery. It is never used by ``resolve_source`` or
-    install-time short-name resolution.
+    The cache is only for discovery. It is never consulted at install time.
     """
 
     cache = _catalog_cache_path()
@@ -68,8 +90,8 @@ def fetch_catalog(
             try:
                 return json.loads(cache.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError):
-                return {"schema_version": 1, "plugins": []}
-        return {"schema_version": 1, "plugins": []}
+                return {"schema_version": 2, "plugins": []}
+        return {"schema_version": 2, "plugins": []}
 
     if not force and cache.is_file():
         try:
@@ -88,58 +110,85 @@ def fetch_catalog(
                 return json.loads(cache.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError):
                 pass
-        return {"schema_version": 1, "plugins": []}
+        return {"schema_version": 2, "plugins": []}
 
     cache.parent.mkdir(parents=True, exist_ok=True)
     cache.write_text(data, encoding="utf-8")
     return parsed
 
 
-def _default_package_name(name: str) -> str:
-    return f"sim-plugin-{name.replace('_', '-')}"
+def _legacy_install_string(raw: dict[str, Any]) -> tuple[str, str]:
+    """Derive (install, distribution) from a v1 catalogue entry.
+
+    v1 entries had ``package`` / ``latest_version`` / ``latest_wheel_url`` /
+    ``git`` instead of a single ``install`` string. Order of preference:
+    pinned wheel URL → PyPI package spec → git URL → bare package name.
+    """
+    package = str(raw.get("package") or raw.get("pypi_package") or "").strip()
+    version = str(raw.get("latest_version") or raw.get("version") or "").strip()
+    wheel_url = str(raw.get("latest_wheel_url") or "").strip()
+    git_url = str(raw.get("git") or "").strip()
+
+    if wheel_url:
+        return wheel_url, "wheel"
+    if package and version:
+        return f"{package}=={version}", "pypi"
+    if package:
+        return package, "pypi"
+    if git_url:
+        return f"git+{git_url}", "git"
+    return "", ""
 
 
 def _entry_from_mapping(raw: dict[str, Any], *, source: str) -> CatalogEntry | None:
-    name = str(raw.get("name") or "").strip()
-    if not name:
+    # Slug: prefer v2 `id`, fall back to v1 `name`.
+    slug = str(raw.get("id") or raw.get("name") or "").strip()
+    if not slug:
         return None
 
-    package = str(raw.get("package") or raw.get("pypi_package") or _default_package_name(name))
-    latest_version = str(raw.get("latest_version") or raw.get("version") or "")
-    install = raw.get("install")
-    install_command = ""
-    if isinstance(install, dict):
-        install_command = str(install.get("command") or "")
-    elif isinstance(install, str):
-        install_command = install
-    if not install_command:
-        install_command = f"sim plugin install {package}"
-        if latest_version and raw.get("pin_latest"):
-            install_command = f"sim plugin install {package}=={latest_version}"
+    # Display name: prefer explicit `name`, fall back to slug.
+    display = str(raw.get("name") or slug).strip()
+    # If both `id` and `name` were absent we used `name` as slug — re-derive
+    # display from the slug to avoid showing the raw key as both fields.
+    if not raw.get("id") and raw.get("name"):
+        display = str(raw["name"]).strip()
+
+    distribution = str(raw.get("distribution") or "").strip()
+    install = str(raw.get("install") or "").strip()
+    version = str(raw.get("version") or raw.get("latest_version") or "").strip()
+
+    # v1 fallback: synthesize install + distribution from legacy fields.
+    if not install:
+        install, legacy_dist = _legacy_install_string(raw)
+        if not distribution:
+            distribution = legacy_dist
 
     return CatalogEntry(
-        name=name,
-        package=package,
+        id=slug,
+        name=display,
+        distribution=distribution,
+        install=install,
+        version=version,
         summary=str(raw.get("summary") or raw.get("description") or ""),
         homepage=str(raw.get("homepage") or raw.get("url") or raw.get("git") or ""),
         license_class=str(raw.get("license_class") or raw.get("license") or ""),
-        latest_version=latest_version,
-        install_command=install_command,
         source=source,
     )
 
 
 def normalize_catalog(raw: dict[str, Any], *, source: str = "catalog") -> list[CatalogEntry]:
-    """Normalize current and future catalogue shapes into ``CatalogEntry`` rows."""
+    """Normalize current and legacy catalogue shapes into ``CatalogEntry`` rows."""
 
     plugins = raw.get("plugins", [])
     if isinstance(plugins, dict):
         iterable = []
-        for name, info in plugins.items():
+        for slug, info in plugins.items():
             if isinstance(info, dict):
-                item = {"name": name, **info}
+                # If the value already carries `id` we trust it; otherwise
+                # promote the dict key to the slug.
+                item = {"id": slug, **info} if "id" not in info else dict(info)
             else:
-                item = {"name": name}
+                item = {"id": slug}
             iterable.append(item)
     elif isinstance(plugins, list):
         iterable = [p for p in plugins if isinstance(p, dict)]
@@ -151,7 +200,7 @@ def normalize_catalog(raw: dict[str, Any], *, source: str = "catalog") -> list[C
         row = _entry_from_mapping(item, source=source)
         if row is not None:
             rows.append(row)
-    return sorted(rows, key=lambda r: r.name.lower())
+    return sorted(rows, key=lambda r: r.id.lower())
 
 
 def list_catalog(
@@ -161,7 +210,13 @@ def list_catalog(
     offline: bool = False,
     force: bool = False,
 ) -> list[CatalogEntry]:
-    """List/search available plugins from the discovery catalogue."""
+    """List available plugins from the discovery catalogue.
+
+    ``query`` is an optional case-insensitive substring filter over
+    ``id``/``name``/``summary``/``homepage``. Kept as a helper-level option for
+    callers that want to filter the same data; the CLI exposes only the full
+    listing (``sim plugin catalog``).
+    """
 
     raw = fetch_catalog(url=url, offline=offline, force=force)
     rows = normalize_catalog(raw, source=url)
@@ -170,8 +225,8 @@ def list_catalog(
     q = query.lower()
     return [
         row for row in rows
-        if q in row.name.lower()
-        or q in row.package.lower()
+        if q in row.id.lower()
+        or q in row.name.lower()
         or q in row.summary.lower()
         or q in row.homepage.lower()
     ]

--- a/src/sim/plugin_catalog.py
+++ b/src/sim/plugin_catalog.py
@@ -1,0 +1,177 @@
+"""Plugin catalogue/discovery helpers.
+
+The catalogue answers "what plugins exist?" for users and agents. It is
+intentionally separate from ``sim plugin install`` source resolution: catalogue
+entries may suggest explicit install commands, but installing still requires a
+pip-native package spec, URL, git URL, or local path.
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CATALOG_URL = (
+    "https://raw.githubusercontent.com/svd-ai-lab/sim-plugin-index/main/index.json"
+)
+CATALOG_CACHE_TTL_SECONDS = 3600
+
+
+def _catalog_cache_path() -> Path:
+    return Path.home() / ".sim" / "index-cache" / "catalog.json"
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    """One available plugin as shown by the discovery catalogue."""
+
+    name: str
+    package: str
+    summary: str = ""
+    homepage: str = ""
+    license_class: str = ""
+    latest_version: str = ""
+    install_command: str = ""
+    source: str = "catalog"
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "package": self.package,
+            "summary": self.summary,
+            "homepage": self.homepage,
+            "license_class": self.license_class,
+            "latest_version": self.latest_version,
+            "install_command": self.install_command,
+            "source": self.source,
+        }
+
+
+def fetch_catalog(
+    url: str = DEFAULT_CATALOG_URL,
+    *,
+    force: bool = False,
+    offline: bool = False,
+) -> dict[str, Any]:
+    """Fetch the plugin discovery catalogue with a small local cache.
+
+    The cache is only for discovery. It is never used by ``resolve_source`` or
+    install-time short-name resolution.
+    """
+
+    cache = _catalog_cache_path()
+    if offline:
+        if cache.is_file():
+            try:
+                return json.loads(cache.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                return {"schema_version": 1, "plugins": []}
+        return {"schema_version": 1, "plugins": []}
+
+    if not force and cache.is_file():
+        try:
+            if time.time() - cache.stat().st_mtime < CATALOG_CACHE_TTL_SECONDS:
+                return json.loads(cache.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            data = resp.read().decode("utf-8")
+        parsed = json.loads(data)
+    except Exception:  # noqa: BLE001 - discovery should degrade gracefully
+        if cache.is_file():
+            try:
+                return json.loads(cache.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                pass
+        return {"schema_version": 1, "plugins": []}
+
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(data, encoding="utf-8")
+    return parsed
+
+
+def _default_package_name(name: str) -> str:
+    return f"sim-plugin-{name.replace('_', '-')}"
+
+
+def _entry_from_mapping(raw: dict[str, Any], *, source: str) -> CatalogEntry | None:
+    name = str(raw.get("name") or "").strip()
+    if not name:
+        return None
+
+    package = str(raw.get("package") or raw.get("pypi_package") or _default_package_name(name))
+    latest_version = str(raw.get("latest_version") or raw.get("version") or "")
+    install = raw.get("install")
+    install_command = ""
+    if isinstance(install, dict):
+        install_command = str(install.get("command") or "")
+    elif isinstance(install, str):
+        install_command = install
+    if not install_command:
+        install_command = f"sim plugin install {package}"
+        if latest_version and raw.get("pin_latest"):
+            install_command = f"sim plugin install {package}=={latest_version}"
+
+    return CatalogEntry(
+        name=name,
+        package=package,
+        summary=str(raw.get("summary") or raw.get("description") or ""),
+        homepage=str(raw.get("homepage") or raw.get("url") or raw.get("git") or ""),
+        license_class=str(raw.get("license_class") or raw.get("license") or ""),
+        latest_version=latest_version,
+        install_command=install_command,
+        source=source,
+    )
+
+
+def normalize_catalog(raw: dict[str, Any], *, source: str = "catalog") -> list[CatalogEntry]:
+    """Normalize current and future catalogue shapes into ``CatalogEntry`` rows."""
+
+    plugins = raw.get("plugins", [])
+    if isinstance(plugins, dict):
+        iterable = []
+        for name, info in plugins.items():
+            if isinstance(info, dict):
+                item = {"name": name, **info}
+            else:
+                item = {"name": name}
+            iterable.append(item)
+    elif isinstance(plugins, list):
+        iterable = [p for p in plugins if isinstance(p, dict)]
+    else:
+        iterable = []
+
+    rows = []
+    for item in iterable:
+        row = _entry_from_mapping(item, source=source)
+        if row is not None:
+            rows.append(row)
+    return sorted(rows, key=lambda r: r.name.lower())
+
+
+def list_catalog(
+    *,
+    query: str | None = None,
+    url: str = DEFAULT_CATALOG_URL,
+    offline: bool = False,
+    force: bool = False,
+) -> list[CatalogEntry]:
+    """List/search available plugins from the discovery catalogue."""
+
+    raw = fetch_catalog(url=url, offline=offline, force=force)
+    rows = normalize_catalog(raw, source=url)
+    if not query:
+        return rows
+    q = query.lower()
+    return [
+        row for row in rows
+        if q in row.name.lower()
+        or q in row.package.lower()
+        or q in row.summary.lower()
+        or q in row.homepage.lower()
+    ]

--- a/tests/base/test_cli.py
+++ b/tests/base/test_cli.py
@@ -13,9 +13,9 @@ def test_version():
     runner = CliRunner()
     result = runner.invoke(main, ["--version"])
     assert result.exit_code == 0
-    from importlib.metadata import version
+    from sim import __version__
 
-    assert version("sim-cli") in result.output
+    assert __version__ in result.output
 
 
 def test_help():
@@ -55,7 +55,7 @@ def test_python_m_sim_invocation():
     which exists so dev users can launch ``sim serve`` without holding a
     Windows file lock on ``Scripts/sim.exe`` during ``uv sync``.
     """
-    from importlib.metadata import version
+    from sim import __version__
 
     result = subprocess.run(
         [sys.executable, "-m", "sim", "--version"],
@@ -67,7 +67,7 @@ def test_python_m_sim_invocation():
     # Click reports prog_name as "python -m sim" here (sys.argv[0] is the
     # module path); accept either form alongside the actual version string.
     assert "version" in result.stdout
-    assert version("sim-cli-core") in result.stdout
+    assert __version__ in result.stdout
 
 
 def test_check_all_json_shape():

--- a/tests/base/test_init_setup.py
+++ b/tests/base/test_init_setup.py
@@ -70,6 +70,7 @@ server_port = 7600
 
 [[sim.plugins]]
 name = "coolprop"
+package = "sim-plugin-coolprop"
 version = ">=0.1.0"
 
 [[sim.plugins]]
@@ -93,13 +94,21 @@ def test_derive_source_from_git():
 
 
 def test_derive_source_from_pinned_version():
-    s = _cfg.derive_install_source({"name": "x", "version": "==1.2.3"})
-    assert s == "x@1.2.3"
+    s = _cfg.derive_install_source({
+        "name": "x",
+        "package": "sim-plugin-x",
+        "version": "==1.2.3",
+    })
+    assert s == "sim-plugin-x==1.2.3"
 
 
-def test_derive_source_from_range_falls_back_to_bare_name():
-    s = _cfg.derive_install_source({"name": "x", "version": ">=0.1"})
-    assert s == "x"
+def test_derive_source_from_range_uses_package_spec():
+    s = _cfg.derive_install_source({
+        "name": "x",
+        "package": "sim-plugin-x",
+        "version": ">=0.1",
+    })
+    assert s == "sim-plugin-x>=0.1"
 
 
 def test_derive_source_bare_name():
@@ -181,6 +190,7 @@ def test_cli_setup_dry_run_lists_what_would_install(runner: CliRunner, tmp_path:
 [sim]
 [[sim.plugins]]
 name = "coolprop"
+package = "sim-plugin-coolprop"
 version = "==0.1.0"
 """.strip(), encoding="utf-8")
     r = runner.invoke(main, ["--json", "setup", "--dry-run"])
@@ -189,5 +199,5 @@ version = "==0.1.0"
     assert data["ok"] is True
     assert len(data["plugins"]) == 1
     assert data["plugins"][0]["name"] == "coolprop"
-    assert data["plugins"][0]["source"] == "coolprop@0.1.0"
+    assert data["plugins"][0]["source"] == "sim-plugin-coolprop==0.1.0"
     assert data["plugins"][0]["action"] == "would-install"

--- a/tests/base/test_plugin_catalog.py
+++ b/tests/base/test_plugin_catalog.py
@@ -1,0 +1,59 @@
+"""Tests for plugin catalogue/discovery helpers."""
+from __future__ import annotations
+
+from sim.plugin_catalog import list_catalog, normalize_catalog
+
+
+def test_normalize_current_index_shape_defaults_to_package_spec():
+    rows = normalize_catalog({
+        "schema_version": 1,
+        "plugins": [
+            {
+                "name": "ltspice",
+                "summary": "LTspice driver",
+                "homepage": "https://github.com/svd-ai-lab/sim-plugin-ltspice",
+                "license_class": "oss",
+                "latest_version": "0.2.3",
+            }
+        ],
+    })
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.name == "ltspice"
+    assert row.package == "sim-plugin-ltspice"
+    assert row.install_command == "sim plugin install sim-plugin-ltspice"
+    assert row.latest_version == "0.2.3"
+
+
+def test_normalize_future_dict_shape_and_install_command():
+    rows = normalize_catalog({
+        "plugins": {
+            "mechanical": {
+                "package": "sim-plugin-mechanical",
+                "license_class": "commercial-wrapper",
+                "install": {
+                    "command": "sim plugin install sim-plugin-mechanical --extra-index-url https://example.com/simple/"
+                },
+            }
+        }
+    })
+    assert rows[0].name == "mechanical"
+    assert rows[0].license_class == "commercial-wrapper"
+    assert "--extra-index-url" in rows[0].install_command
+
+
+def test_list_catalog_search_uses_catalog_without_install_resolution(monkeypatch):
+    from sim import plugin_catalog
+
+    def fake_fetch_catalog(**kwargs):
+        return {
+            "plugins": [
+                {"name": "ltspice", "summary": "Circuit simulation"},
+                {"name": "flotherm", "summary": "Thermal simulation"},
+            ]
+        }
+
+    monkeypatch.setattr(plugin_catalog, "fetch_catalog", fake_fetch_catalog)
+    rows = list_catalog(query="thermal")
+    assert [row.name for row in rows] == ["flotherm"]
+    assert rows[0].install_command == "sim plugin install sim-plugin-flotherm"

--- a/tests/base/test_plugin_catalog.py
+++ b/tests/base/test_plugin_catalog.py
@@ -4,7 +4,56 @@ from __future__ import annotations
 from sim.plugin_catalog import list_catalog, normalize_catalog
 
 
-def test_normalize_current_index_shape_defaults_to_package_spec():
+def test_normalize_v2_pypi_entry():
+    rows = normalize_catalog({
+        "schema_version": 2,
+        "plugins": [
+            {
+                "id": "ltspice",
+                "name": "LTspice",
+                "distribution": "pypi",
+                "install": "sim-plugin-ltspice==0.2.3",
+                "version": "0.2.3",
+                "summary": "LTspice driver",
+                "homepage": "https://github.com/svd-ai-lab/sim-plugin-ltspice",
+                "license_class": "oss",
+            }
+        ],
+    })
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.id == "ltspice"
+    assert row.name == "LTspice"
+    assert row.distribution == "pypi"
+    assert row.install == "sim-plugin-ltspice==0.2.3"
+    assert row.version == "0.2.3"
+
+
+def test_normalize_v2_wheel_entry_carries_install_url_with_hash():
+    rows = normalize_catalog({
+        "schema_version": 2,
+        "plugins": [
+            {
+                "id": "fluent",
+                "name": "Ansys Fluent",
+                "distribution": "wheel",
+                "install": "https://cdn.svdailab.com/wheels/sim_plugin_fluent-0.1.4-py3-none-any.whl#sha256=abcd",
+                "version": "0.1.4",
+                "license_class": "commercial",
+            }
+        ],
+    })
+    assert rows[0].id == "fluent"
+    assert rows[0].distribution == "wheel"
+    assert rows[0].install.startswith("https://cdn.svdailab.com/")
+    assert "#sha256=" in rows[0].install
+    assert rows[0].license_class == "commercial"
+
+
+def test_normalize_legacy_v1_entry_synthesizes_install_string():
+    """Old-shape entries (no ``install``, just ``package``/``latest_version``)
+    still produce a usable install string so the catalogue can migrate
+    independently of sim-cli releases."""
     rows = normalize_catalog({
         "schema_version": 1,
         "plugins": [
@@ -13,47 +62,76 @@ def test_normalize_current_index_shape_defaults_to_package_spec():
                 "summary": "LTspice driver",
                 "homepage": "https://github.com/svd-ai-lab/sim-plugin-ltspice",
                 "license_class": "oss",
+                "package": "sim-plugin-ltspice",
                 "latest_version": "0.2.3",
             }
         ],
     })
     assert len(rows) == 1
     row = rows[0]
-    assert row.name == "ltspice"
-    assert row.package == "sim-plugin-ltspice"
-    assert row.install_command == "sim plugin install sim-plugin-ltspice"
-    assert row.latest_version == "0.2.3"
+    assert row.id == "ltspice"
+    # Legacy fallback synthesizes the install string from package + version.
+    assert row.install == "sim-plugin-ltspice==0.2.3"
+    assert row.version == "0.2.3"
+    assert row.distribution == "pypi"
 
 
-def test_normalize_future_dict_shape_and_install_command():
+def test_normalize_legacy_v1_wheel_url_entry():
+    rows = normalize_catalog({
+        "plugins": [
+            {
+                "name": "fluent",
+                "license_class": "commercial",
+                "latest_version": "0.1.4",
+                "latest_wheel_url": "https://cdn.svdailab.com/wheels/sim_plugin_fluent-0.1.4-py3-none-any.whl",
+            }
+        ],
+    })
+    row = rows[0]
+    assert row.install == "https://cdn.svdailab.com/wheels/sim_plugin_fluent-0.1.4-py3-none-any.whl"
+    assert row.distribution == "wheel"
+
+
+def test_normalize_dict_shape_promotes_key_to_id():
     rows = normalize_catalog({
         "plugins": {
-            "mechanical": {
-                "package": "sim-plugin-mechanical",
-                "license_class": "commercial-wrapper",
-                "install": {
-                    "command": "sim plugin install sim-plugin-mechanical --extra-index-url https://example.com/simple/"
-                },
+            "ltspice": {
+                "name": "LTspice",
+                "distribution": "pypi",
+                "install": "sim-plugin-ltspice==0.2.3",
+                "version": "0.2.3",
             }
         }
     })
-    assert rows[0].name == "mechanical"
-    assert rows[0].license_class == "commercial-wrapper"
-    assert "--extra-index-url" in rows[0].install_command
+    assert rows[0].id == "ltspice"
+    assert rows[0].name == "LTspice"
 
 
-def test_list_catalog_search_uses_catalog_without_install_resolution(monkeypatch):
+def test_list_catalog_query_filters_without_install_resolution(monkeypatch):
     from sim import plugin_catalog
 
     def fake_fetch_catalog(**kwargs):
         return {
+            "schema_version": 2,
             "plugins": [
-                {"name": "ltspice", "summary": "Circuit simulation"},
-                {"name": "flotherm", "summary": "Thermal simulation"},
+                {
+                    "id": "ltspice",
+                    "name": "LTspice",
+                    "distribution": "pypi",
+                    "install": "sim-plugin-ltspice==0.2.3",
+                    "summary": "Circuit simulation",
+                },
+                {
+                    "id": "flotherm",
+                    "name": "Flotherm",
+                    "distribution": "wheel",
+                    "install": "https://cdn.svdailab.com/wheels/sim_plugin_flotherm-0.1.1-py3-none-any.whl",
+                    "summary": "Thermal simulation",
+                },
             ]
         }
 
     monkeypatch.setattr(plugin_catalog, "fetch_catalog", fake_fetch_catalog)
     rows = list_catalog(query="thermal")
-    assert [row.name for row in rows] == ["flotherm"]
-    assert rows[0].install_command == "sim plugin install sim-plugin-flotherm"
+    assert [row.id for row in rows] == ["flotherm"]
+    assert rows[0].install.startswith("https://")

--- a/tests/base/test_plugin_install.py
+++ b/tests/base/test_plugin_install.py
@@ -1,25 +1,19 @@
-"""Tests for sim._plugin_install — source resolution, bundle, and report shape.
+"""Tests for sim._plugin_install — source resolution and report shape.
 
-These cover the *classification* layer (no real pip calls) and the bundle
-flow against mocked HTTP. The actual install path is exercised against a
-fixture wheel in test_plugin_install_e2e — kept small and skipped when
-no fixture wheel exists yet.
+These cover the *classification* layer (no real pip calls). The actual
+install path is exercised against a fixture wheel in test_plugin_install_e2e
+— kept small and skipped when no fixture wheel exists yet.
 """
 from __future__ import annotations
 
-import json
-import textwrap
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
 from sim._plugin_install import (
-    DEFAULT_INDEX_URL,
     InstallReport,
     bundle_plugins,
-    fetch_index,
-    index_entry,
+    install_plugin,
     resolve_source,
 )
 
@@ -55,16 +49,17 @@ def test_resolve_missing_local_path_errors(tmp_path: Path):
 
 
 def test_resolve_git_url():
-    url = "git+https://github.com/svd-ai-lab/sim-plugin-coolprop"
+    url = "git+https://github.com/svd-ai-lab/sim-plugin-ltspice"
     rs = resolve_source(url)
     assert rs.kind == "git-url"
     assert rs.pip_target == url
 
 
 def test_resolve_wheel_url():
-    url = "https://example.com/sim_plugin_x-0.1.0-py3-none-any.whl"
+    url = "https://example.com/sim_plugin_ltspice-0.2.3-py3-none-any.whl"
     rs = resolve_source(url)
     assert rs.kind == "wheel-url"
+    assert rs.pip_target == url
 
 
 def test_resolve_sdist_url():
@@ -73,49 +68,37 @@ def test_resolve_sdist_url():
     assert rs.kind == "sdist-url"
 
 
-def test_resolve_bare_name_offline_without_cache_errors(tmp_path: Path, monkeypatch):
-    # Force an empty cache dir.
-    monkeypatch.setattr("sim._plugin_install._index_cache_dir",
-                        lambda: tmp_path / "no-cache")
-    with pytest.raises(ValueError):
-        resolve_source("coolprop", offline=True)
+def test_resolve_exact_package_spec():
+    rs = resolve_source("sim-plugin-ltspice")
+    assert rs.kind == "package-spec"
+    assert rs.name == "sim-plugin-ltspice"
+    assert rs.pip_target == "sim-plugin-ltspice"
 
 
-def test_resolve_bare_name_with_index_uses_wheel_url(tmp_path: Path, monkeypatch):
-    cache_dir = tmp_path / "cache"
-    cache_dir.mkdir()
-    cache_idx = cache_dir / "index.json"
-    cache_idx.write_text(json.dumps({
-        "schema_version": 1,
-        "plugins": [{
-            "name": "coolprop",
-            "git": "https://github.com/svd-ai-lab/sim-plugin-coolprop",
-            "license_class": "oss",
-            "latest_wheel_url": "https://example.com/x.whl",
-        }],
-    }), encoding="utf-8")
-    monkeypatch.setattr("sim._plugin_install._index_cache_dir", lambda: cache_dir)
-    monkeypatch.setattr("sim._plugin_install._index_cache_path",
-                        lambda: cache_idx)
-    rs = resolve_source("coolprop", offline=True)
-    assert rs.kind == "name"
-    assert rs.pip_target == "https://example.com/x.whl"
+def test_resolve_exact_version_package_spec():
+    rs = resolve_source("sim-plugin-ltspice==0.2.3")
+    assert rs.kind == "package-spec"
+    assert rs.name == "sim-plugin-ltspice"
+    assert rs.version == "0.2.3"
+    assert rs.pip_target == "sim-plugin-ltspice==0.2.3"
 
 
-def test_resolve_name_at_version(tmp_path: Path, monkeypatch):
-    cache_dir = tmp_path / "cache"
-    cache_dir.mkdir()
-    (cache_dir / "index.json").write_text(json.dumps({
-        "schema_version": 1, "plugins": [],
-    }), encoding="utf-8")
-    monkeypatch.setattr("sim._plugin_install._index_cache_dir", lambda: cache_dir)
-    monkeypatch.setattr("sim._plugin_install._index_cache_path",
-                        lambda: cache_dir / "index.json")
-    rs = resolve_source("coolprop@0.2.1", offline=False)  # name not in index, falls to optimistic
-    assert rs.kind == "name-version"
-    assert rs.name == "coolprop"
-    assert rs.version == "0.2.1"
-    assert "coolprop" in rs.pip_target
+def test_resolve_exact_range_package_spec():
+    rs = resolve_source("sim-plugin-ltspice>=0.2")
+    assert rs.kind == "package-spec"
+    assert rs.name == "sim-plugin-ltspice"
+    assert rs.version == "0.2"
+    assert rs.pip_target == "sim-plugin-ltspice>=0.2"
+
+
+@pytest.mark.parametrize("name", ["mechanical", "ltspice"])
+def test_resolve_bare_short_name_rejected(name: str):
+    with pytest.raises(ValueError) as exc:
+        resolve_source(name)
+    msg = str(exc.value)
+    assert "catalog name" in msg
+    assert f"sim plugin search {name}" in msg
+    assert f"sim-plugin-{name}" in msg
 
 
 def test_resolve_garbage_raises():
@@ -123,249 +106,28 @@ def test_resolve_garbage_raises():
         resolve_source("???not-a-source???")
 
 
-# ── R2 manifest + chained lookup ────────────────────────────────────────────
-
-
-def _seed_caches(tmp_path: Path, monkeypatch,
-                 r2_plugins: dict | None = None,
-                 github_plugins: list | None = None):
-    """Set up isolated R2 + GitHub cache files and point fetch_index at them."""
-    cache_dir = tmp_path / "cache"
-    cache_dir.mkdir()
-    r2_cache = cache_dir / "manifest-r2.json"
-    github_cache = cache_dir / "index.json"
-    r2_cache.write_text(json.dumps({"plugins": r2_plugins or {}}), encoding="utf-8")
-    github_cache.write_text(
-        json.dumps({"schema_version": 1, "plugins": github_plugins or []}),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr("sim._plugin_install._index_cache_dir", lambda: cache_dir)
-    monkeypatch.setattr("sim._plugin_install._index_cache_path", lambda: github_cache)
-    monkeypatch.setattr("sim._plugin_install._r2_cache_path", lambda: r2_cache)
-
-
-def test_r2_lookup_normalizes_to_github_shape(tmp_path: Path, monkeypatch):
-    from sim._plugin_install import _r2_lookup
-    _seed_caches(tmp_path, monkeypatch, r2_plugins={
-        "comsol": {"version": "0.1.0",
-                    "wheel": "https://cdn.svdailab.com/wheels/comsol.whl"},
-    })
-    e = _r2_lookup("comsol", offline=True)
-    assert e is not None
-    assert e["name"] == "comsol"
-    assert e["latest_version"] == "0.1.0"
-    assert e["latest_wheel_url"] == "https://cdn.svdailab.com/wheels/comsol.whl"
-
-    assert _r2_lookup("absent", offline=True) is None
-
-
-def test_r2_lookup_skips_entry_without_wheel(tmp_path: Path, monkeypatch):
-    """A malformed R2 entry (no wheel) must miss so we fall back."""
-    from sim._plugin_install import _r2_lookup
-    _seed_caches(tmp_path, monkeypatch, r2_plugins={
-        "comsol": {"version": "0.1.0"},  # missing wheel
-    })
-    assert _r2_lookup("comsol", offline=True) is None
-
-
-def test_index_entry_chained_prefers_r2(tmp_path: Path, monkeypatch):
-    from sim._plugin_install import index_entry_chained
-    _seed_caches(
-        tmp_path, monkeypatch,
-        r2_plugins={"ltspice": {"version": "0.2.1",
-                                  "wheel": "https://r2.example/ltspice.whl"}},
-        github_plugins=[{"name": "ltspice", "license_class": "oss",
-                          "latest_wheel_url": "https://gh.example/ltspice.whl"}],
-    )
-    e = index_entry_chained("ltspice", offline=True)
-    assert e["latest_wheel_url"] == "https://r2.example/ltspice.whl"
-
-
-def test_index_entry_chained_falls_back_to_github(tmp_path: Path, monkeypatch):
-    from sim._plugin_install import index_entry_chained
-    _seed_caches(
-        tmp_path, monkeypatch,
-        r2_plugins={},
-        github_plugins=[{"name": "pybamm", "license_class": "oss",
-                          "latest_wheel_url": "https://gh.example/pybamm.whl"}],
-    )
-    e = index_entry_chained("pybamm", offline=True)
-    assert e is not None
-    assert e["latest_wheel_url"] == "https://gh.example/pybamm.whl"
-
-
-def test_index_entry_chained_returns_none_when_neither_has_it(tmp_path: Path, monkeypatch):
-    from sim._plugin_install import index_entry_chained
-    _seed_caches(tmp_path, monkeypatch)
-    assert index_entry_chained("nope", offline=True) is None
-
-
-def test_resolve_bare_name_uses_r2_wheel(tmp_path: Path, monkeypatch):
-    """Default chain lookup: R2 hit wins."""
-    _seed_caches(
-        tmp_path, monkeypatch,
-        r2_plugins={"comsol": {"version": "0.1.0",
-                                 "wheel": "https://r2.example/comsol.whl"}},
-        github_plugins=[],
-    )
-    rs = resolve_source("comsol", offline=True)
-    assert rs.kind == "name"
-    assert rs.pip_target == "https://r2.example/comsol.whl"
-
-
-def test_resolve_bare_name_falls_back_to_github(tmp_path: Path, monkeypatch):
-    """Default chain lookup: R2 miss → GitHub wheel URL."""
-    _seed_caches(
-        tmp_path, monkeypatch,
-        r2_plugins={},
-        github_plugins=[{"name": "pybamm", "license_class": "oss",
-                          "latest_wheel_url": "https://gh.example/pybamm.whl"}],
-    )
-    rs = resolve_source("pybamm", offline=True)
-    assert rs.kind == "name"
-    assert rs.pip_target == "https://gh.example/pybamm.whl"
-
-
-def test_resolve_name_at_version_uses_r2_filename_convention(tmp_path: Path, monkeypatch):
-    """name@<old-version>: when entry is from R2 manifest, build URL by
-    filename convention so old wheels (kept on R2 but not in manifest) resolve."""
-    _seed_caches(
-        tmp_path, monkeypatch,
-        r2_plugins={"comsol": {"version": "0.1.1",
-                                  "wheel": "https://cdn.svdailab.com/wheels/sim_plugin_comsol-0.1.1-py3-none-any.whl"}},
-    )
-    rs = resolve_source("comsol@0.1.0", offline=True)
-    assert rs.kind == "name-version"
-    assert rs.version == "0.1.0"
-    assert rs.pip_target == (
-        "https://cdn.svdailab.com/wheels/sim_plugin_comsol-0.1.0-py3-none-any.whl"
-    )
-
-
-def test_resolve_name_at_version_github_entry_falls_back_to_git(tmp_path: Path, monkeypatch):
-    """name@<version> with a community-catalogue entry that has a git field
-    still uses git+@v<version> (R2 convention only fires for cdn.svdailab.com URLs)."""
-    _seed_caches(
-        tmp_path, monkeypatch,
-        r2_plugins={},
-        github_plugins=[{
-            "name": "ltspice",
-            "license_class": "oss",
-            "git": "https://github.com/svd-ai-lab/sim-plugin-ltspice",
-            "latest_version": "0.2.1",
-            "latest_wheel_url": "https://github.com/svd-ai-lab/sim-plugin-ltspice/releases/download/v0.2.1/sim_plugin_ltspice-0.2.1-py3-none-any.whl",
-        }],
-    )
-    rs = resolve_source("ltspice@0.1.0", offline=True)
-    assert rs.kind == "name-version"
-    assert rs.pip_target == "git+https://github.com/svd-ai-lab/sim-plugin-ltspice@v0.1.0"
-
-
-def test_resolve_explicit_index_url_skips_chain(tmp_path: Path, monkeypatch):
-    """Explicit index_url uses just that source — no R2 fallback."""
-    _seed_caches(
-        tmp_path, monkeypatch,
-        r2_plugins={"comsol": {"version": "0.1.0",
-                                 "wheel": "https://r2.example/comsol.whl"}},
-        github_plugins=[{"name": "comsol", "license_class": "oss",
-                          "latest_wheel_url": "https://gh.example/comsol.whl"}],
-    )
-    from sim._plugin_install import DEFAULT_INDEX_URL
-    rs = resolve_source("comsol", offline=True, index_url=DEFAULT_INDEX_URL)
-    assert rs.pip_target == "https://gh.example/comsol.whl"
-
-
-# ── Index fetch + cache ──────────────────────────────────────────────────────
-
-
-def test_fetch_index_offline_missing_cache_returns_empty(tmp_path: Path, monkeypatch):
-    monkeypatch.setattr("sim._plugin_install._index_cache_dir",
-                        lambda: tmp_path / "missing")
-    monkeypatch.setattr("sim._plugin_install._index_cache_path",
-                        lambda: tmp_path / "missing" / "index.json")
-    idx = fetch_index(offline=True)
-    assert idx == {"schema_version": 1, "plugins": []}
-
-
-def test_index_entry_lookup(tmp_path: Path, monkeypatch):
-    cache_dir = tmp_path / "cache"
-    cache_dir.mkdir()
-    (cache_dir / "index.json").write_text(json.dumps({
-        "schema_version": 1,
-        "plugins": [
-            {"name": "coolprop", "license_class": "oss"},
-            {"name": "simpy", "license_class": "oss"},
-        ],
-    }), encoding="utf-8")
-    monkeypatch.setattr("sim._plugin_install._index_cache_dir", lambda: cache_dir)
-    monkeypatch.setattr("sim._plugin_install._index_cache_path",
-                        lambda: cache_dir / "index.json")
-    e = index_entry("coolprop", offline=True)
-    assert e is not None and e["name"] == "coolprop"
-    assert index_entry("nope", offline=True) is None
-
-
-# ── Bundle ──────────────────────────────────────────────────────────────────
-
-
-def test_bundle_plugins_writes_filtered_index(tmp_path: Path, monkeypatch):
-    """Bundle should write an index.json with only the requested plugins."""
-    cache_dir = tmp_path / "cache"
-    cache_dir.mkdir()
-    monkeypatch.setattr("sim._plugin_install._index_cache_dir", lambda: cache_dir)
-    monkeypatch.setattr("sim._plugin_install._index_cache_path",
-                        lambda: cache_dir / "index.json")
-
-    full_index = {
-        "schema_version": 1,
-        "plugins": [
-            {"name": "coolprop",
-             "latest_wheel_url": "http://fake/coolprop.whl",
-             "license_class": "oss"},
-            {"name": "simpy",
-             "latest_wheel_url": "http://fake/simpy.whl",
-             "license_class": "oss"},
-        ],
-    }
-    (cache_dir / "index.json").write_text(json.dumps(full_index), encoding="utf-8")
-
-    # Real file-like; bundle uses shutil.copyfileobj which calls .read(size).
-    import io
-
-    class _FakeResp(io.BytesIO):
-        def __enter__(self):
-            return self
-        def __exit__(self, *a):
-            self.close()
-
-    def fake_open(url, timeout=30):
-        return _FakeResp(b"WHEEL")
-
+def test_bundle_plugins_is_disabled_without_index(tmp_path: Path):
     output = tmp_path / "out"
-    with mock.patch("sim._plugin_install.urllib.request.urlopen", fake_open):
-        result = bundle_plugins(["coolprop"], output)
-
-    assert result["ok"] is True
-    assert result["fetched"] == ["coolprop"]
-    written_idx = json.loads((output / "index.json").read_text(encoding="utf-8"))
-    assert len(written_idx["plugins"]) == 1
-    assert written_idx["plugins"][0]["name"] == "coolprop"
-    assert written_idx["plugins"][0]["latest_wheel_url"].startswith("file://")
-
-
-def test_bundle_plugins_unknown_returns_partial_failure(tmp_path: Path, monkeypatch):
-    cache_dir = tmp_path / "cache"
-    cache_dir.mkdir()
-    (cache_dir / "index.json").write_text(json.dumps({"plugins": []}), encoding="utf-8")
-    monkeypatch.setattr("sim._plugin_install._index_cache_dir", lambda: cache_dir)
-    monkeypatch.setattr("sim._plugin_install._index_cache_path",
-                        lambda: cache_dir / "index.json")
-
-    output = tmp_path / "out"
-    result = bundle_plugins(["nope"], output)
+    result = bundle_plugins(["ltspice"], output)
     assert result["ok"] is False
     assert result["fetched"] == []
-    assert result["errors"][0]["name"] == "nope"
+    assert result["errors"][0]["name"] == "ltspice"
+    assert "bundle no longer resolves catalogue names" in result["errors"][0]["error"]
+
+
+def test_install_bare_short_name_returns_helpful_error(monkeypatch):
+    from sim import _plugin_install
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("pip install should not be called")
+
+    monkeypatch.setattr(_plugin_install, "_pip_install", fail_if_called)
+
+    report = install_plugin("mechanical")
+    assert report.ok is False
+    assert report.source_kind == "invalid"
+    assert report.error_code == "PLUGIN_NOT_FOUND"
+    assert "sim-plugin-mechanical" in report.message
 
 
 # ── InstallReport shape ─────────────────────────────────────────────────────
@@ -457,3 +219,30 @@ def test_pip_install_defaults_to_sys_executable(monkeypatch):
     cmd = captured["cmd"]
     assert "--python" in cmd
     assert sys.executable in cmd
+
+
+def test_install_passes_extra_index_urls(monkeypatch):
+    from sim import _plugin_install
+
+    captured = {}
+
+    def fake_pip_install(target, **kwargs):
+        captured["target"] = target
+        captured["kwargs"] = kwargs
+        return _FakeProc()
+
+    monkeypatch.setattr(_plugin_install, "_pip_install", fake_pip_install)
+    monkeypatch.setattr(_plugin_install, "_default_skills_target", lambda: Path("/tmp/no-skills"))
+
+    report = install_plugin(
+        "sim-plugin-mechanical",
+        skip_sync=True,
+        extra_index_urls=["https://example.com/simple/"],
+    )
+
+    assert report.ok is True
+    assert captured["target"] == "sim-plugin-mechanical"
+    assert captured["kwargs"]["extra_args"] == [
+        "--extra-index-url",
+        "https://example.com/simple/",
+    ]

--- a/tests/base/test_plugin_install.py
+++ b/tests/base/test_plugin_install.py
@@ -96,8 +96,8 @@ def test_resolve_bare_short_name_rejected(name: str):
     with pytest.raises(ValueError) as exc:
         resolve_source(name)
     msg = str(exc.value)
-    assert "catalog name" in msg
-    assert f"sim plugin search {name}" in msg
+    assert "explicit plugin install source" in msg
+    assert "sim plugin catalog" in msg
     assert f"sim-plugin-{name}" in msg
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,8 +105,14 @@ def _inject_synthetic_coolprop(request):
 
     from sim import drivers as _drivers_pkg
 
+    # Make the synthetic driver importable by the same module path stored in
+    # the registry. Depending on pytest import mode this file may not already
+    # be visible as top-level ``conftest`` in sys.modules, and ``tests`` is not
+    # a package in this repo, so ``tests.conftest`` is not a portable spec.
+    sys.modules.setdefault("conftest", sys.modules[__name__])
+
     instance = _SyntheticPyDriver()
-    fake_spec = ("coolprop", "tests.conftest:_SyntheticPyDriver")
+    fake_spec = ("coolprop", "conftest:_SyntheticPyDriver")
 
     orig_builtin = list(_drivers_pkg._BUILTIN_REGISTRY)
     orig_registry = list(_drivers_pkg._REGISTRY)


### PR DESCRIPTION
## Summary
- separate plugin discovery from plugin installation
- add `sim plugin catalog` and `sim plugin search` for agent/user discovery via the community catalogue
- keep `sim plugin install` explicit and pip-native: exact package specs, local paths, direct wheel/sdist URLs, git URLs, and private Python indexes via `--extra-index-url`
- remove install-time automatic short-name resolution through custom JSON indexes so `sim plugin install ltspice` no longer silently installs a stale URL/package
- update docs/tests to distinguish:
  - `sim plugin catalog/search` = available plugins
  - `sim plugin list` = installed/registered plugins
  - `sim plugin install` = explicit source installation
- fix source-tree test robustness while here: use `sim.__version__`, preserve `workspace_delta` in normalized history, and treat non-package modules as having no `compatibility.yaml`

## Why
The previous implementation mixed two different responsibilities:

1. discovery: “what plugins exist?”
2. installation: “what exact source should pip install?”

The custom install resolver could go stale or become schema-incompatible. For example, current `origin/main` still resolves `ltspice` to a v0.2.2 GitHub Release URL even though the PyPI pilot has moved forward.

This PR keeps both important index concepts, but separates their roles:

- **community index/catalogue stays** for discovery by humans and agents
- **private Python indexes stay** for commercial/private wheels via standard `--extra-index-url`
- **install-time short-name resolver goes away** so installs remain explicit, auditable, and pip-native

Related issue update: svd-ai-lab/sim-proj#100

## Example flow

```bash
sim plugin search ltspice
sim plugin install sim-plugin-ltspice
sim plugin list
```

For private/commercial wrappers:

```bash
sim plugin search mechanical
sim plugin install sim-plugin-mechanical --extra-index-url https://example.com/simple/
```

## Test plan
- [x] `PYTHONPATH=src python -m pytest tests/base/test_plugin_catalog.py tests/base/test_plugin_install.py tests/base/test_describe.py -q -o 'addopts='`
- [x] `PYTHONPATH=src python -m pytest tests -q -o 'addopts='`

Full suite result:

```text
282 passed, 5 skipped, 10 subtests passed in 7.19s
```

## Notes for review
This is intentionally a draft because it changes user-facing plugin install behavior. Please review the docs, command names, and whether `catalog/search` should keep reading the current `sim-plugin-index/index.json` shape or wait for a renamed `catalog.json` in that repo.
