### PR TITLE
[codex] remove plugin search docs drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Per-solver protocols, snippets, and demo workflows live in [`sim-skills`](https:
 ### 🔌 Solver-agnostic
 - **One protocol** (`DriverProtocol`) — every driver is ~200 LOC, shipped as its own `sim-plugin-<name>` package via Python entry points
 - **Persistent + one-shot** from the same CLI — no separate client per mode
-- **Plugin discovery + explicit installs** — `sim plugin catalog/search` discovers available plugins; `sim plugin install` accepts exact package specs, private indexes, direct URLs, git URLs, and local artifacts
+- **Plugin discovery + explicit installs** — `sim plugin catalog` discovers available plugins; `sim plugin install` accepts exact package specs, private indexes, direct URLs, git URLs, and local artifacts
 - **Companion skills** in [`sim-skills`](https://github.com/svd-ai-lab/sim-skills) so an LLM picks up each new backend without prior context
 
 ### 🌐 Remote-friendly
@@ -220,7 +220,7 @@ Per-solver protocols, snippets, and demo workflows live in [`sim-skills`](https:
 
 | Command | What it does | Analogy |
 |---|---|---|
-| `sim plugin catalog / search` | Discover available solver plugins | `npm search` |
+| `sim plugin catalog` | Discover available solver plugins | `npm search` |
 | `sim plugin list / install / uninstall` | Manage installed plugins from explicit install sources | `npm install` |
 | `sim check <solver>` | Detect installations + resolve a profile | `docker info` |
 | `sim env install <profile>` | Bootstrap a profile env (venv + pinned SDK) | `pyenv install` |

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -167,7 +167,7 @@ sim plugin list                 # 查看本机已安装/已注册插件
 ### 🔌 求解器无关
 - **一套协议** (`DriverProtocol`) —— 每个 driver 仅 ~200 行，注册到 `drivers/__init__.py` 即可
 - **持久 + 一次性**两种模式共用同一个 CLI
-- **插件发现 + 显式安装** —— `sim plugin catalog/search` 用来发现可用插件；`sim plugin install` 只执行精确包名、私有索引、URL、git 或本地 artifact
+- **插件发现 + 显式安装** —— `sim plugin catalog` 用来发现可用插件；`sim plugin install` 只执行精确包名、私有索引、URL、git 或本地 artifact
 - **配套 skills** 在 [`sim-skills`](https://github.com/svd-ai-lab/sim-skills) —— 让大模型立刻知道每个新后端的坑
 
 ### 🌐 远程友好
@@ -181,7 +181,7 @@ sim plugin list                 # 查看本机已安装/已注册插件
 
 | 命令 | 功能 | 类比 |
 |---|---|---|
-| `sim plugin catalog / search` | 发现可用插件 | `npm search` |
+| `sim plugin catalog` | 发现可用插件 | `npm search` |
 | `sim plugin list / install / uninstall` | 管理本机已安装插件 | `npm install` |
 | `sim check <solver>` | 检测安装版本并解析 profile | `docker info` |
 | `sim env install <profile>` | 启动 profile env（venv + 固定 SDK） | `pyenv install` |

--- a/docs/plugin-install.md
+++ b/docs/plugin-install.md
@@ -47,7 +47,7 @@ Agents can discover available plugins without installing anything:
 
 ```sh
 sim plugin catalog
-sim plugin catalog --json
+sim --json plugin catalog
 ```
 
 The catalogue is for discovery only. Each entry includes a copy-paste
@@ -135,7 +135,7 @@ After install, check the plugin loaded cleanly:
 ```sh
 sim plugin list                  # one row per installed plugin
 sim plugin doctor coolprop       # detailed validation
-sim plugin doctor --all --json   # machine-readable
+sim --json plugin doctor --all   # machine-readable
 ```
 
 `doctor` checks that the plugin's entry-points resolve, the driver

--- a/src/sim/_plugin_install.py
+++ b/src/sim/_plugin_install.py
@@ -332,7 +332,7 @@ def bundle_plugins(names: list[str], output_dir: Path, *,
                 "name": name,
                 "error": (
                     "bundle no longer resolves catalogue names; use "
-                    "sim plugin catalog/search to discover plugins, then pass "
+                    "sim plugin catalog to discover plugins, then pass "
                     "explicit wheel URLs, local artifacts, git URLs, or exact "
                     "package specs"
                 ),

--- a/src/sim/describe.py
+++ b/src/sim/describe.py
@@ -116,16 +116,12 @@ _EXAMPLES: dict[str, list[dict[str, str]]] = {
          "summary": "List the closed enum of error codes."},
     ],
     "plugin list": [
-        {"cmd": "sim plugin list --json",
+        {"cmd": "sim --json plugin list",
          "summary": "List every registered plugin (built-in + external)."},
     ],
     "plugin catalog": [
-        {"cmd": "sim plugin catalog --json",
+        {"cmd": "sim --json plugin catalog",
          "summary": "List available plugins from the discovery catalogue."},
-    ],
-    "plugin search": [
-        {"cmd": "sim plugin search ltspice --json",
-         "summary": "Search the discovery catalogue for package and install guidance."},
     ],
     "plugin info": [
         {"cmd": "sim plugin info coolprop",
@@ -152,7 +148,7 @@ _EXAMPLES: dict[str, list[dict[str, str]]] = {
          "summary": "Materialize installed plugins' _skills into .claude/skills/."},
     ],
     "plugin doctor": [
-        {"cmd": "sim plugin doctor --all --json",
+        {"cmd": "sim --json plugin doctor --all",
          "summary": "Run doctor on every plugin; exits with the count of FAILs."},
     ],
 }


### PR DESCRIPTION
## Summary
- remove stale `sim plugin search` references now that `sim plugin catalog` is the discovery surface
- drop the removed `plugin search` entry from the agent-readable command examples
- fix plugin docs/manifest examples to put the global `--json` flag before the `plugin` command

## Validation
- `rg -n "plugin catalog/search|plugin search|catalog / search|catalog/search|sim plugin search" README.md docs src tests` returned no matches
- `rg -n "sim plugin (catalog|list|doctor)[^`\r\n]*--json|sim plugin catalog --json" README.md docs src tests` returned no matches
- `PYTHONPATH=src .\.venv\Scripts\python.exe -m pytest tests\base\test_describe.py tests\base\test_plugin_install.py::test_bundle_plugins_is_disabled_without_index -q -o 'addopts=' --basetemp .tmp\pytest-doc-drift`
- `PYTHONPATH=src .\.venv\Scripts\python.exe -m sim describe "plugin catalog"`
- `PYTHONPATH=src .\.venv\Scripts\python.exe -m sim --json plugin catalog`