### PR TITLE
[codex] Add hosted engineering context client

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ plugins. A plugin can provide both:
 - a **skill**, so the agent knows the solver-specific workflow, pitfalls, and
   inspection rules
 
+Hosted engineering context is optional. When configured, agents can ask for a
+Context7-style context pack before modeling:
+
+```powershell
+$env:SIM_CONTEXT_API_KEY="sim_sk_..."
+uv run sim context get --domain comsol "chip package overheating near voltage regulator"
+```
+
+The context API returns source pointers and engineering hints. It does not
+replace local solver execution or expose private index internals.
+
 ## Human-in-the-loop collaboration
 
 `sim` is designed for shared control, not unattended black-box automation.

--- a/docs/agent-readability.md
+++ b/docs/agent-readability.md
@@ -62,6 +62,10 @@ top-level keys (`stdout`, `stderr`); never inside `message`.
 | `PLUGIN_INSTALL_FAILED` | `pip install` for a plugin returned non-zero. |
 | `PROTOCOL_VIOLATION` | A driver returned a value that doesn't match `DriverProtocol`. |
 | `NONINTERACTIVE_INPUT_REQUIRED` | `--no-interactive` is set and the command would otherwise prompt. |
+| `CONTEXT_API_KEY_MISSING` | Hosted engineering context was requested but no API key is configured. |
+| `CONTEXT_API_UNAUTHORIZED` | The hosted engineering context API rejected the configured API key or scope. |
+| `CONTEXT_API_RATE_LIMITED` | The hosted engineering context API rate limit was exceeded. |
+| `CONTEXT_API_REQUEST_FAILED` | The hosted engineering context API could not be reached or returned an error. |
 
 This list is closed: adding a new code requires updating this doc, the CLI,
 and the JSON schema emitted by `sim describe --error-codes`.

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -807,6 +807,110 @@ def screenshot(ctx, output):
     click.echo(f"[sim] screenshot saved: {out_path} ({w}x{h})")
 
 
+# ── context ──────────────────────────────────────────────────────────────────
+
+
+def _context_error(ctx, error_code: str, message: str, status_code: int | None = None) -> None:
+    out = {
+        "ok": False,
+        "error_code": error_code,
+        "message": message,
+        "status_code": status_code,
+        "fallback": "Continue without hosted context, or configure SIM_CONTEXT_API_KEY and retry.",
+    }
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps(out, indent=2))
+    else:
+        click.echo(f"[sim] context: {message}", err=True)
+        click.echo("  fallback: continue without hosted context, or configure SIM_CONTEXT_API_KEY and retry.", err=True)
+
+
+def _redact_config_for_display(config: dict) -> dict:
+    import copy
+
+    redacted = copy.deepcopy(config)
+    context = redacted.get("context")
+    if isinstance(context, dict) and context.get("api_key"):
+        context["api_key"] = "***configured***"
+    return redacted
+
+
+def _render_context_pack(pack: dict) -> None:
+    domain = pack.get("domain", "?")
+    mode = pack.get("mode", "context_only")
+    llm = pack.get("llm_used", False)
+    usage = pack.get("usage", {})
+    click.echo(f"[sim] context: {domain} ({mode}, llm_used={llm})")
+    click.echo(f"  returned: {usage.get('returned_example_count', 0)} example(s), "
+               f"{usage.get('context_block_count', 0)} block(s), "
+               f"~{usage.get('estimated_returned_tokens', 0)} tokens")
+
+    examples = pack.get("recommended_examples", [])
+    if examples:
+        click.echo("\n  recommended examples:")
+        for item in examples[:5]:
+            click.echo(f"  - {item.get('title', item.get('id'))} [{item.get('source_kind')}]")
+            summary = item.get("summary")
+            if summary:
+                click.echo(f"    {summary}")
+            pointer = item.get("source_pointer", {})
+            source = pointer.get("url") or pointer.get("local_application_library_path")
+            if source:
+                click.echo(f"    source: {source}")
+
+    hints = pack.get("agent_hints", {})
+    if hints:
+        click.echo("\n  agent hints:")
+        for category, values in list(hints.items())[:6]:
+            click.echo(f"  {category}:")
+            for value in values[:3]:
+                click.echo(f"    - {value}")
+
+
+@main.group(name="context")
+def context_group():
+    """Fetch hosted engineering context packs for agents."""
+
+
+@context_group.command("get")
+@click.argument("query", nargs=-1, required=True)
+@click.option("--domain", default="comsol", show_default=True, help="Engineering context domain.")
+@click.option("--max-tokens", default=4000, type=int, show_default=True,
+              help="Approximate token budget for returned context blocks.")
+@click.option("--source-preference", default="any", type=click.Choice(["any", "local", "online"]),
+              show_default=True, help="Prefer local Application Library or online Gallery examples.")
+@click.option("--solver-version", default=None, help="Optional solver version hint, e.g. 6.4.")
+@click.option("--api-base-url", default=None, help="Override the Engineering Context API base URL.")
+@click.option("--timeout", default=20.0, type=float, show_default=True, help="HTTP timeout in seconds.")
+@click.pass_context
+def context_get(ctx, query, domain, max_tokens, source_preference, solver_version, api_base_url, timeout):
+    """Request an agent-ready context pack from sim.svdailab.com."""
+    from sim import context_client as _context_client
+
+    query_text = " ".join(query).strip()
+    try:
+        pack = _context_client.get_context(
+            domain=domain,
+            query=query_text,
+            max_tokens=max_tokens,
+            source_preference=source_preference,
+            solver_version=solver_version,
+            api_base_url=api_base_url,
+            timeout=timeout,
+        )
+    except _context_client.MissingContextApiKey as exc:
+        _context_error(ctx, "CONTEXT_API_KEY_MISSING", str(exc))
+        sys.exit(2)
+    except _context_client.ContextApiError as exc:
+        _context_error(ctx, exc.error_code, exc.message, exc.status_code)
+        sys.exit(1)
+
+    if ctx.obj["json"]:
+        click.echo(json_mod.dumps(pack, indent=2, default=str))
+    else:
+        _render_context_pack(pack)
+
+
 # ── config ───────────────────────────────────────────────────────────────────
 
 
@@ -847,13 +951,17 @@ def config_show(ctx):
     merged = _cfg.load_config()
     if ctx.obj["json"]:
         click.echo(json_mod.dumps({
-            "merged": merged,
+            "merged": _redact_config_for_display(merged),
             "server_port": _cfg.resolve_server_port(),
             "server_host": _cfg.resolve_server_host(),
+            "context_api_base_url": _cfg.resolve_context_api_base_url(),
+            "context_api_key_configured": bool(_cfg.resolve_context_api_key()),
         }, indent=2))
     else:
         click.echo(f"  server.host: {_cfg.resolve_server_host()}")
         click.echo(f"  server.port: {_cfg.resolve_server_port()}")
+        click.echo(f"  context.api_base_url: {_cfg.resolve_context_api_base_url()}")
+        click.echo(f"  context.api_key: {'configured' if _cfg.resolve_context_api_key() else '(none)'}")
         solvers = _cfg.list_solver_pins()
         if solvers:
             click.echo("  solver pins:")

--- a/src/sim/config.py
+++ b/src/sim/config.py
@@ -29,6 +29,7 @@ else:  # pragma: no cover — exercised only on 3.10
 
 DEFAULT_SERVER_PORT = 7600
 DEFAULT_SERVER_HOST = "127.0.0.1"
+DEFAULT_CONTEXT_API_BASE_URL = "https://sim.svdailab.com/api/v1"
 
 
 # ── Paths ────────────────────────────────────────────────────────────────────
@@ -179,6 +180,30 @@ def list_solver_pins() -> dict[str, dict]:
     return {k: v for k, v in solvers.items() if isinstance(v, dict)}
 
 
+def resolve_context_api_base_url() -> str:
+    """env SIM_CONTEXT_API_BASE_URL > config [context].api_base_url > hosted default."""
+    raw = os.environ.get("SIM_CONTEXT_API_BASE_URL")
+    if raw:
+        return raw.rstrip("/")
+    cfg = _cached_config()
+    base_url = cfg.get("context", {}).get("api_base_url")
+    if isinstance(base_url, str) and base_url:
+        return base_url.rstrip("/")
+    return DEFAULT_CONTEXT_API_BASE_URL
+
+
+def resolve_context_api_key() -> str | None:
+    """env SIM_CONTEXT_API_KEY > config [context].api_key > None."""
+    raw = os.environ.get("SIM_CONTEXT_API_KEY")
+    if raw:
+        return raw
+    cfg = _cached_config()
+    key = cfg.get("context", {}).get("api_key")
+    if isinstance(key, str) and key:
+        return key
+    return None
+
+
 # ── Init helper ──────────────────────────────────────────────────────────────
 
 
@@ -192,6 +217,11 @@ GLOBAL_STUB = """\
 # [server]
 # port = 7600
 # host = "127.0.0.1"
+#
+# [context]
+# api_base_url = "https://sim.svdailab.com/api/v1"
+# Prefer SIM_CONTEXT_API_KEY for secrets; config is supported for managed hosts.
+# api_key = "sim_sk_..."
 
 # [solvers.fluent]
 # path = "C:\\\\Program Files\\\\ANSYS Inc\\\\v252"
@@ -207,6 +237,11 @@ PROJECT_STUB = """\
 
 # [server]
 # port = 7600
+#
+# [context]
+# api_base_url = "https://sim.svdailab.com/api/v1"
+# Prefer SIM_CONTEXT_API_KEY for secrets; config is supported for managed hosts.
+# api_key = "sim_sk_..."
 
 # [solvers.fluent]
 # profile = "pyfluent_0_38_modern"

--- a/src/sim/context_client.py
+++ b/src/sim/context_client.py
@@ -1,0 +1,89 @@
+"""Client for the hosted Engineering Context API."""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from sim import config as _cfg
+
+
+class MissingContextApiKey(RuntimeError):
+    """Raised when no hosted context API key is configured."""
+
+
+class ContextApiError(RuntimeError):
+    def __init__(self, status_code: int | None, error_code: str, message: str, detail: Any = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_code = error_code
+        self.message = message
+        self.detail = detail
+
+
+def _endpoint(base_url: str) -> str:
+    return base_url.rstrip("/") + "/context"
+
+
+def _extract_error(response: httpx.Response) -> tuple[str, str, Any]:
+    try:
+        payload = response.json()
+    except ValueError:
+        return "CONTEXT_API_REQUEST_FAILED", response.text or f"HTTP {response.status_code}", None
+
+    detail = payload.get("detail", payload)
+    if isinstance(detail, dict):
+        code = str(detail.get("error_code") or _code_for_status(response.status_code))
+        message = str(detail.get("message") or detail.get("error") or f"HTTP {response.status_code}")
+    else:
+        code = _code_for_status(response.status_code)
+        message = str(detail)
+    return code, message, payload
+
+
+def _code_for_status(status_code: int) -> str:
+    if status_code in {401, 403}:
+        return "CONTEXT_API_UNAUTHORIZED"
+    if status_code == 429:
+        return "CONTEXT_API_RATE_LIMITED"
+    return "CONTEXT_API_REQUEST_FAILED"
+
+
+def get_context(
+    *,
+    domain: str,
+    query: str,
+    max_tokens: int = 4000,
+    source_preference: str = "any",
+    solver_version: str | None = None,
+    api_base_url: str | None = None,
+    api_key: str | None = None,
+    timeout: float = 20.0,
+) -> dict[str, Any]:
+    key = api_key or _cfg.resolve_context_api_key()
+    if not key:
+        raise MissingContextApiKey("Set SIM_CONTEXT_API_KEY or [context].api_key before requesting hosted context.")
+
+    payload = {
+        "domain": domain,
+        "query": query,
+        "max_tokens": max_tokens,
+        "source_preference": source_preference,
+    }
+    if solver_version:
+        payload["solver_version"] = solver_version
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            response = client.post(
+                _endpoint(api_base_url or _cfg.resolve_context_api_base_url()),
+                headers={"Authorization": f"Bearer {key}"},
+                json=payload,
+            )
+    except httpx.HTTPError as exc:
+        raise ContextApiError(None, "CONTEXT_API_REQUEST_FAILED", f"Cannot reach hosted context API: {exc}") from exc
+
+    if response.status_code != 200:
+        code, message, detail = _extract_error(response)
+        raise ContextApiError(response.status_code, code, message, detail)
+    return response.json()

--- a/src/sim/describe.py
+++ b/src/sim/describe.py
@@ -81,6 +81,14 @@ _EXAMPLES: dict[str, list[dict[str, str]]] = {
     "logs": [
         {"cmd": "sim logs --limit 20", "summary": "Show the last 20 history entries."},
     ],
+    "context": [
+        {"cmd": 'sim context get --domain comsol "chip package overheating"',
+         "summary": "Fetch hosted engineering context for an agent."},
+    ],
+    "context get": [
+        {"cmd": 'sim --json context get --domain comsol "chip package overheating"',
+         "summary": "Return an agent-readable context pack as JSON."},
+    ],
     "config show": [
         {"cmd": "sim config show --json",
          "summary": "Print the resolved config (project + global merged)."},
@@ -179,6 +187,14 @@ ERROR_CODES: dict[str, str] = {
         "A driver returned a value that doesn't match DriverProtocol.",
     "NONINTERACTIVE_INPUT_REQUIRED":
         "--no-interactive is set and the command would otherwise prompt.",
+    "CONTEXT_API_KEY_MISSING":
+        "Hosted engineering context was requested but no API key is configured.",
+    "CONTEXT_API_UNAUTHORIZED":
+        "The hosted engineering context API rejected the configured API key or scope.",
+    "CONTEXT_API_RATE_LIMITED":
+        "The hosted engineering context API rate limit was exceeded.",
+    "CONTEXT_API_REQUEST_FAILED":
+        "The hosted engineering context API could not be reached or returned an error.",
 }
 
 

--- a/tests/base/test_context_client.py
+++ b/tests/base/test_context_client.py
@@ -1,0 +1,124 @@
+import json
+
+from click.testing import CliRunner
+
+from sim import config as _cfg
+from sim import context_client
+from sim.cli import main
+
+
+def _pack():
+    return {
+        "schema_version": "context_pack_v1",
+        "domain": "comsol",
+        "mode": "context_only",
+        "llm_used": False,
+        "usage": {
+            "returned_example_count": 1,
+            "context_block_count": 1,
+            "estimated_returned_tokens": 42,
+        },
+        "recommended_examples": [
+            {
+                "id": "seed_surface_mount_package_847",
+                "title": "Heat Transfer in a Surface-Mount Package for a Silicon Chip",
+                "summary": "Electronics cooling context.",
+                "source_kind": "online_application_gallery_example",
+                "source_pointer": {
+                    "url": "https://www.comsol.com/model/heat-transfer-in-a-surface-mount-package-for-a-silicon-chip-847"
+                },
+            }
+        ],
+        "agent_hints": {
+            "physics": ["Use Heat Transfer in Solids."]
+        },
+    }
+
+
+def test_context_config_resolvers(tmp_path, monkeypatch):
+    proj = tmp_path / "proj-sim"
+    proj.mkdir()
+    (proj / "config.toml").write_text(
+        "[context]\napi_base_url = \"http://127.0.0.1:8088/api/v1\"\napi_key = \"sim_sk_config\"\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SIM_HOME", str(tmp_path / "home-sim"))
+    monkeypatch.setenv("SIM_DIR", str(proj))
+    monkeypatch.delenv("SIM_CONTEXT_API_BASE_URL", raising=False)
+    monkeypatch.delenv("SIM_CONTEXT_API_KEY", raising=False)
+    _cfg.clear_cache()
+
+    assert _cfg.resolve_context_api_base_url() == "http://127.0.0.1:8088/api/v1"
+    assert _cfg.resolve_context_api_key() == "sim_sk_config"
+
+    monkeypatch.setenv("SIM_CONTEXT_API_BASE_URL", "http://localhost:9999/api/v1/")
+    monkeypatch.setenv("SIM_CONTEXT_API_KEY", "sim_sk_env")
+    assert _cfg.resolve_context_api_base_url() == "http://localhost:9999/api/v1"
+    assert _cfg.resolve_context_api_key() == "sim_sk_env"
+
+
+def test_config_show_redacts_context_api_key(tmp_path, monkeypatch):
+    proj = tmp_path / "proj-sim"
+    proj.mkdir()
+    (proj / "config.toml").write_text("[context]\napi_key = \"sim_sk_secret\"\n", encoding="utf-8")
+    monkeypatch.setenv("SIM_HOME", str(tmp_path / "home-sim"))
+    monkeypatch.setenv("SIM_DIR", str(proj))
+    monkeypatch.delenv("SIM_CONTEXT_API_KEY", raising=False)
+    _cfg.clear_cache()
+
+    result = CliRunner().invoke(main, ["--json", "config", "show"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["context_api_key_configured"] is True
+    assert "sim_sk_secret" not in result.output
+    assert data["merged"]["context"]["api_key"] == "***configured***"
+
+
+def test_context_get_json(monkeypatch, tmp_path):
+    def fake_get_context(**kwargs):
+        assert kwargs["domain"] == "comsol"
+        assert kwargs["query"] == "chip cooling"
+        assert kwargs["source_preference"] == "any"
+        return _pack()
+
+    monkeypatch.setenv("SIM_HOME", str(tmp_path / "home-sim"))
+    monkeypatch.setenv("SIM_DIR", str(tmp_path / "proj-sim"))
+    monkeypatch.setattr(context_client, "get_context", fake_get_context)
+
+    result = CliRunner().invoke(main, ["--json", "context", "get", "--domain", "comsol", "chip cooling"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["schema_version"] == "context_pack_v1"
+    assert data["recommended_examples"][0]["id"] == "seed_surface_mount_package_847"
+
+
+def test_context_get_missing_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("SIM_HOME", str(tmp_path / "home-sim"))
+    monkeypatch.setenv("SIM_DIR", str(tmp_path / "proj-sim"))
+    monkeypatch.delenv("SIM_CONTEXT_API_KEY", raising=False)
+    _cfg.clear_cache()
+
+    result = CliRunner().invoke(main, ["--json", "context", "get", "chip cooling"])
+
+    assert result.exit_code == 2
+    data = json.loads(result.output)
+    assert data["error_code"] == "CONTEXT_API_KEY_MISSING"
+    assert "fallback" in data
+
+
+def test_context_get_api_error(monkeypatch, tmp_path):
+    def fake_get_context(**kwargs):
+        raise context_client.ContextApiError(429, "CONTEXT_API_RATE_LIMITED", "Rate limit exceeded.")
+
+    monkeypatch.setenv("SIM_HOME", str(tmp_path / "home-sim"))
+    monkeypatch.setenv("SIM_DIR", str(tmp_path / "proj-sim"))
+    monkeypatch.setattr(context_client, "get_context", fake_get_context)
+
+    result = CliRunner().invoke(main, ["--json", "context", "get", "chip cooling"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["error_code"] == "CONTEXT_API_RATE_LIMITED"
+    assert data["status_code"] == 429


### PR DESCRIPTION
## Summary
- Add `sim context get --domain comsol "..."` for hosted Engineering Context API calls.
- Add config/env resolution for `SIM_CONTEXT_API_BASE_URL` and `SIM_CONTEXT_API_KEY`, with config-show redaction.
- Add context API error codes to `sim describe`/agent-readability docs and a small README example.

## Validation
- `python -m pytest -q tests\base\test_context_client.py tests\base\test_config.py tests\base\test_describe.py --basetemp .pytest_basetemp\local` -> 31 passed.
- `python -c "from sim.cli import main; main(args=['context','get','--help'], standalone_mode=False)"` -> help renders.
- `python -c "from sim.cli import main; main(args=['describe','context.get'], standalone_mode=False)"` -> manifest entry renders.
- `python -c "from sim.cli import main; main(args=['--json','context','get','--domain','comsol','chip cooling'], standalone_mode=False)"` with no key -> expected `CONTEXT_API_KEY_MISSING` JSON.
- `sim --help` after editable install lists the new `context` command.

## Notes
- A full `tests/base` run reached 201 passed but had 4 unrelated/environmental failures from installed external COMSOL plugin registry/skills assumptions, a Windows path-classification expectation, and an existing workspace-delta output assertion. Targeted context/config/describe coverage passed.