### PR TITLE
Add Blender plugin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Ready-to-use plugins:
 | Abaqus | `sim-plugin-abaqus` | [sim-plugin-abaqus](https://github.com/svd-ai-lab/sim-plugin-abaqus) |
 | LTspice | `sim-plugin-ltspice` | [sim-plugin-ltspice](https://github.com/svd-ai-lab/sim-plugin-ltspice) |
 | OpenFOAM | `sim-plugin-openfoam` | [sim-plugin-openfoam](https://github.com/svd-ai-lab/sim-plugin-openfoam) |
+| Blender | `sim-plugin-blender @ https://github.com/svd-ai-lab/sim-plugin-blender/releases/download/v0.1.0/sim_plugin_blender-0.1.0-py3-none-any.whl` | [sim-plugin-blender](https://github.com/svd-ai-lab/sim-plugin-blender) |
 
 Under development: Amesim, Dymola, and Flotherm.
 


### PR DESCRIPTION
## Summary
- Add `sim-plugin-blender` to the ready-to-use plugin table after OpenFOAM.
- Use the GitHub Release wheel URL for v0.1.0 as the installable package spec.

## Validation
- `git diff --check`
- Fresh release-wheel smoke from `https://github.com/svd-ai-lab/sim-plugin-blender/releases/download/v0.1.0/sim_plugin_blender-0.1.0-py3-none-any.whl`: `sim check blender`, `sim connect --solver blender --ui-mode no_gui`, `sim exec`, `sim inspect blender.scene.summary`, `sim disconnect` passed against local Blender 5.1.1.

## Notes
PyPI is intentionally not used for this entry; GitHub Release is the current public install channel.