### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sim-cli-core"
-version = "0.3.1"
+version = "0.3.2"
 description = "Make every engineering tool agent-native — a CLI runtime that lets LLM agents launch, drive, and observe CAD/CAE software"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Ships PR #90's discovery/install split: `sim plugin catalog` + explicit-source install, custom resolver removed. Catalogue side already migrated to schema_version 2 in sim-plugin-index. Triggers PyPI publish on tag push.