### PR TITLE
release: 0.3.6 — drop plugin discovery catalogue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sim-cli-core"
-version = "0.3.5"
+version = "0.3.6"
 description = "Make every engineering tool agent-native — a CLI runtime that lets LLM agents launch, drive, and observe CAD/CAE software"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cut 0.3.6 to publish the plugin-catalogue removal (#106) and the README/docs cleanup that landed since v0.3.5.

Changes since v0.3.5 (in publish order):
- Add "Why CLI-first?" section + reposition intro
- Remove hosted Engineering Context API client (#104)
- Reframe README around CAE control loop (#105)
- Drop plugin discovery catalogue: `sim plugin catalog`, `sim.plugin_catalog` module, JSON fetcher, cache logic. README plugin table trimmed to 5 representative entries with link to sim-plugin-index for the curated full list (#106)

## Test plan

- [x] `uv build` produces `sim_cli_core-0.3.6-py3-none-any.whl` + sdist
- [x] `twine check` passes both artifacts
- [x] Clean-venv smoke: `sim --version` → "sim, version 0.3.6"
- [x] `python -c "import sim; print(sim.__version__)"` → "0.3.6"
- [x] `importlib.metadata.version("sim-cli-core")` → "0.3.6"

## After merge

1. `git tag -a v0.3.6 -m "Release 0.3.6 …" main && git push origin v0.3.6`
2. Watch `.github/workflows/publish.yml` run; expect OIDC publish to PyPI.
3. Verify `pip install sim-cli-core==0.3.6` in a fresh venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)