### PR TITLE
[codex] Retire legacy plugin installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ uv run sim check <solver>
 uv run sim plugin doctor <solver> --deep
 ```
 
-For direct wheel, Git, local checkout, or non-uv workflows, see
+For direct wheel, Git, local checkout, or non-uv package workflows, see
 [docs/plugin-install.md](docs/plugin-install.md).
 
 ## Project setup with sim.toml
@@ -351,7 +351,7 @@ uv run sim plugin sync-skills --target .claude/skills --copy
 | `uv run sim inspect <target>` | Query session, result, or solver-specific state. |
 | `uv run sim run script.py --solver <solver>` | Run a deterministic one-shot script. |
 | `uv run sim disconnect` | Tear down the active session. |
-| `uv run sim setup` | Apply plugin declarations from `sim.toml` when you use them. |
+| `uv run sim setup` | Validate `sim.toml` and report declared plugin package specs. |
 
 Run `uv run sim describe` for a machine-readable command manifest, or
 `uv run sim <command> --help` for exact options.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -35,7 +35,8 @@ src/sim/
   driver.py          DriverProtocol + result dataclasses
   compat.py          Version-compat profiles + layered skill resolution
   plugins.py         Plugin discovery, listing, info
-  _plugin_install.py Explicit install / uninstall sources
+  _plugin_install.py Migration shim for retired package mutation commands
+  _skills/           sim-cli shared runtime skills bundled with the wheel
   drivers/
     __init__.py      Plugin registry — discovers external plugins
                      via the `sim.drivers` entry-point group at
@@ -90,10 +91,11 @@ execute even when the directive is present in the input file.
 
 ## Layered skill composition
 
-Skills in [`sim-skills`](https://github.com/svd-ai-lab/sim-skills) use a layered directory structure to handle SDK and solver version differences:
+Plugin-bundled skills can use a layered directory structure to handle SDK and
+solver version differences:
 
 ```
-sim-skills/<driver>/
+_skills/<driver>/
   base/                     shared — always loaded
   sdk/<sdk_version>/        override when SDK API differs
   solver/<solver_version>/  override when solver behavior differs

--- a/docs/agent-readability.md
+++ b/docs/agent-readability.md
@@ -58,8 +58,8 @@ top-level keys (`stdout`, `stderr`); never inside `message`.
 | `LINT_FAILED` | `sim lint` produced at least one error-level diagnostic. |
 | `RUN_FAILED` | The solver returned non-zero or the driver detected an error in the output. |
 | `SESSION_NOT_FOUND` | `--session <id>` does not match any active session on the server. |
-| `PLUGIN_NOT_FOUND` | `sim plugin install` received an invalid explicit source, or a plugin name is not installed. |
-| `PLUGIN_INSTALL_FAILED` | `pip install` for a plugin returned non-zero. |
+| `PLUGIN_NOT_FOUND` | A requested plugin name is not registered in this environment. |
+| `PLUGIN_INSTALL_RETIRED` | A retired plugin package mutation command was invoked; use `uv add` / `uv remove` instead. |
 | `PROTOCOL_VIOLATION` | A driver returned a value that doesn't match `DriverProtocol`. |
 | `NONINTERACTIVE_INPUT_REQUIRED` | `--no-interactive` is set and the command would otherwise prompt. |
 
@@ -74,7 +74,7 @@ and the JSON schema emitted by `sim describe --error-codes`.
 | 1 | Run-level failure (solver returned non-zero, lint produced diagnostics). |
 | 2 | User error (bad args, unknown command). |
 | 3 | Environment error (solver not installed). |
-| 4 | Plugin error (`sim plugin install` failed, plugin doctor FAIL). |
+| 4 | Plugin error (retired mutation command invoked, plugin doctor FAIL). |
 
 `sim plugin doctor --all` exits with a count of FAILed plugins (so it works
 in `&&` chains).
@@ -106,10 +106,11 @@ name = "local_plugin"
 wheel = "./vendor/sim_plugin_local-1.2.0-py3-none-any.whl"   # local, air-gapped
 ```
 
-`sim init` creates a starter `sim.toml`. `sim setup` reads it and ensures
-plugins/server config/workspace are in place. `sim config show --json`
-prints the resolved config; `sim config validate <file>` checks a file
-against the schema without applying it.
+`sim init` creates a starter `sim.toml`. `sim setup` reads it, validates it,
+and reports declared plugin package specs; package installation belongs to
+the uv project (`uv add sim-cli-core <plugin-package-spec>`). `sim config
+show --json` prints the resolved config; `sim config validate <file>` checks
+a file against the schema without applying it.
 
 ### Resolution order (later overrides earlier)
 

--- a/docs/architecture/skills-layering-plan.md
+++ b/docs/architecture/skills-layering-plan.md
@@ -1,306 +1,68 @@
-# Skills Layering — Design Plan (v2)
+# Skills Layering
 
-> Status: **proposal, awaiting review**
->
-> This doc replaces the v1 draft. Key corrections from v1, all from
-> review feedback:
->
-> 1. There is **one** `SKILL.md` per driver (at the driver root), and it
->    is purely an index — not concatenated from per-layer fragments.
-> 2. **No `sim skills` CLI subcommands.** The LLM already has Read /
->    Glob / Grep; wrapping them adds nothing.
-> 3. **No `sim/skills.py` module.** v1 introduced one; it turned out to
->    be ~140 LOC of machinery for a contract that fits in ~40 LOC inside
->    `compat.py`. The v1 module and its tests have been deleted.
+This document records the current skill packaging model.
 
----
+## Ownership
 
-## 1. Problem (one paragraph)
+- `sim-cli` owns shared runtime skills under `src/sim/_skills/sim-cli/`.
+- Solver plugins own solver-specific skills under their package-local
+  `_skills/<solver>/` directory and expose them through the `sim.skills`
+  entry-point group.
+- A local `SIM_SKILLS_ROOT` can override plugin-bundled skills during
+  development, but it is not the default public distribution path.
 
-Each driver currently ships a flat `sim-skills/<driver>/` tree. As we
-add more SDK and solver versions, the API-specific bits (one SDK
-release vs the next) and solver-specific bits (one solver release vs
-the next) start fighting the cross-cutting bits (concepts, file
-formats, license tips). We need a way to say "this reference is
-generic; this snippet is SDK-rev-only; this known-issue is
-solver-rev-only" *without* duplicating the whole tree per profile.
+The old external shared-skill repository is archival. New public solver
+workflow guidance should live with the plugin package that owns the driver.
 
-## 2. Layout
+## Runtime Sync
 
-```
-sim-skills/<driver>/
-    SKILL.md            ← single entry point. Hand-written index that
-                          tells the LLM where to look. Does NOT contain
-                          actual knowledge — only pointers like
-                          "for SDK API see sdk/<your-version>/, for
-                          solver-specific quirks see solver/<ver>/".
-    base/               ← knowledge that applies to ALL profiles. May
-                          have arbitrary internal structure:
-        concepts/
-        reference/
-        snippets/
-        workflows/
-    sdk/
-        <sdk-rev-a>/
-        <sdk-rev-b>/
-    solver/
-        <solver-rev-a>/
-        <solver-rev-b>/
+`sim plugin sync-skills` materializes:
+
+1. the bundled `sim-cli` runtime skill, and
+2. every installed plugin skill discoverable through `sim.skills`.
+
+The command does not install packages. Agents add packages with `uv add`, then
+sync and verify:
+
+```bash
+uv add sim-cli-core <plugin-package-spec>
+uv run sim plugin sync-skills --target .agents/skills --copy
+uv run sim check <solver>
+uv run sim plugin doctor <solver> --deep
 ```
 
-`base/` is always relevant. `sdk/<slug>/` and `solver/<slug>/` carry
-deltas that apply only to specific profiles.
+Use `.agents/skills` for Codex and GitHub Copilot. Use `.claude/skills` for
+Claude Code.
 
-The same template applies to every driver. SDK-less drivers (e.g. those
-that drive a solver purely through its scripting interface or a CLI
-batch mode) just have an empty or absent `sdk/` directory.
+## Layered Layout
 
-## 3. compat.yaml change
+Version-sensitive plugin skills may use this layout:
 
-Each profile gains two optional string fields:
+```text
+_skills/<driver>/
+  SKILL.md
+  base/
+  sdk/<sdk-slug>/
+  solver/<solver-slug>/
+```
+
+`compatibility.yaml` can declare:
 
 ```yaml
 profiles:
-  - name: <profile-name>
-    sdk: ">=X.Y,<Z.W"
-    solver_versions: ["<solver-rev-a>", "<solver-rev-b>"]
-    runner_module: sim._runners.<driver>.<runner>
-    active_sdk_layer: <sdk-slug>            # ← new
-    active_solver_layer: "<solver-slug>"    # ← new
+  - name: solver_2025_sdk_1
+    solver_versions: ["2025"]
+    sdk: ">=1,<2"
+    active_sdk_layer: "1.x"
+    active_solver_layer: "2025"
 ```
 
-`base/` is implicit and always active — no field for it.
+The `/connect` response includes `active_sdk_layer` and
+`active_solver_layer` so an agent can pick the correct skill layer after the
+Step-0 version probe.
 
-`active_sdk_layer` resolves to `sim-skills/<driver>/sdk/<value>/`.
-`active_solver_layer` resolves to `sim-skills/<driver>/solver/<value>/`.
+## Validation
 
-Either field may be omitted (e.g. SDK-less drivers leave
-`active_sdk_layer` unset, drivers with no version-sensitive solver
-content leave `active_solver_layer` unset). The current
-`skill_revision` field is **deleted**.
-
-## 4. Runtime contract
-
-The only runtime requirement: when an LLM connects, it needs to know
-which sdk/solver layers are active for its profile. Otherwise it can't
-tell which `sdk/<slug>/` directory to read.
-
-Wire it through the existing `/connect` response. After a successful
-connect, sim-server returns:
-
-```json
-{
-  "ok": true,
-  "data": {
-    "session_id": "...",
-    "profile": "<profile-name>",
-    "skills": {
-      "root": "/path/to/sim-skills/<driver>",
-      "index": "/path/to/sim-skills/<driver>/SKILL.md",
-      "active_sdk_layer": "sdk/<sdk-slug>",
-      "active_solver_layer": "solver/<solver-slug>"
-    },
-    ...
-  }
-}
-```
-
-The LLM reads `index` once, follows the pointers it finds there,
-filtered by the active layers. sim-cli does no file reading, no
-composition, no overlay logic. Path strings are the entire API.
-
-## 5. Code changes
-
-### `src/sim/compat.py`
-
-- Add `Profile.active_sdk_layer: str | None = None`
-- Add `Profile.active_solver_layer: str | None = None`
-- Loader recognizes the two new keys; unrecognized keys still go into
-  `Profile.extra` as today
-- Delete `skill_revision` field from `Profile` (and from every
-  `compatibility.yaml` — see §6)
-- New helper:
-
-  ```python
-  def verify_skills_layout(skills_root: Path) -> list[str]:
-      """For every profile in every driver compat.yaml, verify the
-      declared sdk/solver layer directories exist on disk under
-      <skills_root>/<driver>/. Returns a list of human-readable
-      mismatch lines; empty list means healthy. Always checks that
-      <skills_root>/<driver>/SKILL.md and <skills_root>/<driver>/base/
-      exist."""
-  ```
-
-  ~30 lines, no module.
-
-### `src/sim/server.py`
-
-In `/connect`, after the runner is up and the profile is known, build
-the `skills` dict and include it in the response. ~15 lines, including
-locating `SIM_SKILLS_ROOT` (env var, fallback to sibling of sim-cli
-checkout — same probe logic that lived in the deleted skills.py,
-inlined as a 6-line function).
-
-### `src/sim/cli.py`
-
-No changes. The session client already JSON-passes the connect response
-through; the LLM sees `skills` in its tool result automatically.
-
-### Optional: `sim doctor`
-
-If `sim doctor` already exists, hook `verify_skills_layout()` into it.
-If it doesn't, skip — punt to a future PR. (Confirmed not to exist;
-skipping.)
-
-## 6. sim-skills migration
-
-Per-driver, in dependency order. Each driver is a separate sim-skills PR.
-
-1. **pybamm** — currently has only `SKILL.md`. Create `base/` with the
-   existing content, write a fresh top-level `SKILL.md` index.
-   Validates the loader/contract end-to-end on minimal content.
-2. **openfoam** — SDK-less. Move existing `reference/`, `docs/`,
-   `tests/` into `base/`. Create `solver/<rev>/` directories per
-   supported release (initially empty `.gitkeep`). Hand-write SKILL.md
-   index. compat.yaml profiles get `active_solver_layer`.
-3. Drivers with both SDK and solver-version sensitivity — move bulk
-   content into `base/`. Create one `sdk/<rev>/` per supported SDK
-   release and triage which existing snippets/reference files are
-   version-specific. Create `solver/<rev>/` directories (probably
-   mostly empty at first). Hand-write SKILL.md index.
-4. SDK-less drivers and drivers with smallest deltas — do last.
-
-After each driver's PR lands, the corresponding `compatibility.yaml` in
-sim-cli (or the plugin package, for out-of-tree drivers) is updated in
-the same commit. The schema change in §3 must be additive and backward
-compatible *for unmigrated drivers*: profiles without the two new
-fields just get None for both, which means "no sdk/solver overlay,
-base only".
-
-## 7. SKILL.md content (template)
-
-Each driver's top-level `SKILL.md` is hand-written. Suggested skeleton:
-
-```markdown
-# <driver> skill index
-
-You are connected to <driver>. The sim-cli connect response told you
-which active layers apply (`active_sdk_layer`, `active_solver_layer`).
-
-## Always relevant — base/
-
-- `base/concepts/` — what a case file is, what meshing means, …
-- `base/reference/` — generic API and CLI reference
-- `base/snippets/` — copy-pasteable starters
-- `base/workflows/` — multi-step recipes
-
-## SDK-version-specific — sdk/<your-active-sdk-layer>/
-
-For example, if your active_sdk_layer is `<sdk-slug>`, look in
-`sdk/<sdk-slug>/` for:
-- the API surface (method names, kwargs)
-- migration notes from earlier SDKs
-- known SDK-version bugs
-
-## Solver-version-specific — solver/<your-active-solver-layer>/
-
-For example, if your active_solver_layer is `<solver-slug>`, look in
-`solver/<solver-slug>/` for:
-- features added/removed in this release
-- license syntax quirks
-- known issues
-
-## Lookup order when answering a question
-
-1. base/ for concepts and shape of the workflow
-2. sdk/<active>/ for the exact API call
-3. solver/<active>/ for any caveats
-
-A file in sdk/ or solver/ overrides anything in base/ on the same
-topic — if both exist, prefer the more specific one.
-```
-
-The override convention is **policy in the SKILL.md**, not enforced by
-sim-cli. The LLM follows the index. This keeps the runtime stupid.
-
-## 8. Tests
-
-Tests live alongside `compat.py`. Create `tests/test_compat_skills.py`
-(or fold into a new `tests/test_compat.py` — neither exists yet).
-
-| # | Test | Asserts |
-|---|------|---------|
-| 1 | `profile_loads_active_layer_fields` | Synthetic compat.yaml with `active_sdk_layer` / `active_solver_layer` round-trips into `Profile` correctly. |
-| 2 | `profile_active_layers_default_to_none` | A profile that omits both fields gets `None` / `None` and still loads. |
-| 3 | `verify_skills_layout_passes_on_complete_tree` | Build a synthetic sim-skills tree with `<driver>/SKILL.md`, `<driver>/base/`, `<driver>/sdk/<sdk-slug>/`, `<driver>/solver/<solver-slug>/`. Pretend compat.yaml declares those active layers. `verify_skills_layout()` returns `[]`. |
-| 4 | `verify_skills_layout_flags_missing_skill_md` | Drop `<driver>/SKILL.md` → mismatch entry. |
-| 5 | `verify_skills_layout_flags_missing_base` | Drop `<driver>/base/` → mismatch entry. |
-| 6 | `verify_skills_layout_flags_missing_sdk_layer` | compat.yaml declares an `active_sdk_layer` slug for which no directory exists → mismatch entry. |
-| 7 | `verify_skills_layout_flags_missing_solver_layer` | symmetric. |
-| 8 | `verify_skills_layout_skips_unset_layers` | A profile with `active_sdk_layer: None` doesn't trigger any sdk-related check. |
-| 9 | `connect_response_includes_skills_block` | (server-side, async test) `/connect` against a fake driver returns a response whose `data.skills` block has `root`, `index`, `active_sdk_layer`, `active_solver_layer`. |
-| 10 | `connect_response_skills_root_is_none_when_tree_absent` | If `SIM_SKILLS_ROOT` is unset and there's no sibling tree, `data.skills.root` is `None` and connect still succeeds. |
-
-All tests use `tempfile` synthetic trees. No dependency on the real
-sim-skills repo.
-
-## 9. Order of execution (after this plan is approved)
-
-1. Schema + loader change in `compat.py` (§5), with tests #1, #2 above.
-2. `verify_skills_layout()` in `compat.py` with tests #3 – #8.
-3. `/connect` server change in `server.py` with tests #9, #10.
-4. Per-driver sim-skills migration PRs in the order from §6. Each PR
-   updates that driver's `compatibility.yaml` to set the two active
-   layer fields and removes `skill_revision`.
-5. Once every driver is migrated, delete the back-compat tolerance for
-   `skill_revision` (a one-line removal — until then the loader
-   accepts and ignores it with a warning).
-
-## 10. What this plan deliberately does NOT do
-
-- No file composition / overlay logic in sim-cli. The runtime returns
-  paths; the LLM does the rest.
-- No `sim skills *` CLI subcommands.
-- No `sim/skills.py` module. Everything fits in `compat.py` + a small
-  block in `server.py`.
-- No `SKILL.md` concatenation across layers. One driver, one index,
-  hand-written.
-- No automatic layer detection from `sdk:` / `solver_versions:` ranges.
-  Authors set `active_sdk_layer` and `active_solver_layer` explicitly
-  — explicit is reviewable, magic isn't.
-- No templating in skill files.
-
-## 11. Net effect
-
-Code: `compat.py` grows by ~50 LOC. `server.py` grows by ~20 LOC. No
-new modules. Total surface area is much smaller than v1's plan.
-
-Content: each driver's sim-skills tree gains a top-level `SKILL.md`
-plus three subdirectories. The bulk of existing content moves into
-`base/` unchanged. New solver/SDK versions add a directory each, no
-duplication.
-
-LLM ergonomics: one connect call hands the agent a stable starting
-path and the names of its active overlay layers. From there, the agent
-works with the same Read/Glob/Grep tools it already has.
-
----
-
-## 12. Open questions for review
-
-1. **Layer slug convention.** Should the slug repeat the SDK package
-   name (e.g. `sdk/<sdk-package>-<rev>/`) or stay terse (e.g.
-   `sdk/<rev>/`, since the parent dir already names the driver)?
-2. **`active_sdk_layer` value format.** Same question — does the yaml
-   value include the SDK-package prefix, or just the rev?
-3. **Should `verify_skills_layout()` be wired into a CI step now**, or
-   only added as a function for later use? (I lean: add the function,
-   no CI hook yet — wiring it into CI requires both repos to migrate
-   in lockstep, which is the thing we're trying to avoid.)
-4. **`skills.root` when sim-skills isn't installed.** Currently I plan
-   to return `None`. Alternative: return the path it *would* be at
-   (sibling of sim-cli) so the LLM can at least produce a useful error
-   message. Preference?
-
-Once these are settled I'll start with step 1 of §9 (TDD: write
-`tests/test_compat.py` red, then make it green).
+`verify_skills_layout(root, profiles)` checks that declared layers exist in an
+explicit skills root. Plugin packages should also test that their packaged
+`_skills/<solver>/SKILL.md` exists and that the `sim.skills` entry point loads.

--- a/docs/architecture/version-compat.md
+++ b/docs/architecture/version-compat.md
@@ -61,8 +61,8 @@ profiles:
   - name: <stable-identifier>
     sdk: ">=X.Y,<Z.W"                          # PEP 440 specifier, optional
     solver_versions: [...]                     # concrete solver versions tested
-    active_sdk_layer: <slug>                   # optional, for sim-skills overlays
-    active_solver_layer: <slug>                # optional, for sim-skills overlays
+    active_sdk_layer: <slug>                   # optional, for skill overlays
+    active_solver_layer: <slug>                # optional, for skill overlays
     notes: |
       Free-form notes surfaced in `sim check` output.
 
@@ -81,8 +81,8 @@ Field rules:
 | `profiles[].name` | yes | Stable identifier — never rename, agents and skill folders reference it. |
 | `profiles[].sdk` | no | PEP 440 specifier for the SDK version range. |
 | `profiles[].solver_versions` | no | Concrete solver versions tested against this profile. |
-| `profiles[].active_sdk_layer` | no | Slug of the matching `sim-skills/<driver>/sdk/<slug>/` layer. |
-| `profiles[].active_solver_layer` | no | Slug of the matching `sim-skills/<driver>/solver/<slug>/` layer. |
+| `profiles[].active_sdk_layer` | no | Slug of the matching `<skills-root>/<driver>/sdk/<slug>/` layer. |
+| `profiles[].active_solver_layer` | no | Slug of the matching `<skills-root>/<driver>/solver/<slug>/` layer. |
 | `profiles[].notes` | no | Surfaced in `sim check`. |
 | `deprecated[]` | no | Old profile names + migration hints. |
 
@@ -114,8 +114,8 @@ manage their own subprocesses, but plugin discovery itself is in-process.
 ## 5. Possible future profile environments
 
 The following remains a design direction for plugins that need strong SDK
-isolation. It is not the current behavior of `sim plugin install` or
-`sim connect`.
+isolation. It is not the current behavior of package installation or
+`sim connect`; add plugin packages to the uv project with `uv add`.
 
 When a driver opts into a profile env, its layout is:
 

--- a/docs/plugin-install.md
+++ b/docs/plugin-install.md
@@ -105,30 +105,24 @@ Skills are different from Python packages. The plugin package lives in Python's
 site-packages; the bundled skill is synced into an agent-readable directory such
 as `.agents/skills` or `.claude/skills`.
 
-## sim plugin install
+## Direct sources
 
-`sim plugin install <source>` is still available for direct wheel, Git, local
-checkout, or non-uv workflows. It installs into the Python interpreter running
-`sim` unless you pass `--python`.
+Use `uv add` for direct wheel, Git, or local checkout sources too. Keep the
+plugin dependency in `pyproject.toml` so another agent can reproduce the same
+environment with `uv sync`.
 
 Examples:
 
 ```bash
-sim plugin install sim-plugin-comsol
-sim plugin install sim-plugin-comsol==<version>
-sim plugin install https://example.com/sim_plugin_comsol-<version>-py3-none-any.whl
-sim plugin install ./sim_plugin_comsol-<version>-py3-none-any.whl
-sim plugin install ./sim-plugin-comsol
-sim plugin install -e ./sim-plugin-comsol
-sim plugin install git+https://github.com/svd-ai-lab/sim-plugin-comsol
+uv add sim-cli-core sim-plugin-comsol==<version>
+uv add sim-cli-core https://example.com/sim_plugin_comsol-<version>-py3-none-any.whl
+uv add sim-cli-core ./sim_plugin_comsol-<version>-py3-none-any.whl
+uv add sim-cli-core ./sim-plugin-comsol
+uv add sim-cli-core git+https://github.com/svd-ai-lab/sim-plugin-comsol
 ```
 
-Only use `--python` when you intend to run `sim` from that same Python
-environment or otherwise know that the plugin will be discoverable there:
-
-```bash
-sim plugin install sim-plugin-comsol --python /path/to/venv/bin/python
-```
+After changing dependencies, run `uv run sim plugin sync-skills` and
+`uv run sim check <solver>` again from the same project.
 
 ## Skill sync targets
 
@@ -178,13 +172,17 @@ uv run sim plugin sync-skills --target .agents/skills --copy
 uv run sim check comsol
 ```
 
-`sim setup` remains useful when a project chooses to declare plugin sources in
-`sim.toml`; the uv project dependency list remains the clearest place to pin
-the Python environment.
+`sim setup` validates `sim.toml` and reports declared plugin package specs. It
+does not mutate the Python environment. Use `uv add sim-cli-core
+<plugin-package-spec>` to add packages and commit the resulting
+`pyproject.toml` / `uv.lock`.
 
 ## Discovery
 
-A curated plugin list lives in the [sim-plugin-index](https://github.com/svd-ai-lab/sim-plugin-index) README — a markdown table with the install string for each plugin. Agents and humans read it directly.
+A curated plugin list lives in the
+[sim-plugin-index](https://github.com/svd-ai-lab/sim-plugin-index) README — a
+markdown table with package specs and `uv add` commands for each plugin.
+Agents and humans read it directly.
 
 ## Verifying an install
 

--- a/src/sim/_plugin_install.py
+++ b/src/sim/_plugin_install.py
@@ -1,158 +1,64 @@
-"""Install / uninstall / bundle plugins.
+"""Migration shims for retired plugin installer commands.
 
-The `sim plugin` group's mutating commands route through here. Discovery
-and validation live in :mod:`sim.plugins`; this module only handles the
-install pipeline.
-
-A `<source>` argument can be any of:
-
-* ``sim-plugin-<name>`` / ``sim-plugin-<name>==<version>`` — exact pip
-  package spec.
-* ``https://...whl`` / ``https://...tar.gz`` — direct wheel/sdist URL.
-* ``./path/to/dir`` — local plugin source directory.
-* ``./path/to/wheel.whl`` / ``./path/to/sdist.tar.gz`` — local artifact.
-* ``git+https://...`` / ``git+ssh://...`` — git URL.
-
-The resolver classifies the source with no network calls and no plugin
-registry lookup. Then a single ``pip install`` invocation does the work.
+``sim`` no longer installs or uninstalls plugin packages. Package mutation
+belongs to the user's uv project; sim inspects installed packages, checks
+drivers, and syncs bundled skills.
 """
 from __future__ import annotations
 
 import re
-import shutil
-import subprocess
-import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 
-# ── Source resolution ──────────────────────────────────────────────────────
-
-
-@dataclass(frozen=True)
-class ResolvedSource:
-    """One install source classified into a canonical kind."""
-    kind: str
-    raw: str            # the original argument
-    name: str | None = None
-    version: str | None = None
-    pip_target: str = ""   # what pip install gets handed
-    extras: dict[str, Any] = field(default_factory=dict)
-
-
-_SHORT_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
-_SIM_PLUGIN_PACKAGE_RE = re.compile(
+_PACKAGE_SPEC_RE = re.compile(
     r"^(sim-plugin-[A-Za-z0-9][A-Za-z0-9_.-]*)(?:\[[A-Za-z0-9_,.-]+\])?"
     r"(?:\s*(?:==|!=|~=|>=|<=|>|<)\s*[A-Za-z0-9.*+!_.-]+)?$"
 )
-_VERSION_PIN_RE = re.compile(r"(?:==|!=|~=|>=|<=|>|<)\s*(.+)$")
+_SHORT_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
 
 
-def _short_name_error(name: str) -> str:
-    return (
-        f"{name!r} is not an explicit plugin install source. "
-        "See https://github.com/svd-ai-lab/sim-plugin-index for a curated "
-        "plugin list, or pass an explicit pip-installable source: a local "
-        "wheel/sdist path, a direct wheel/sdist URL, a git URL, or a package "
-        f"spec such as 'sim-plugin-{name}'."
+def _install_migration_message(source: str | None = None) -> str:
+    base = (
+        "sim plugin install is retired.\n\n"
+        "Add plugins with uv instead:\n"
+        "  uv add sim-cli-core <plugin-package-spec>\n"
+        "  uv run sim plugin sync-skills --target .agents/skills --copy\n"
+        "  uv run sim check <solver>"
     )
 
+    if source:
+        match = _PACKAGE_SPEC_RE.match(source.strip())
+        if match:
+            return (
+                f"{base}\n\n"
+                f"For this package spec, run:\n"
+                f"  uv add sim-cli-core {source.strip()}"
+            )
+        if _SHORT_NAME_RE.match(source.strip()):
+            return (
+                f"{base}\n\n"
+                "Short solver names are not package specs. Find the package spec in "
+                "docs.svdailab.com/plugin-index or sim-plugin-index, then run:\n"
+                "  uv add sim-cli-core <plugin-package-spec>"
+            )
 
-def resolve_source(source: str, *, offline: bool = False,
-                   index_url: str | None = None) -> ResolvedSource:
-    """Classify a source argument and choose what to hand to pip.
-
-    ``offline`` and ``index_url`` are accepted for API compatibility but no
-    longer affect resolution; this resolver never reads a plugin index or maps
-    short names to ``sim-plugin-*`` package names.
-    """
-    s = source.strip()
-    _ = (offline, index_url)
-
-    # Local files / dirs first (cheapest to check).
-    p = Path(s)
-    if s.startswith(("./", "../", "/", "~")) or p.exists():
-        target = p.expanduser().resolve()
-        if target.is_file():
-            if target.suffix == ".whl":
-                return ResolvedSource(kind="local-wheel", raw=s, pip_target=str(target))
-            if target.name.endswith(".tar.gz") or target.suffix == ".tar":
-                return ResolvedSource(kind="local-sdist", raw=s, pip_target=str(target))
-            return ResolvedSource(kind="local-file", raw=s, pip_target=str(target))
-        if target.is_dir():
-            return ResolvedSource(kind="local-dir", raw=s, pip_target=str(target))
-        # Path doesn't exist on disk and doesn't look obviously remote — error.
-        if s.startswith(("./", "../", "/", "~")):
-            raise FileNotFoundError(f"local path does not exist: {s}")
-
-    # URLs — direct wheel/sdist or git.
-    if s.startswith("git+"):
-        return ResolvedSource(kind="git-url", raw=s, pip_target=s)
-    if s.startswith(("http://", "https://")):
-        if s.endswith(".whl"):
-            return ResolvedSource(kind="wheel-url", raw=s, pip_target=s)
-        if s.endswith(".tar.gz") or s.endswith(".tar.bz2"):
-            return ResolvedSource(kind="sdist-url", raw=s, pip_target=s)
-        # Generic URL: treat as wheel-url and let pip complain.
-        return ResolvedSource(kind="wheel-url", raw=s, pip_target=s)
-
-    package_match = _SIM_PLUGIN_PACKAGE_RE.match(s)
-    if package_match:
-        version_match = _VERSION_PIN_RE.search(s)
-        version = version_match.group(1).strip() if version_match else None
-        return ResolvedSource(
-            kind="package-spec",
-            raw=s,
-            name=package_match.group(1),
-            version=version,
-            pip_target=s,
-        )
-
-    if _SHORT_NAME_RE.match(s):
-        raise ValueError(_short_name_error(s))
-
-    raise ValueError(f"could not classify install source: {source!r}")
+    return base
 
 
-# ── pip invocation ──────────────────────────────────────────────────────────
-
-
-def _pip_install(target: str, *, editable: bool = False, upgrade: bool = False,
-                 extra_args: list[str] | None = None,
-                 python: str | None = None) -> subprocess.CompletedProcess:
-    """Run ``pip install`` (or ``uv pip install`` if uv is on PATH).
-
-    ``python`` lets the caller pin which interpreter receives the install.
-    Defaults to ``sys.executable`` (the interpreter running ``sim``), which
-    is the right choice in 90% of cases. The canary verification proved
-    that without an explicit pin, ``uv pip install`` resolves the active
-    venv via ``$VIRTUAL_ENV`` / ``$CONDA_PREFIX`` / cwd discovery, which
-    can target the *wrong* interpreter when the user's terminal has no
-    venv activated.
-    """
-    use_uv = shutil.which("uv") is not None
-
-    target_python = python or sys.executable
-
-    cmd: list[str]
-    if use_uv:
-        cmd = ["uv", "pip", "install", "--python", target_python]
-    else:
-        cmd = [target_python, "-m", "pip", "install"]
-
-    if upgrade:
-        cmd.append("--upgrade")
-    if editable:
-        cmd.append("-e")
-    if extra_args:
-        cmd.extend(extra_args)
-    cmd.append(target)
-
-    return subprocess.run(cmd, capture_output=True, text=True)
-
-
-# ── Top-level install ──────────────────────────────────────────────────────
+def _uninstall_migration_message(name: str | None = None) -> str:
+    package = None
+    if name:
+        clean = name.strip()
+        package = clean if clean.startswith("sim-plugin-") else f"sim-plugin-{clean}"
+    command = f"  uv remove {package}" if package else "  uv remove <plugin-package-spec>"
+    return (
+        "sim plugin uninstall is retired.\n\n"
+        "Remove plugin packages with uv instead:\n"
+        f"{command}\n"
+        "  uv run sim plugin sync-skills --target .agents/skills --copy"
+    )
 
 
 @dataclass
@@ -175,7 +81,7 @@ class InstallReport:
             "source_kind": self.source_kind,
             "pip_target": self.pip_target,
             "pip_returncode": self.pip_returncode,
-            "pip_stdout": self.pip_stdout[-2000:],   # cap for sanity
+            "pip_stdout": self.pip_stdout[-2000:],
             "pip_stderr": self.pip_stderr[-2000:],
             "sync_skills": self.sync_skills,
             "error_code": self.error_code,
@@ -194,63 +100,19 @@ def install_plugin(
     python: str | None = None,
     extra_index_urls: list[str] | None = None,
 ) -> InstallReport:
-    """High-level installer used by ``sim plugin install``.
-
-    Returns an InstallReport — never raises for normal failures (bad source,
-    pip non-zero, sync failure). Catches and reports cleanly so the CLI
-    layer can render either JSON or human output without try/except.
-
-    ``python`` overrides the install-target interpreter. Defaults to
-    ``sys.executable`` (the interpreter running ``sim``).
-    """
-    try:
-        resolved = resolve_source(source, offline=offline)
-    except (ValueError, FileNotFoundError) as e:
-        return InstallReport(
-            ok=False, name=None, source_kind="invalid", pip_target=source,
-            pip_returncode=-1, pip_stdout="", pip_stderr="",
-            error_code="PLUGIN_NOT_FOUND",
-            message=str(e),
-        )
-
-    extra_args: list[str] = []
-    for extra_index_url in extra_index_urls or []:
-        extra_args.extend(["--extra-index-url", extra_index_url])
-
-    proc = _pip_install(
-        resolved.pip_target,
-        editable=editable,
-        upgrade=upgrade,
-        python=python,
-        extra_args=extra_args or None,
-    )
-    ok = proc.returncode == 0
-
-    if not ok:
-        return InstallReport(
-            ok=False, name=resolved.name, source_kind=resolved.kind,
-            pip_target=resolved.pip_target,
-            pip_returncode=proc.returncode,
-            pip_stdout=proc.stdout, pip_stderr=proc.stderr,
-            error_code="PLUGIN_INSTALL_FAILED",
-            message=f"pip install returned {proc.returncode}",
-        )
-
-    sync_result: dict[str, Any] | None = None
-    if not skip_sync:
-        try:
-            from sim.plugins import sync_skills_to
-            target = sync_target or _default_skills_target()
-            sync_result = sync_skills_to(target)
-        except Exception as e:  # noqa: BLE001 — sync is best-effort
-            sync_result = {"ok": False, "message": f"{type(e).__name__}: {e}"}
-
+    """Return migration guidance without invoking pip or uv pip."""
+    _ = (editable, upgrade, offline, sync_target, skip_sync, python, extra_index_urls)
+    match = _PACKAGE_SPEC_RE.match(source.strip())
     return InstallReport(
-        ok=True, name=resolved.name, source_kind=resolved.kind,
-        pip_target=resolved.pip_target,
-        pip_returncode=proc.returncode,
-        pip_stdout=proc.stdout, pip_stderr=proc.stderr,
-        sync_skills=sync_result,
+        ok=False,
+        name=match.group(1) if match else None,
+        source_kind="retired",
+        pip_target=source,
+        pip_returncode=-1,
+        pip_stdout="",
+        pip_stderr="",
+        error_code="PLUGIN_INSTALL_RETIRED",
+        message=_install_migration_message(source),
     )
 
 
@@ -266,63 +128,22 @@ def _default_skills_target() -> Path:
     return Path.home() / ".claude" / "skills"
 
 
-# ── Uninstall ───────────────────────────────────────────────────────────────
-
-
 def uninstall_plugin(name: str, *, sync: bool = True,
-                      python: str | None = None) -> dict[str, Any]:
-    """Best-effort plugin uninstall.
-
-    Tries the canonical PyPI distribution name (``sim-plugin-<name>``)
-    first, then falls back to whatever package the registry says owns
-    that driver. ``python`` pins the target interpreter (defaults to
-    ``sys.executable``).
-    """
-    from sim.plugins import list_installed_plugins
-
-    rows = {p.name: p for p in list_installed_plugins()}
-    if name not in rows:
-        return {"ok": False, "error_code": "PLUGIN_NOT_FOUND",
-                "message": f"unknown plugin: {name!r}"}
-    if rows[name].builtin:
-        return {"ok": False, "error_code": "PLUGIN_INSTALL_FAILED",
-                "message": "cannot uninstall a built-in driver — wait for v1.0 cut "
-                           "or remove from sim-cli's _BUILTIN_REGISTRY."}
-
-    package = rows[name].package or f"sim-plugin-{name}"
-    target_python = python or sys.executable
-    use_uv = shutil.which("uv") is not None
-    cmd = (["uv", "pip", "uninstall", "--python", target_python, package] if use_uv
-           else [target_python, "-m", "pip", "uninstall", "-y", package])
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-
-    if proc.returncode != 0:
-        return {"ok": False, "error_code": "PLUGIN_INSTALL_FAILED",
-                "message": f"pip uninstall returned {proc.returncode}",
-                "pip_stderr": proc.stderr[-1000:]}
-
-    # Remove the on-disk skill copy if present.
-    if sync:
-        target = _default_skills_target() / name
-        if target.is_symlink():
-            target.unlink()
-        elif target.is_dir():
-            shutil.rmtree(target)
-    return {"ok": True, "package": package, "name": name}
-
-
-# ── Bundle ──────────────────────────────────────────────────────────────────
+                     python: str | None = None) -> dict[str, Any]:
+    """Return migration guidance without invoking pip or uv pip."""
+    _ = (sync, python)
+    return {
+        "ok": False,
+        "name": name,
+        "error_code": "PLUGIN_INSTALL_RETIRED",
+        "message": _uninstall_migration_message(name),
+    }
 
 
 def bundle_plugins(names: list[str], output_dir: Path, *,
-                    index_url: str | None = None) -> dict[str, Any]:
-    """The install-resolver-backed bundle flow was removed.
-
-    See https://github.com/svd-ai-lab/sim-plugin-index for a curated plugin
-    list, then download explicit wheel URLs or install exact package specs.
-    There is no install-time resolver to map short names to wheels.
-    """
-    _ = (names, output_dir, index_url)
+                   index_url: str | None = None) -> dict[str, Any]:
+    """Return migration guidance for the removed bundle flow."""
+    _ = index_url
     return {
         "ok": False,
         "output": str(output_dir),
@@ -330,11 +151,11 @@ def bundle_plugins(names: list[str], output_dir: Path, *,
         "errors": [
             {
                 "name": name,
+                "error_code": "PLUGIN_INSTALL_RETIRED",
                 "error": (
-                    "bundle no longer resolves short plugin names; see "
-                    "https://github.com/svd-ai-lab/sim-plugin-index for a "
-                    "curated plugin list, then pass explicit wheel URLs, "
-                    "local artifacts, git URLs, or exact package specs"
+                    "sim plugin bundle is retired. Add plugin packages with "
+                    "uv add sim-cli-core <plugin-package-spec> in the target "
+                    "uv project instead."
                 ),
             }
             for name in names
@@ -343,10 +164,9 @@ def bundle_plugins(names: list[str], output_dir: Path, *,
 
 
 __all__ = [
-    "ResolvedSource",
     "InstallReport",
-    "resolve_source",
     "install_plugin",
     "uninstall_plugin",
     "bundle_plugins",
+    "_default_skills_target",
 ]

--- a/src/sim/_skills/sim-cli/SKILL.md
+++ b/src/sim/_skills/sim-cli/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: sim-cli
+description: Use whenever driving any solver through sim-cli — shared session lifecycle, command surface, input classification, version awareness, acceptance, and escalation. Load alongside the relevant plugin-specific SKILL.md — this skill owns the runtime contract; the plugin skill owns the solver-specific parts.
+---
+
+# sim-cli
+
+You are driving a solver through the **sim-cli** runtime. This skill
+owns the runtime contract that applies to **every** solver — session
+lifecycle, command surface, input validation, version awareness,
+acceptance semantics, escalation triggers.
+
+Each plugin-specific skill layers on top of this one. The plugin skill
+owns only:
+
+- Solver-specific hard constraints
+- Solver-specific dependency chains
+- Solver-specific artifacts (snippets, workflows, reference, SDK/solver layer notes)
+
+If a rule applies to more than one driver, it belongs here.
+
+---
+
+## How to use this skill
+
+1. Read the driver skill's `SKILL.md` first to learn what solver you're
+   driving and which execution model it uses.
+2. Read the sections below of **this** skill that match that model.
+3. Follow the **Required protocol** at the bottom.
+
+There are two execution models in sim-cli — the driver skill tells you
+which one applies:
+
+| Model | Used by | Lifecycle |
+|---|---|---|
+| **Persistent session** | Drivers that keep a live process/session open | `connect → exec × N → inspect → disconnect` |
+| **One-shot batch** | Drivers that execute one script/input deck and exit | `run → parse_output → evaluate` |
+
+---
+
+## Where `sim serve` runs (Windows session-context foot-gun)
+
+If you reach a remote `sim` host via `sim --host <host>` or `SIM_HOST`,
+**how the operator started `sim serve` on that host changes which
+drivers actually work.** This is purely a Windows concern — Linux and
+macOS don't isolate display sessions the same way.
+
+| `sim serve` started from… | Headless / CLI-only drivers | GUI-capable drivers |
+|---|---|---|
+| Logged-in Windows desktop (Windows Terminal / RDP / Task Scheduler with **"run only when user is logged on" + interactive**) | ✅ works | ✅ works — windows are visible, `gui` actuation can find / click / screenshot them |
+| SSH session (`ssh win1` then `sim serve …`) | ✅ works | ❌ silent breakage — windows launch in a non-interactive Windows session with no display surface; `gui` finds zero windows; screenshots come back black; `sim exec`s that touch the GUI hang or no-op |
+
+**What this means for you, the agent:**
+
+- If the host advertises `tools: ["gui"]` on `/connect` (driver in
+  `ui_mode=gui|desktop`) but `gui.find(...)` returns nothing for
+  windows you have strong reason to believe exist, **do not retry**.
+  Surface "the server may have been started from a non-interactive
+  session" as a likely cause and ask the operator to restart `sim
+  serve` from a desktop session. See `escalation.md`.
+- For headless or one-shot batch drivers, the session context does not
+  matter — you can proceed without checking.
+- The agent never starts `sim serve` itself. Server lifecycle is the
+  operator's responsibility; this section exists only so you can
+  diagnose the specific failure mode where the server is up and
+  reachable but GUI ops silently no-op.
+
+See [`gui/SKILL.md`](gui/SKILL.md) for the full GUI actuation API and
+its window-not-found troubleshooting.
+
+---
+
+## Reference files
+
+| Path | Read when |
+|---|---|
+| [`reference/command_surface.md`](reference/command_surface.md) | Before writing any `sim …` command — canonical CLI surface, verified against source. |
+| [`reference/lifecycle.md`](reference/lifecycle.md) | For the per-step decision loop. Covers both persistent and one-shot models. |
+| [`reference/version_awareness.md`](reference/version_awareness.md) | Every session — the mandatory Step-0 version probe and how to pick the right `sdk/` / `solver/` layer inside the driver skill. |
+| [`reference/input_classification.md`](reference/input_classification.md) | Before every task — Category A (ask), B (default + disclose), C (file-derive). |
+| [`reference/acceptance.md`](reference/acceptance.md) | At the end of every task — outcome-based evaluation. `exit_code == 0` alone is **not** acceptance. |
+| [`reference/escalation.md`](reference/escalation.md) | When something goes wrong — what to stop on, what to report. Do not silently retry. |
+
+When sim-cli is one valid path but not the only path, use [`reference/tool_choice.md`](reference/tool_choice.md) to choose between live `sim ...` commands and file-side Python/vendor-SDK recipes.
+
+---
+
+## Hard constraints (apply to every sim-cli session)
+
+1. **Never invent Category A defaults.** Physical decisions (geometry,
+   materials, BCs, acceptance criteria) must come from the user. User
+   pressure to "just use defaults" does **not** override this. See
+   `reference/input_classification.md`.
+2. **Step-0 version probe is mandatory.** After `sim connect` succeeds
+   (persistent) or before `sim run` (one-shot), call
+   `sim --host <host> inspect session.versions` (or the driver's
+   documented equivalent) and use the returned `profile` /
+   `active_sdk_layer` / `active_solver_layer` to pick the right files
+   inside the driver skill. If `profile` is empty, unknown, or
+   deprecated — **stop**. See `reference/version_awareness.md`.
+3. **Acceptance ≠ exit code.** A `sim run` or `sim exec` can return
+   `ok=true` and the simulation can still be physically wrong. Always
+   validate against an outcome-based criterion from the driver skill's
+   acceptance checklist. See `reference/acceptance.md`.
+4. **Never silently retry a failed step.** Report `stderr`, `stdout`,
+   and `run_count` / completion state; let the user decide the next
+   move. See `reference/escalation.md`.
+5. **Reference example values are not defaults.** Values in any
+   `.../examples/` directory describe a specific published test case.
+   You may offer them as examples, but must wait for explicit
+   confirmation before adopting them.
+6. **Prefer uv for file-side Python helpers when available.** `sim` is
+   a CLI and can be invoked directly when installed. Do not wrap `sim`
+   in `uv run` unless you are intentionally using a source checkout or
+   project-local environment. For ordinary host/file-side Python helpers
+   used across solvers — plotting with matplotlib, CSV/JSON parsing,
+   report generation, lightweight acceptance calculations — prefer
+   `uv run python ...` or `uv run --with <pkg> python ...` when uv is
+   available because it makes dependencies explicit. If uv is unavailable
+   or the user has provided a specific Python environment, use the user's
+   environment. Vendor-embedded Python paths remain solver-specific and
+   should be run through the driver skill's documented `sim` workflow.
+
+---
+
+## Required protocol (one paragraph)
+
+Before any `sim` command: read the driver skill's `SKILL.md` and its
+"Required protocol" section. Classify inputs per
+`reference/input_classification.md`; ask the user for missing
+Category A inputs, including the acceptance criterion. Start the
+session (`sim connect` for persistent, nothing for one-shot). Run the
+Step-0 version probe (`sim inspect session.versions`) and pick the
+driver-skill subfolder that matches the returned profile. Execute per
+`reference/lifecycle.md` — incrementally for persistent sessions,
+validate-then-run for one-shot. After the final step (or the one-shot
+return), evaluate against the driver skill's acceptance checklist per
+`reference/acceptance.md`. On any failure, follow
+`reference/escalation.md` — do not silently retry.

--- a/src/sim/_skills/sim-cli/gui/SKILL.md
+++ b/src/sim/_skills/sim-cli/gui/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: gui
+description: Cross-driver GUI actuation for CAE solvers running under sim-cli. Use to click buttons, fill fields, dismiss dialogs, and capture window screenshots against GUI-capable driver windows through `sim exec`.
+type: tool
+---
+
+# `gui` — cross-driver GUI actuation
+
+Whenever the active driver runs with `ui_mode=gui` (or `desktop`),
+`sim serve` injects a **`gui`** object into your `sim exec` namespace
+alongside `session` / `solver` / `meshing` / `model`. The object is the
+same shape across solvers — only the process filter differs — so one
+skill serves every GUI-capable driver.
+
+`/connect` advertises it:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "...": "...",
+    "tools": ["gui"],
+    "tool_refs": {"gui": "sim-cli/_skills/sim-cli/gui/SKILL.md"}
+  }
+}
+```
+
+If `tools` doesn't contain `"gui"`, the driver launched headless and
+the object is absent — don't call it.
+
+## When to reach for `gui`
+
+Three scenarios dominate:
+
+1. **A blocking dialog is wedging the workflow.** A login prompt,
+   overwrite confirmation, or script-error dialog can pause agent work
+   until someone clicks a button — that someone is you, via `gui`.
+2. **You need to drive the GUI where the SDK can't.** Some workflows
+   expose a UI-only surface that the driver API does not cover.
+3. **You need a per-window screenshot.** `sim screenshot` captures the
+   whole desktop. `SimWindow.screenshot()` captures just the window you
+   care about — cheaper to read, less visual clutter for the LLM.
+
+If the SDK has a programmatic path (`session.tui.*`, `model.solve()`,
+`ModelUtil.loadCopy()`), prefer that. `gui` is for the UI-only surface
+that the SDK doesn't cover.
+
+## Remote equivalence
+
+`gui` is in the session namespace on the `sim serve` side. You talk to
+it via the existing `/exec` HTTP channel:
+
+```bash
+# local Windows box
+sim exec "dlg = gui.find('Login'); dlg.click('OK')"
+
+# Windows box on the LAN / Tailscale
+sim --host 10.0.x.y exec "dlg = gui.find('Login'); dlg.click('OK')"
+```
+
+No new endpoint, no new protocol — the same API shape from anywhere
+the agent runs.
+
+Requirement on the server host: `sim serve` must run in a **real
+interactive desktop session** (normal login or RDP). Windows
+service / SSH session 0 has no desktop, so pywinauto can't enumerate
+any windows even though the solver processes are running. This is the
+same constraint GUI-capable drivers document.
+
+## API
+
+### Discover what the controller is looking at
+
+```python
+gui.available          # True iff pywinauto can run — check before driving anything
+gui.process_filter     # tuple of process-name substrings this gui will target
+gui.list_windows()     # {ok, windows: [{hwnd, pid, proc, title, rect}, ...]}
+```
+
+### Find a window (polled until timeout)
+
+```python
+dlg = gui.find(title_contains="Login", timeout_s=5)
+# returns a SimWindow, or None on timeout
+```
+
+`title_contains` is a plain substring match (case-sensitive, any language).
+Returns `None` if nothing matched — **always check** before calling
+methods on it:
+
+```python
+dlg = gui.find("连接到")
+if dlg is None:
+    _result = {"ok": False, "error": "login dialog not visible"}
+else:
+    dlg.click("确定")
+```
+
+### Act on a window
+
+Every action returns `{ok: bool, ...}`. No exceptions unless you pass
+invalid Python types — surface `ok=False` + `error` to the agent.
+
+```python
+dlg.click("OK", timeout_s=5)             # click a button by accessible name
+dlg.send_text("alice", into="Username")  # type into a named Edit field
+dlg.send_text("/tmp/out.cas.h5")         # without `into` → first editable
+dlg.close()                              # WM_CLOSE (Alt+F4 equivalent)
+dlg.activate()                           # bring to foreground
+dlg.screenshot(label="after_login")      # window-only PNG under workdir
+```
+
+Each action method tries the most natural pywinauto strategy first
+(`button_by_title`) and falls back to a broader match
+(`any_control_by_title`) before giving up — the response tells you
+which path worked via the `strategy` field.
+
+### Full UIA dump
+
+Expensive but sometimes necessary for reasoning about an unfamiliar GUI:
+
+```python
+state = gui.snapshot(max_depth=3)
+# {ok, windows: [{hwnd, pid, proc, title,
+#                  controls: [{name, control_type, handle, children?}, ...]}]}
+```
+
+Use this when `find(title)` misses and you need to see what the GUI
+actually exposes.
+
+### Handle metadata
+
+`SimWindow` fields you can read without another round-trip:
+
+```python
+dlg.hwnd     # int
+dlg.pid      # int
+dlg.proc     # str, process name
+dlg.title    # current window title
+dlg.as_dict() # {hwnd, pid, proc, title, rect}
+```
+
+## Typical patterns
+
+### Pattern 1 — dismiss a blocking login dialog
+
+```python
+dlg = gui.find(title_contains="Login", timeout_s=5)
+if dlg:
+    dlg.send_text("alice", into="Username")
+    dlg.send_text("secret", into="Password")
+    dlg.click("OK")
+_result = {"dismissed": dlg is not None}
+```
+
+### Pattern 2 — confirm a "file exists, overwrite?" dialog
+
+```python
+dlg = gui.find(title_contains="Question", timeout_s=3)
+if dlg is None:
+    dlg = gui.find(title_contains="overwrite", timeout_s=3)  # other
+if dlg:
+    dlg.click("OK")
+_result = {"confirmed": dlg is not None, "title": dlg.title if dlg else None}
+```
+
+### Pattern 3 — walk the solver UI tree to find an unexpected control
+
+```python
+state = gui.snapshot(max_depth=4)
+names = []
+def walk(items):
+    for c in items:
+        if c.get("name"):
+            names.append((c["control_type"], c["name"]))
+        walk(c.get("children") or [])
+for w in state["windows"]:
+    walk(w.get("controls") or [])
+_result = {"control_names": names[:50]}
+```
+
+### Pattern 4 — capture only the solver window for the agent to read
+
+```python
+dlg = gui.find(title_contains="Main", timeout_s=3)
+if dlg:
+    shot = dlg.screenshot(label="after_solve")
+    _result = shot  # contains {ok, path, width, height}
+else:
+    _result = {"ok": False, "error": "main window not found"}
+```
+
+## Error handling
+
+Every call returns a dict; failures look like
+`{"ok": False, "error": "connect(handle=...) failed: ..."}`. The UIA
+machinery runs in an isolated subprocess so a COM glitch in one call
+never poisons the next.
+
+Things that commonly make `ok` false:
+
+| Symptom | Likely cause | What to do |
+|---|---|---|
+| `find` returns `None` | title didn't match / process filter too strict | print `gui.list_windows()` to see what is live |
+| `click` says `no control titled ... in hwnd=...` | the button label in the UI is not what you think | snapshot the window, read `controls[*].name` |
+| `screenshot` returns minimal PNG | window is minimized (pywinauto captures the window rect; min'd windows live at `(-32000, -32000, …)`) | `dlg.activate()` first, then screenshot |
+| `gui.available` is `False` | off-Windows host, or pywinauto not installed | don't use `gui` — fall back to SDK-only path |
+| `list_windows()` returns `[]` even though the solver clearly launched | `sim serve` was started from an SSH / non-interactive Windows session — the GUI exists in a session with no display surface and pywinauto can't see it | ask the operator to restart `sim serve` from a desktop session (RDP, Windows Terminal, or Task Scheduler with **"run only when user is logged on" + interactive**). See [`../SKILL.md` → "Where `sim serve` runs"](../SKILL.md). Do **not** retry. |
+| `screenshot` returns a uniformly black PNG | same as above — non-interactive session has no compositor | same fix |
+
+## Pitfalls
+
+- **Don't guess button labels.** Windows localisation is real. Use
+  `gui.snapshot()` to confirm the actual accessible name before calling
+  `click(name)`.
+- **Don't assume single window.** Some solvers open extra floating
+  panels. `find(title)` returns the first match; if the workflow is
+  ambiguous, use `list_windows()` and pick by `pid`.
+- **Don't rely on `gui` for SDK-shaped work.** Solver objects (`session`,
+  `model`) are always faster and more reliable than UI clicks. `gui` is
+  the fallback for the UI-only surface.
+- **Remote servers need a real desktop.** If `sim serve` runs from an
+  SSH session, a Windows service, or any non-interactive context, the
+  spawned solver process inherits a session with no display surface.
+  pywinauto then finds zero windows, screenshots come back uniformly
+  black, and `find(...)` silently times out — the server itself is up
+  and reachable, only the GUI half is dead. Restart `sim serve` from a
+  desktop session (Windows Terminal on the console, RDP, or Task
+  Scheduler with "run only when user is logged on" + interactive). See
+  [`../SKILL.md` → "Where `sim serve` runs"](../SKILL.md) for the full
+  driver-by-driver matrix.
+
+## Related skills
+
+- Plugin-specific skills list the dialogs that a given driver is known
+  to pop. Check those for recipes before inventing your own.
+- `sim.inspect` probes (issue #8a `window_observed`, #8b screenshots)
+  tell you **what is on screen** — read them first, then reach for
+  `gui` to act.

--- a/src/sim/_skills/sim-cli/gui/snippets/dismiss_named_dialog.py
+++ b/src/sim/_skills/sim-cli/gui/snippets/dismiss_named_dialog.py
@@ -1,0 +1,19 @@
+"""Dismiss a blocking dialog by title and button text.
+
+Paste into ``sim exec`` when the plugin-specific skill identifies a
+known modal dialog. Keep solver-specific titles in the plugin skill;
+this shared snippet only shows the generic control flow.
+"""
+
+# ruff: noqa: F821
+# This snippet is executed inside `sim exec`, where the runtime injects `gui`.
+
+title = "Dialog title substring"
+button = "OK"
+
+dlg = gui.find(title_contains=title, timeout_s=5)
+if dlg is None:
+    _result = {"ok": False, "dismissed": False, "error": "dialog not visible"}
+else:
+    click = dlg.click(button, timeout_s=5)
+    _result = {"ok": bool(click.get("ok")), "dismissed": bool(click.get("ok")), "click": click}

--- a/src/sim/_skills/sim-cli/reference/acceptance.md
+++ b/src/sim/_skills/sim-cli/reference/acceptance.md
@@ -1,0 +1,90 @@
+# Acceptance semantics
+
+Across every sim-cli driver: **`exit_code == 0` alone does not satisfy
+acceptance.** A simulation can return `ok=true` and still be physically
+wrong — diverged but quietly, converged to the wrong basin, ran the
+correct model with the wrong BCs, hit the iteration cap before
+residuals dropped.
+
+Acceptance is always outcome-based.
+
+---
+
+## The distinction
+
+> "The script ran without error" ≠ task complete.
+> "The acceptance checklist is satisfied" = task complete.
+
+Exit code and `ok=true` are *preconditions*, not *acceptance*. If exit
+code is non-zero, acceptance cannot possibly be met; if it is zero,
+acceptance still has to be checked.
+
+---
+
+## What counts as an acceptance criterion
+
+A good criterion is **outcome-based**, **bounded**, and **measurable**:
+
+- Outcome: describes the physical result, not the operation
+  (✅ "outlet temperature in 28–35 °C"; ❌ "the solver ran for 150 iterations")
+- Bounded: has an explicit tolerance or range, not just a target
+- Measurable: extractable from the solver via `sim inspect last.result`
+  (persistent) or `parse_output(stdout)` (one-shot)
+
+Examples by physics:
+
+| Domain | Good criterion |
+|---|---|
+| Thermal | Max junction T < 85 °C; peak T within ±2 K of reference |
+| CFD / flow | Outlet mass-flow balance within 1 % of inlet; all RMS residuals < 1e-4 |
+| Structural | Tip displacement within 5 % of analytical / reference |
+| Meshing | Min orthogonal quality > 0.2; max aspect ratio < 50 |
+| Battery | End-of-discharge voltage within 10 mV of reference |
+| Optimization | Pareto front has ≥ N non-dominated points at generation G |
+
+---
+
+## Where criteria live
+
+Each driver skill ships an `acceptance_checklists.md` (or equivalent
+per-workflow README) under `base/reference/` or `base/workflows/`.
+Those define the canonical criteria for each packaged workflow.
+
+For **user-supplied tasks** (not a packaged workflow), the acceptance
+criterion is a **Category A input** — ask the user for it. See
+[`input_classification.md`](input_classification.md).
+
+Acceptable shapes of a user answer:
+
+- "Max junction temp must be under 85 °C." ← outcome-based ✅
+- "Outlet mass flow within 1 % of inlet." ← outcome-based ✅
+- "Just run it." ← operation-based, **treat as missing Category A** ❌
+- "Let me know when it's done." ← operation-based, ❌
+
+---
+
+## Evaluation loop
+
+After the final step (persistent) or the single `sim run` return
+(one-shot):
+
+1. Verify preconditions: exit_code == 0, `ok=true`, `stderr` free of
+   ERROR lines.
+2. Extract the numeric value(s) the criterion needs — via
+   `sim inspect last.result` or `parse_output(stdout)`.
+   The acceptance check itself can be a python computation against output
+   files, a sim inspect query against the live session, or a vendor-script
+   invoked via sim run — pick whichever is closest to where the data lives.
+3. Compare against the criterion. Record the comparison explicitly in
+   the final report: "`T_max = 82.3 °C` — criterion `< 85 °C` ✅".
+4. If any criterion fails — task is **INCOMPLETE**. Report which
+   criterion failed, the extracted value, and the gap.
+
+---
+
+## Acceptance vs escalation
+
+This file covers the "happy path" final check. If a step *fails
+outright* (non-zero exit, `ok=false`, exception in stderr), see
+[`escalation.md`](escalation.md) — that is not an acceptance failure,
+it is an execution failure, and it has its own reporting protocol.

--- a/src/sim/_skills/sim-cli/reference/command_surface.md
+++ b/src/sim/_skills/sim-cli/reference/command_surface.md
@@ -1,0 +1,124 @@
+# sim-cli command surface
+
+This is the canonical reference for `sim …` subcommands. Verified
+against `sim-cli/src/sim/cli.py`. If a driver skill or downstream doc
+disagrees, this file wins — fix the downstream doc.
+
+---
+
+## Global options (all commands)
+
+```
+sim [--host HOST] [--port PORT] [--json] <command> …
+```
+
+- `--host` — defaults to `localhost`. Use for remote `sim serve`
+  instances (e.g. a Windows box over Tailscale).
+- `--port` — defaults to `8765`.
+- `--json` — machine-readable output. Prefer when parsing in snippets;
+  human output is for terminals.
+
+---
+
+## One-shot execution
+
+### `sim run <script> --solver <solver>`
+
+Executes a script in a subprocess and exits. No persistent session. The
+driver's `parse_output(stdout)` extracts the JSON payload, which is
+returned on the `parsed_output` field in `--json` mode.
+
+```bash
+sim run analysis.py --solver example
+sim run job.in     --solver example_batch
+```
+
+**Exit code**: 0 if the driver reports `ok=true`, non-zero otherwise.
+**Use for**: drivers that have no persistent-session model.
+
+---
+
+## Persistent session
+
+### `sim serve [--host HOST] [--port PORT] [--reload]`
+
+Starts the HTTP server. Usually launched once per host; `sim connect`
+on a local host auto-starts a server if none is running. Run manually
+for remote boxes.
+
+### `sim connect --solver <solver> [--mode MODE] [--ui-mode UI] [--processors N] [--workspace PATH] [--driver-option KEY=VALUE]...`
+
+Launches the solver inside the server and holds a session open.
+Core launch flags:
+
+| Flag | Drivers that use it |
+|---|---|
+| `--mode <mode>` | drivers with multiple runtime modes |
+| `--ui-mode gui \| no_gui` | GUI-capable drivers |
+| `--processors N` | any MPI-capable solver |
+| `--workspace PATH` | drivers with a run/work directory concept |
+| `--driver-option KEY=VALUE` | generic plugin-owned launch option passthrough; repeat as needed |
+
+`--driver-option` is intentionally opaque to sim-cli. The driver skill
+documents which keys its driver accepts, what the defaults mean, and how
+the plugin validates or translates them. Keep solver-specific launch
+settings here instead of inventing new top-level sim-cli flags.
+
+### `sim exec [<code>] [--file PATH] [--label LABEL]`
+
+Runs a snippet inside the live session. Pass code as a positional arg,
+or read from a file with `--file`. `--label` is free-text; it shows up
+in `session.summary.run_count` and log files — use descriptive labels
+like `import-geometry`, `hybrid-init`.
+
+```bash
+sim exec --file 03_setup_physics.py --label setup-physics
+sim exec "model.mesh.check()"       --label mesh-check
+```
+
+**Exit code**: 0 if the snippet's `ok=true`, `2` on `ok=false`.
+
+### `sim inspect <target>`
+
+Queries live session state. Common targets across all drivers:
+
+| Target | Returns |
+|---|---|
+| `session.summary` | `connected`, `mode`, `run_count` |
+| `session.versions` | `sdk`, `solver`, `profile`, `active_sdk_layer`, `active_solver_layer`, `env_path` — **use at Step 0** |
+| `session.mode` | Current session mode (driver-dependent) |
+| `last.result` | `ok`, `label`, `result`, `stdout`, `stderr` from the most recent `exec` |
+| `workflow.summary` | Workflow task states, when exposed by a driver |
+| `field.catalog` | Available fields for post-processing, when exposed by a driver |
+
+Driver-specific targets are documented in each driver skill's SKILL.md
+and may include additional namespaces.
+
+### `sim disconnect [--stop-server]`
+
+Tears down the solver session. By default the server keeps running so
+subsequent `connect` calls are instant. `--stop-server` also kills the
+server (equivalent to `sim stop` afterwards).
+
+---
+
+## Housekeeping
+
+| Command | Purpose |
+|---|---|
+| `sim ps` | List active sessions on the server |
+| `sim stop` | Stop the running server |
+| `sim check <solver>` | On-demand driver detection without holding a session |
+
+---
+
+## Common drift to avoid
+
+These are mistakes found in existing driver skills — do not repeat:
+
+- `sim query …` → it is **`sim inspect …`**. `query` was the old name;
+  the current CLI does not expose `query` as a subcommand.
+- `sim exec --code-file PATH` → it is **`sim exec --file PATH`**. There
+  is no `--code-file` flag.
+- `sim run … --solver <name>` **cannot take `--mode`**. Mode is a
+  persistent-session concept (`sim connect --mode …`).

--- a/src/sim/_skills/sim-cli/reference/escalation.md
+++ b/src/sim/_skills/sim-cli/reference/escalation.md
@@ -1,0 +1,91 @@
+# Escalation — when to stop and report
+
+Across all sim-cli drivers: **do not silently retry failed steps.**
+Agents that burn through 50 retries leave the user with unusable session
+state and no diagnostic signal. Stop early, report cleanly, let the
+user decide.
+
+---
+
+## Stop-and-report triggers
+
+Stop on any of these. Do not attempt automated recovery.
+
+| Trigger | Signal |
+|---|---|
+| Driver unavailable | `sim connect` / `sim run` exits non-zero with "no driver for `<solver>`" or "solver not installed" |
+| Runtime profile empty / unknown / deprecated | `sim inspect session.versions` returns `profile: null` or a value not in the driver's `compatibility.yaml` (see [`version_awareness.md`](version_awareness.md)) |
+| Step failed (persistent) | `sim exec` non-zero exit, or `sim inspect last.result` returns `ok=false`, or `stderr` contains an exception |
+| Step failed (one-shot) | `sim run` non-zero exit, or `stderr` contains ERROR lines, or `parse_output(stdout)` returns `{}` when a payload was expected |
+| Session state inconsistent | `sim inspect session.summary` shows unexpected `run_count` or `mode` after a step |
+| Acceptance failed | After all steps succeeded, an acceptance criterion was not met — see [`acceptance.md`](acceptance.md) |
+
+---
+
+## What to report
+
+Always include, in a structured summary:
+
+1. **What was attempted** — solver, workflow, the failing step's label.
+2. **The error signal** — exit code, first ~20 lines of `stderr`,
+   exception class and message if present.
+3. **Completion state** — how many steps succeeded before the failure
+   (`session.summary.run_count` for persistent; "reached step N of M"
+   for one-shot).
+4. **Session liveness** — for persistent sessions, whether the session
+   is still alive (`sim inspect session.summary → connected`). If it
+   is, the user can inspect it manually before you disconnect.
+5. **What would need to change to try again** — a missing input, a
+   different mode, an incompatible SDK version, a corrupted file.
+
+Format example (persistent):
+
+```
+[sim] FAILED at step 4/8 (label="setup-material")
+  error: AttributeError: settings object has no attribute 'general'
+  session: connected=true, mode=solver, run_count=3
+  stdout (last 5 lines): …
+  stderr (last 5 lines): …
+
+Likely cause: snippet/API dialect does not match the active runtime.
+The active_sdk_layer returned by Step-0 was "sdk-1.1"
+but the snippet is from a newer SDK layer.
+To proceed: either swap to a matching snippet layer, or update the
+runtime environment.
+```
+
+Format example (one-shot):
+
+```
+[sim] FAILED (exit=2) during sim run analysis.py --solver example
+  stderr: Undefined function 'solve_case' for input arguments of type 'double'.
+  stdout: (empty)
+
+Likely cause: a required helper is not on the runtime path.
+To proceed: either add the package containing that helper to the
+environment, or supply a self-contained script.
+```
+
+---
+
+## What *not* to do
+
+- ❌ Silently retry with different parameters ("maybe it'll work this
+  time").
+- ❌ Disconnect the session before the user has had a chance to inspect
+  it — if it is still alive, leave it alive.
+- ❌ Edit the user's input files to "fix" the error. If inputs are
+  wrong, ask the user.
+- ❌ Swap to a different solver because the current one failed. The
+  user picked this solver; respect that.
+- ❌ Claim success because "the exit code was 0" when an acceptance
+  criterion was not met. See [`acceptance.md`](acceptance.md).
+
+---
+
+## Automated recovery is out of scope
+
+v0 sim-cli skills do **not** attempt automated error recovery. Recovery
+strategies (retry with different `--processors`, fall back to a simpler
+mesh, switch execution surfaces, …) are a v1
+concern and require explicit user opt-in.

--- a/src/sim/_skills/sim-cli/reference/input_classification.md
+++ b/src/sim/_skills/sim-cli/reference/input_classification.md
@@ -1,0 +1,100 @@
+# Input classification
+
+Every sim-cli task starts with the same question: **which inputs must
+the user supply, which may I default, and which can I derive from the
+files in front of me?** The answer is the same three-bucket rule across
+every driver.
+
+---
+
+## Category A — Physical decision inputs
+
+**Must ask the user if absent. Non-negotiable.**
+
+These define *what the simulation physically represents*:
+
+- Geometry parameters (dimensions, feature sizes, orientations)
+- Materials and material properties
+- Boundary conditions (inlet velocities, heat loads, wall temperatures, …)
+- Initial conditions
+- Physics model choices (laminar vs turbulent, steady vs transient, …)
+- **Acceptance criterion** — the outcome-based check that decides
+  whether the task is complete (see [`acceptance.md`](acceptance.md))
+
+User pressure to "just use defaults" does **not** override this. Phrases
+like "just run it" / "跑完就好" / "use whatever makes sense" describe an
+operation, not an outcome — treat them as a missing Category A input and
+ask.
+
+Values lifted from a reference example (`sdk/*/examples/`, workflow
+READMEs, tutorial scripts) are **not defaults** — they describe a
+specific published test case. You may offer them explicitly ("the
+mixing_elbow example uses 0.4 m/s inlet — would you like to use those
+values?") but you must wait for the user's confirmation before
+adopting them.
+
+---
+
+## Category B — Operational inputs
+
+**May default. Must disclose.**
+
+These affect runtime / performance / convenience only, not what the
+simulation physically represents:
+
+- `--processors N` (parallelism)
+- `--ui-mode gui | no_gui`
+- `--mode meshing | solver` when only one makes sense for the task
+- `--workspace PATH` (run directory / artifact location)
+- `--driver-option KEY=VALUE` when the driver skill classifies the key
+  as operational rather than physical
+- Smoke-test iteration counts (e.g. "run 10 iters to check setup")
+- Output verbosity, log locations
+
+Defaults are fine, but surface them. A line like "Using 4 processors
+and headless UI — reply if you want different" is enough.
+
+---
+
+## Category C — File-derivable inputs
+
+**Infer from the actual files. Confirm if critical.**
+
+These are facts about the user's input files that the solver itself can
+tell you if you ask:
+
+- Mesh cell count, face zones, cell zones
+- Variables / fields present in a `.cas` / `.dat` / `.vtu`
+- Boundary names and types from a mesh file
+- Material IDs from an `.inp` deck
+- Element types, node counts
+
+**Rule**: derive these via a diagnostic snippet (`sim exec` with a tiny
+`dir()` / inspect call), **not** from a reference example of a similar
+case. A reference example describes its own files, not the user's.
+
+For anything downstream decisions depend on (e.g. naming a boundary as
+`inlet_cold` vs `inlet_hot`), confirm with the user before proceeding.
+
+---
+
+## Worked example
+
+> User: "Here's my mesh file `flipchip.msh`. Run a steady thermal
+> analysis."
+
+Classification:
+
+| Field | Category | Action |
+|---|---|---|
+| Ambient temperature | A | **Ask** — physical decision |
+| Chip heat load | A | **Ask** — physical decision |
+| Solver mode (steady) | A | User stated it |
+| Acceptance criterion | A | **Ask** — "what outcome would make this run successful? e.g. max junction temp < 85 °C" |
+| Number of processors | B | Default to 4, disclose |
+| UI mode | B | Default to headless, disclose |
+| Cell count, boundary names | C | Inspect via a diagnostic `sim exec` snippet |
+| Material properties | A | **Ask** — did not come with the mesh |
+
+Do not start the analysis until every Category A field has an explicit
+value from the user.

--- a/src/sim/_skills/sim-cli/reference/lifecycle.md
+++ b/src/sim/_skills/sim-cli/reference/lifecycle.md
@@ -1,0 +1,159 @@
+# Lifecycle control patterns
+
+These are **control patterns** — agent decision logic, not code
+templates. They cover the two sim-cli execution models; the driver
+skill tells you which one applies.
+
+---
+
+# Part A — Persistent session (connect / exec / inspect / disconnect)
+
+Used by any driver that holds a live process/session open.
+
+## Pattern 0 — Session lifecycle
+
+```
+CONNECT → STEP-0 VERSION PROBE → [STEP × N] → DISCONNECT
+```
+
+- One session per task. Do not reuse a session across unrelated tasks.
+- Connect with the correct core launch flags (`mode`, `ui-mode`,
+  `processors`, `workspace`) and any plugin-owned `--driver-option`
+  values documented by the driver skill. Mode cannot change mid-session.
+- Always disconnect explicitly, even if steps failed.
+
+## Pattern 1 — Connect + verify
+
+**When**: at the start of every task.
+
+1. Run `sim connect --solver <solver> [core launch flags] [--driver-option KEY=VALUE]...`.
+2. Check exit code = 0.
+3. Run `sim inspect session.summary`. Verify `connected=true`,
+   `mode=<expected>`, `run_count=0`.
+4. Run `sim inspect session.versions` → see
+   [`version_awareness.md`](version_awareness.md). Use the returned
+   `profile` / `active_sdk_layer` / `active_solver_layer` to pick the
+   right subfolder inside the driver skill.
+
+If verification fails: stop, report to the user. Do not proceed.
+
+## Pattern 2 — Step execution loop
+
+**When**: for each workflow step.
+
+```
+write code → sim exec --file <tmp> --label <label>
+         ↓
+     exit code?
+       0 → sim inspect last.result → ok=true? → continue
+                                   → ok=false? → STOP, report
+       ≠0 → STOP, report
+```
+
+Each step is a checkpoint. The loop does not advance until the current
+step is confirmed successful. Labels appear in `session.summary` and
+log files — they are the audit trail. Use descriptive labels
+(`import-geometry`, `surface-mesh`, `hybrid-init`) not generic ones
+(`step1`, `run`).
+
+## Pattern 3 — State query
+
+**When**: after any step that changes session state, or when verifying
+a precondition for the next step.
+
+See [`command_surface.md`](command_surface.md) for the full list of
+`sim inspect` targets. Do not skip inspects between steps that depend
+on each other — e.g. do not send a volume-mesh step before confirming
+surface-mesh succeeded.
+
+## Pattern 6 — Disconnect + report
+
+**When**: at the end of every task (success or failure).
+
+1. Run `sim disconnect`.
+2. Report:
+   - Solver and mode.
+   - Steps completed (labels and final `run_count`).
+   - Key extracted values (cell count, residuals, integral quantities, …).
+   - Whether the driver skill's acceptance checklist was satisfied.
+   - Any warnings or non-fatal issues observed in stdout.
+
+Format: structured summary, not a narrative. Values should be explicit.
+
+---
+
+# Part B — One-shot batch (run / parse / evaluate)
+
+Used by drivers that execute one input/script and exit.
+
+## Pattern 0 — Execution model
+
+```
+VALIDATE → RUN → EVALUATE → REPORT
+```
+
+There is no live session. The entire solve is one blocking `sim run …`
+call. All agent decisions happen **before** the call (input validation,
+acceptance-criterion confirmation) and **after** (output parsing,
+acceptance evaluation).
+
+## Pattern 1 — Validate before running
+
+**When**: before every `sim run` call.
+
+1. Classify inputs per
+   [`input_classification.md`](input_classification.md) and ask for any
+   missing Category A inputs — especially the acceptance criterion.
+2. Optionally call the driver's lint/check hook if the driver skill
+   documents one.
+3. Confirm the input files exist and are readable.
+
+If any check fails: stop. Report the specific failure. Do not call
+`sim run`.
+
+## Pattern 2 — Run and capture
+
+```bash
+sim run <script_or_deck> --solver <solver>
+# exit code, stdout, stderr, parsed_output returned on the result object
+```
+
+This call blocks until the solver exits. It may take seconds to hours.
+Do not assume a timeout — the solver manages its own execution, and a
+parent timeout that kills a long solve mid-run can leave an inconsistent
+workdir.
+
+## Pattern 3 — Evaluate output
+
+**When**: after `sim run` returns.
+
+```
+exit_code?
+  0  → check stderr for ERROR lines → check stdout non-empty → parse_output()
+                                                             → evaluate vs acceptance
+  ≠0 → STOP. Report exit_code + stderr. Task incomplete.
+```
+
+Structured data extraction uses the driver's `parse_output()` hook,
+which returns the last JSON object found in stdout (or `{}` if none).
+The driver skill tells you what fields to expect.
+
+## Pattern 4 — Report
+
+Same as Part A's Pattern 6, minus the `disconnect` step.
+
+---
+
+# Part C — Shared across both models
+
+## Acceptance evaluation
+
+See [`acceptance.md`](acceptance.md). Exit code and `ok=true` are
+necessary but not sufficient. Always evaluate against an outcome-based
+criterion from the driver skill's acceptance checklist.
+
+## Failure handling
+
+See [`escalation.md`](escalation.md). Never silently retry. When a step
+fails, capture `stderr`, `stdout`, and the completion state; report to
+the user; let them decide the next move.

--- a/src/sim/_skills/sim-cli/reference/tool_choice.md
+++ b/src/sim/_skills/sim-cli/reference/tool_choice.md
@@ -1,0 +1,35 @@
+# Tool choice
+
+sim-cli is the right tool when the task needs a live solver session, vendor-only Python inside the solver, GUI actuation, runtime version probing, or Windows-friendly streaming diagnostics. For post-mortem artifact reads and small acceptance computations, prefer the file-side Python path when it is closer to the data.
+
+Keep both paths visible when both are valid. Pick the one that matches the state the user actually has.
+
+## Example 1: read an Abaqus `.sta` after a job
+
+| Mode | Pick when | Recipe |
+|---|---|---|
+| Live | The solve is in progress or an Abaqus session is already open. | `sim inspect job.diagnostics` |
+| Post-mortem | The job finished and `job.sta` is on disk. | Prefer `uv run python -c "from pathlib import Path; print(Path('job.sta').read_text(errors='replace'))"` when uv is available; otherwise use the user's Python environment. |
+
+## Example 2: read a Mechanical `.rst`
+
+| Mode | Pick when | Recipe |
+|---|---|---|
+| Live | Mechanical is open and you need to add/evaluate result objects in the Solution tree. | `sim exec` with IronPython, for example `sol.Children[0].Maximum.Value` |
+| Post-mortem | The solve already finished and you only need result data from the file. | Use `ansys-dpf-core` in normal CPython against the downloaded `.rst`. |
+
+```python
+from ansys.dpf import core as dpf
+
+ds = dpf.DataSources("file.rst")
+model = dpf.Model(ds)
+disp = model.results.displacement().eval()
+stress = model.results.stress().eval()
+```
+
+## Example 3: introspect a saved COMSOL `.mph`
+
+| Mode | Pick when | Recipe |
+|---|---|---|
+| Live | The model needs to be mutated, solved, or compared against the live JPype session. | `sim inspect comsol.model.describe_text` |
+| Post-mortem | The question is about a saved `.mph`: parameters, physics tags, solved/unsolved state, mesh size. | `from sim_plugin_comsol.lib import inspect_mph; inspect_mph(path)` |

--- a/src/sim/_skills/sim-cli/reference/version_awareness.md
+++ b/src/sim/_skills/sim-cli/reference/version_awareness.md
@@ -1,0 +1,99 @@
+# Version awareness — the Step-0 probe
+
+**Mandatory.** The first thing every task does after the session starts
+is probe the runtime version and use the result to pick the right
+subfolder inside the driver skill.
+
+---
+
+## Why this exists
+
+A snippet written for one SDK or solver release can silently fail on
+another release, or worse, appear to run while using the wrong API
+surface. Without an explicit version check, the agent has to guess from
+package versions and local paths — exactly the failure mode this probe
+eliminates.
+
+---
+
+## The probe
+
+After `sim connect` succeeds (persistent) — or at the start of a
+one-shot task, against a short-lived session:
+
+```bash
+sim --host <host> inspect session.versions
+```
+
+Returns:
+
+```json
+{
+  "sdk":                 {"name": "example-sdk", "version": "1.2.3"},
+  "solver":              {"name": "example",     "version": "4.5"},
+  "profile":             "example_sdk_1_2",
+  "active_sdk_layer":    "sdk-1.2",
+  "active_solver_layer": "solver-4.5",
+  "env_path":            "/.../.sim/envs/example-sdk-1-2"
+}
+```
+
+---
+
+## How to use the result
+
+The driver skill's `SKILL.md` tells you it has a layered folder
+structure:
+
+```
+<driver>/
+  base/                ← always relevant
+  sdk/<slug>/          ← SDK-specific deltas (empty for SDK-less drivers)
+  solver/<slug>/       ← solver-release deltas
+```
+
+Use the probe's fields to pick the right `<slug>`:
+
+- **`base/`** — always load.
+- **`sdk/<active_sdk_layer>/`** — load if set.
+- **`solver/<active_solver_layer>/`** — load if set.
+
+Later layers override earlier ones on identically-named files.
+
+Example:
+
+```
+active_sdk_layer = "sdk-1.2"     → read sdk/sdk-1.2/
+active_solver_layer = "solver-4.5" → read solver/solver-4.5/
+```
+
+If a driver skill has snippets in both `base/snippets/` and
+`sdk/<slug>/snippets/`, prefer the SDK-layer snippet when it exists for
+the same task — it was written against the exact API surface you're
+connected to.
+
+---
+
+## Failure modes — stop and surface
+
+Do **not** proceed silently if any of these hold:
+
+- `profile` is empty or missing.
+- `profile` is not listed in the driver's `compatibility.yaml`.
+- `profile` is marked `deprecated` in the driver's `compatibility.yaml`.
+- `active_sdk_layer` points to a directory that does not exist in the
+  driver skill.
+
+**Action**: stop, print the full `session.versions` payload, ask the
+user how to proceed (upgrade, downgrade, skip).
+
+Full contract: [`sim-cli/docs/architecture/version-compat.md`](https://github.com/svd-ai-lab/sim-cli/blob/main/docs/architecture/version-compat.md).
+
+---
+
+## Notes for SDK-less drivers
+
+Some drivers have no Python SDK and drive tools through batch
+executables or other local interfaces. For these, `active_sdk_layer` is
+typically `null` and only `active_solver_layer` matters. The probe shape
+is the same; just ignore the null fields.

--- a/src/sim/cli.py
+++ b/src/sim/cli.py
@@ -177,9 +177,9 @@ def _render_check(data: dict) -> None:
         click.echo(f"      source:  {inst['source']}")
         simulink = inst.get("extra", {}).get("simulink_installed")
         if simulink is True:
-            click.echo(f"      simulink: installed")
+            click.echo("      simulink: installed")
         elif simulink is False:
-            click.echo(f"      simulink: not found on disk")
+            click.echo("      simulink: not found on disk")
         if profile is None:
             if compat is None:
                 click.echo("      profile: (driver has no compatibility.yaml yet)")
@@ -341,8 +341,9 @@ def lint(ctx, script):
                 level="error",
                 message=(
                     f"No registered driver claims {script_path.name!r}. "
-                    "Install the matching plugin (e.g. `sim plugin install sim-plugin-<solver>`) "
-                    "or pass `sim run` if you want to attempt execution anyway."
+                    "Add the matching plugin package to this uv project, e.g. "
+                    "`uv add sim-cli-core sim-plugin-<solver>`, then run "
+                    "`uv run sim check <solver>`."
                 ),
             )],
         )
@@ -921,19 +922,16 @@ def init(ctx, force):
 @click.option("--config", "config_path", type=click.Path(exists=True, dir_okay=False, path_type=Path),
               default=None, help="Override the sim.toml location.")
 @click.option("--offline", is_flag=True,
-              help="Accepted for compatibility; plugin install no longer uses an index.")
+              help="Accepted for compatibility; setup no longer installs plugin packages.")
 @click.option("--dry-run", is_flag=True,
-              help="Print what would happen without installing anything.")
+              help="Print declared plugin package specs without changing anything.")
 @click.pass_context
 def setup(ctx, config_path, offline, dry_run):
-    """Read sim.toml and install / verify everything it declares.
+    """Read sim.toml and report the plugin packages it declares.
 
-    Idempotent: re-running after a successful setup is a no-op modulo plugin
-    upgrades. Designed to be the *one* command an agent runs to bring a
-    fresh checkout into a runnable state.
+    Package installation belongs to uv. This command validates sim.toml and
+    shows the uv-addable package specs agents should use.
     """
-    from sim._plugin_install import install_plugin
-
     path = config_path or _cfg.project_sim_toml_path()
     errors = _cfg.validate_sim_toml(path) if path.is_file() else ["sim.toml not found"]
     if errors:
@@ -945,7 +943,6 @@ def setup(ctx, config_path, offline, dry_run):
                    err=not ctx.obj["json"])
         sys.exit(2)
 
-    import sys as _sys
     if sys.version_info >= (3, 11):
         import tomllib as _tomllib
     else:
@@ -954,25 +951,19 @@ def setup(ctx, config_path, offline, dry_run):
 
     plugins = (data.get("sim") or {}).get("plugins") or []
     actions: list[dict] = []
-    fail = False
+    _ = offline
 
     for entry in plugins:
         source = _cfg.derive_install_source(entry)
-        if dry_run:
-            actions.append({"name": entry.get("name"), "source": source, "action": "would-install"})
-            continue
-        report = install_plugin(source, offline=offline)
         actions.append({
             "name": entry.get("name"),
             "source": source,
-            "ok": report.ok,
-            "message": report.message,
+            "action": "declared",
+            "install": f"uv add sim-cli-core {source}",
         })
-        if not report.ok:
-            fail = True
 
     summary = {
-        "ok": not fail,
+        "ok": True,
         "path": str(path),
         "dry_run": dry_run,
         "plugins": actions,
@@ -980,14 +971,12 @@ def setup(ctx, config_path, offline, dry_run):
     if ctx.obj["json"]:
         click.echo(json_mod.dumps(summary, indent=2))
     else:
-        verb = "would install" if dry_run else "installed"
-        click.echo(f"[sim] setup: {verb} {len(actions)} plugin(s) from {path}")
+        click.echo(f"[sim] setup: {len(actions)} plugin declaration(s) in {path}")
+        click.echo("[sim] setup: package installation is handled by uv")
         for a in actions:
-            mark = "OK" if a.get("ok", True) else "FAIL"
-            click.echo(f"  [{mark}] {a['name']} ← {a['source']}")
-            if a.get("message") and not a.get("ok", True):
-                click.echo(f"        {a['message']}")
-    sys.exit(0 if not fail else 4)
+            click.echo(f"  - {a['name']} ← {a['source']}")
+            click.echo(f"    {a['install']}")
+    sys.exit(0)
 
 
 # ── plugin (manage installed sim plugins) ────────────────────────────────────
@@ -995,11 +984,10 @@ def setup(ctx, config_path, offline, dry_run):
 
 @main.group()
 def plugin():
-    """Manage installed sim plugins (drivers + bundled skills).
+    """Inspect installed sim plugins and sync bundled skills.
 
-    Plugins extend sim with additional solvers. Each plugin ships its
-    driver + skill in one wheel; see docs/plugin-install.md for the install
-    flows (package spec, direct URL, local wheel, git URL, etc.).
+    Plugins extend sim with additional solvers. Add plugin packages with uv;
+    use this group to inspect registered drivers, run doctor, and sync skills.
     """
 
 
@@ -1081,7 +1069,7 @@ def plugin_info_cmd(ctx, name):
         click.echo(f"  profiles:      {', '.join(p.name for p in compat.profiles)}")
 
 
-@plugin.command("install")
+@plugin.command("install", hidden=True)
 @click.argument("source")
 @click.option("-e", "--editable", is_flag=True,
               help="Editable install (pip install -e). For plugin authors.")
@@ -1091,7 +1079,7 @@ def plugin_info_cmd(ctx, name):
                    "Default: enabled. Use --no-upgrade to keep an existing "
                    "install if one is already present.")
 @click.option("--offline", is_flag=True,
-              help="Accepted for compatibility; plugin install no longer uses an index.")
+              help="Accepted for compatibility; retired installer no longer uses an index.")
 @click.option("--no-sync", "no_sync", is_flag=True,
               help="Skip sync-skills after install.")
 @click.option("--target", "sync_target", type=click.Path(file_okay=False, path_type=Path),
@@ -1103,22 +1091,11 @@ def plugin_info_cmd(ctx, name):
                    "when sim is on PATH but the desired venv isn't activated.")
 @click.option("--extra-index-url", "extra_index_urls", multiple=True,
               help="Additional Python package index for private plugins. "
-                   "Passed through to pip/uv pip install.")
+                   "Accepted for compatibility by the retired installer.")
 @click.pass_context
 def plugin_install(ctx, source, editable, upgrade, offline, no_sync, sync_target,
                     python_exe, extra_index_urls):
-    """Install a plugin from any supported source.
-
-    \b
-    Examples:
-      sim plugin install sim-plugin-coolprop               # exact package spec
-      sim plugin install sim-plugin-coolprop==0.1.0        # pinned package spec
-      sim plugin install ./sim_plugin_coolprop-0.1.0-py3-none-any.whl
-      sim plugin install ./sim-plugin-coolprop -e          # editable, for authors
-      sim plugin install git+https://github.com/svd-ai-lab/sim-plugin-coolprop
-      sim plugin install sim-plugin-coolprop --python /path/to/venv/bin/python
-      sim plugin install sim-plugin-mechanical --extra-index-url https://example.com/simple/
-    """
+    """Retired compatibility shim. Add plugin packages with uv."""
     from sim._plugin_install import install_plugin
 
     report = install_plugin(
@@ -1132,55 +1109,36 @@ def plugin_install(ctx, source, editable, upgrade, offline, no_sync, sync_target
     if ctx.obj["json"]:
         click.echo(json_mod.dumps(report.to_dict(), indent=2))
     else:
-        if report.ok:
-            click.echo(f"[sim] plugin install: ok ({report.source_kind} → {report.pip_target})")
-            if report.sync_skills:
-                if report.sync_skills.get("ok"):
-                    linked = len(report.sync_skills.get("linked", []))
-                    copied = len(report.sync_skills.get("copied", []))
-                    if linked or copied:
-                        click.echo(f"[sim] sync-skills: {linked} linked, {copied} copied")
-        else:
-            click.echo(f"[sim] plugin install: FAIL — {report.message}", err=True)
-            if report.pip_stderr:
-                click.echo(report.pip_stderr.rstrip(), err=True)
+        click.echo(report.message, err=True)
 
     sys.exit(0 if report.ok else 4)
 
 
-@plugin.command("uninstall")
+@plugin.command("uninstall", hidden=True)
 @click.argument("name")
 @click.option("--python", "python_exe", default=None,
               help="Pin the target Python interpreter for the uninstall.")
 @click.pass_context
 def plugin_uninstall(ctx, name, python_exe):
-    """Uninstall a plugin and remove its synced skill directory."""
+    """Retired compatibility shim. Remove plugin packages with uv."""
     from sim._plugin_install import uninstall_plugin
 
     result = uninstall_plugin(name, python=python_exe)
     if ctx.obj["json"]:
         click.echo(json_mod.dumps(result, indent=2))
     else:
-        if result["ok"]:
-            click.echo(f"[sim] plugin uninstall: removed {result['package']}")
-        else:
-            click.echo(f"[sim] plugin uninstall: FAIL — {result.get('message')}", err=True)
+        click.echo(result.get("message"), err=True)
     sys.exit(0 if result.get("ok") else 4)
 
 
-@plugin.command("bundle")
+@plugin.command("bundle", hidden=True)
 @click.argument("names", nargs=-1, required=True)
 @click.option("--output", "-o", type=click.Path(file_okay=False, path_type=Path),
               default=Path("./plugins-bundle"),
               help="Output directory for wheels + filtered index.json.")
 @click.pass_context
 def plugin_bundle(ctx, names, output):
-    """Deprecated: index-backed plugin bundles are no longer supported.
-
-    \b
-    Examples:
-      sim plugin install ./vendor/sim_plugin_coolprop-0.1.0-py3-none-any.whl
-    """
+    """Retired compatibility shim. Add plugin packages with uv."""
     from sim._plugin_install import bundle_plugins
 
     result = bundle_plugins(list(names), output)
@@ -1201,12 +1159,12 @@ def plugin_bundle(ctx, names, output):
 
 @plugin.command("sync-skills")
 @click.option("--target", type=click.Path(file_okay=False, path_type=Path), default=None,
-              help="Where to materialize plugin _skills/ dirs (default: per-project .claude/skills/).")
+              help="Where to materialize sim-cli/plugin _skills/ dirs (default: per-project .claude/skills/).")
 @click.option("--copy", "copy_mode", is_flag=True,
               help="Copy instead of symlink (Windows-friendly).")
 @click.pass_context
 def plugin_sync_skills(ctx, target, copy_mode):
-    """Materialize every installed plugin's bundled skill into a target dir.
+    """Materialize sim-cli and installed plugin skills into a target dir.
 
     Idempotent. Symlinks where supported; ``--copy`` on environments where
     symlinks aren't available (Windows without dev mode).
@@ -1241,8 +1199,8 @@ def plugin_doctor(ctx, name, all_plugins, deep):
     """Validate that a plugin loads, conforms to DriverProtocol, and has skills.
 
     Exit code is the count of FAILed checks; 0 means clean. Use this in CI
-    to catch plugin-side regressions, and in `sim setup` to verify a fresh
-    install.
+    to catch plugin-side regressions, and after `uv add` to verify a fresh
+    project environment.
     """
     from sim import plugins as _plugins
 

--- a/src/sim/compat.py
+++ b/src/sim/compat.py
@@ -6,9 +6,9 @@ module parses that file into a small typed surface (`Profile`,
 
   1. Given a detected solver version, which profile applies?
   2. What profiles does sim-cli know about across all drivers?
-  3. For a given profile, which sim-skills overlay layers are active?
+  3. For a given profile, which skill overlay layers are active?
 
-It is intentionally a **metadata catalogue**, not a runtime. sim-cli
+It is intentionally a metadata index, not a runtime. sim-cli
 runs every driver in its own process — compat.yaml exists so the CLI
 can tell users which profile applies to a detected solver version and
 so the skills layer can resolve a profile to its (sdk, solver)
@@ -57,7 +57,7 @@ class Profile:
     `sdk` is optional: solvers like OpenFOAM have no Python SDK to pin.
 
     `active_sdk_layer` and `active_solver_layer` declare which sub-folders
-    under `<sim-skills>/<driver>/sdk/` and `<sim-skills>/<driver>/solver/`
+    under `<skills-root>/<driver>/sdk/` and `<skills-root>/<driver>/solver/`
     apply to this profile. Both are optional — SDK-less drivers leave
     `active_sdk_layer` unset, drivers with no version-sensitive solver
     content leave `active_solver_layer` unset. The `base/` overlay is
@@ -298,28 +298,25 @@ def load_compatibility(driver_dir: str | Path) -> Compatibility:
 
 
 _SKILLS_HINT = (
-    "set SIM_SKILLS_ROOT or place sim-skills/ next to sim-cli/"
+    "set SIM_SKILLS_ROOT or install/sync the plugin's bundled skills"
 )
 
 
 def find_skills_root() -> Path | None:
-    """Locate the sim-skills root.
+    """Locate an external skills root for local development overrides.
 
     Probe order:
-      1. ``SIM_SKILLS_ROOT`` env var (authoritative when set)
-      2. ``../sim-skills`` sibling of the sim-cli checkout
+      1. ``SIM_SKILLS_ROOT`` env var
 
-    Returns None when neither succeeds. The function never raises —
-    callers degrade gracefully by returning a hint to the user.
+    Returns None when it is unset or invalid. The function never raises —
+    callers degrade gracefully by returning a hint to the user or falling
+    back to plugin-bundled skills.
     """
     raw = os.environ.get("SIM_SKILLS_ROOT")
     if raw:
         p = Path(raw)
         return p.resolve() if p.is_dir() else None
-
-    # this file lives at <sim-cli>/src/sim/compat.py
-    sibling = Path(__file__).resolve().parents[2].parent / "sim-skills"
-    return sibling.resolve() if sibling.is_dir() else None
+    return None
 
 
 def verify_skills_layout(
@@ -396,9 +393,9 @@ def skills_block_for_profile(driver: str, profile: "Profile | None") -> dict:
 
     if driver_dir is None or not driver_dir.is_dir():
         # Out-of-tree plugins can bundle skills through the ``sim.skills``
-        # entry-point. Prefer the external sim-skills tree when present so
-        # local development overlays win, then fall back to the installed
-        # plugin bundle.
+        # entry-point. Prefer the explicit SIM_SKILLS_ROOT override when
+        # present so local development overlays win, then fall back to the
+        # installed plugin bundle.
         try:
             from sim.plugins import skills_dir_for
             plugin_dir = skills_dir_for(driver)

--- a/src/sim/describe.py
+++ b/src/sim/describe.py
@@ -14,7 +14,6 @@ sync with their documentation.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any
 
 import click
@@ -103,9 +102,9 @@ _EXAMPLES: dict[str, list[dict[str, str]]] = {
     ],
     "setup": [
         {"cmd": "sim setup --dry-run",
-         "summary": "Print what plugins sim would install from sim.toml."},
+         "summary": "Print plugin package specs declared in sim.toml."},
         {"cmd": "sim setup",
-         "summary": "Install every plugin declared in sim.toml."},
+         "summary": "Validate sim.toml and report declared plugin packages."},
     ],
     "describe": [
         {"cmd": "sim describe --json",
@@ -123,25 +122,9 @@ _EXAMPLES: dict[str, list[dict[str, str]]] = {
         {"cmd": "sim plugin info coolprop",
          "summary": "Show one plugin's metadata and compatibility profiles."},
     ],
-    "plugin install": [
-        {"cmd": "sim plugin install sim-plugin-coolprop",
-         "summary": "Install from an exact package spec."},
-        {"cmd": "sim plugin install ./sim_plugin_coolprop-0.1.0-py3-none-any.whl",
-         "summary": "Install from a local wheel (offline-friendly)."},
-        {"cmd": "sim plugin install ./sim-plugin-coolprop -e",
-         "summary": "Editable install for plugin authors."},
-    ],
-    "plugin uninstall": [
-        {"cmd": "sim plugin uninstall coolprop",
-         "summary": "Remove a plugin and its synced skill dir."},
-    ],
-    "plugin bundle": [
-        {"cmd": "sim plugin bundle coolprop simpy gmsh -o ./plugins-bundle/",
-         "summary": "Fetch wheels into a directory for offline install."},
-    ],
     "plugin sync-skills": [
         {"cmd": "sim plugin sync-skills",
-         "summary": "Materialize installed plugins' _skills into .claude/skills/."},
+         "summary": "Materialize sim-cli and installed plugin _skills into .claude/skills/."},
     ],
     "plugin doctor": [
         {"cmd": "sim --json plugin doctor --all",
@@ -168,9 +151,9 @@ ERROR_CODES: dict[str, str] = {
     "SESSION_NOT_FOUND":
         "--session <id> does not match any active session on the server.",
     "PLUGIN_NOT_FOUND":
-        "sim plugin install received an invalid explicit source, or a plugin name is not installed.",
-    "PLUGIN_INSTALL_FAILED":
-        "pip install for a plugin returned non-zero.",
+        "A requested plugin name is not registered in this environment.",
+    "PLUGIN_INSTALL_RETIRED":
+        "A retired plugin package mutation command was invoked; use uv add/remove instead.",
     "PROTOCOL_VIOLATION":
         "A driver returned a value that doesn't match DriverProtocol.",
     "NONINTERACTIVE_INPUT_REQUIRED":
@@ -311,6 +294,8 @@ def _walk(group: click.Group, prefix: str = "") -> list[dict[str, Any]]:
     """
     entries: list[dict[str, Any]] = []
     for sub_name, sub_cmd in sorted(group.commands.items()):
+        if getattr(sub_cmd, "hidden", False):
+            continue
         full = f"{prefix}{sub_name}" if prefix else sub_name
         if isinstance(sub_cmd, click.Group):
             # Describe the group itself plus walk into it.
@@ -343,4 +328,6 @@ def build_command_entry(app: click.Group, command_path: str) -> dict[str, Any] |
         if not isinstance(cur, click.Group) or part not in cur.commands:
             return None
         cur = cur.commands[part]
+        if getattr(cur, "hidden", False):
+            return None
     return _describe_command(command_path, cur)

--- a/src/sim/gui/__init__.py
+++ b/src/sim/gui/__init__.py
@@ -32,7 +32,7 @@ raise unless the caller passes invalid Python types. The agent's
 subsequent inspect round (channel #3 traceback / #8 window_observed)
 will reflect the outcome.
 
-See ``sim-skills/sim-cli/gui/SKILL.md`` for the full agent-facing
+See ``sim-cli/_skills/sim-cli/gui/SKILL.md`` for the full agent-facing
 reference and solver-specific dialog recipes.
 """
 from __future__ import annotations

--- a/src/sim/inspect.py
+++ b/src/sim/inspect.py
@@ -486,7 +486,7 @@ class StdoutJsonTailProbe:
         return ProbeResult(diagnostics=[Diagnostic(
             severity="info",
             message=f"parsed {found_from}: {preview}",
-            source=f"stdout:json",
+            source="stdout:json",
             code="sim.stdout.json_tail",
             extra={
                 "source_kind": found_from,
@@ -604,7 +604,7 @@ class SdkAttributeProbe:
 #
 # Deliberately empty — solver-specific exception→domain-code mapping is a
 # semantic judgement ("this Python exception means a Fluent RPC timeout")
-# and that belongs to the agent / sim-skills layer, not the driver layer.
+# and that belongs to the agent skill layer, not the driver layer.
 # The class remains available so a skill or agent can pass its own rules
 # explicitly via DomainExceptionMapProbe(rules=[...]).
 _EXC_MAP_RULES: list[dict] = []

--- a/src/sim/plugins.py
+++ b/src/sim/plugins.py
@@ -20,9 +20,8 @@ This module exposes:
   plugin_info_for(name)     -> dict | None
   skills_dir_for(name)      -> Traversable | None
 
-It deliberately does **not** install / uninstall plugins — that's
-``sim plugin install``'s concern, in :mod:`sim._plugin_install`. Discovery
-is read-only and side-effect-free.
+It deliberately does **not** install / uninstall plugins. Package mutation
+belongs to uv; discovery is read-only and side-effect-free.
 """
 from __future__ import annotations
 
@@ -37,6 +36,7 @@ from typing import Any
 _GROUP_DRIVERS = "sim.drivers"
 _GROUP_SKILLS = "sim.skills"
 _GROUP_PLUGINS = "sim.plugins"
+_RUNTIME_SKILLS_NAME = "sim-cli"
 
 
 # ── Data shapes ─────────────────────────────────────────────────────────────
@@ -193,6 +193,17 @@ def skills_dir_for(name: str):
         return candidate
     # Otherwise treat it as the leaf already.
     return traversable
+
+
+def runtime_skills_dir():
+    """Return sim-cli's bundled shared runtime skill directory, if present."""
+    try:
+        skills = _resources.files("sim").joinpath("_skills", _RUNTIME_SKILLS_NAME)
+        if skills.joinpath("SKILL.md").is_file():
+            return skills
+    except Exception:  # noqa: BLE001
+        return None
+    return None
 
 
 def list_installed_plugins() -> list[InstalledPlugin]:
@@ -399,15 +410,14 @@ def doctor_all(deep: bool = False) -> list[DoctorReport]:
 
 
 def sync_skills_to(target_dir, *, copy: bool = False) -> dict[str, Any]:
-    """Materialize every installed plugin's ``_skills/<name>/`` under ``target_dir``.
+    """Materialize sim-cli and plugin ``_skills/<name>/`` dirs under ``target_dir``.
 
     Default mode is symlink (idempotent, near-free); ``copy=True`` falls
     back to recursive copy for environments where symlinks are blocked
     (Windows without developer mode).
 
     Returns ``{"ok": bool, "linked": [...], "copied": [...], "skipped": [...]}``.
-    Skips drivers without a ``sim.skills`` entry-point (built-ins, OSS plugins
-    that haven't shipped skills yet).
+    Skips drivers without a ``sim.skills`` entry-point.
     """
     from pathlib import Path
 
@@ -418,20 +428,12 @@ def sync_skills_to(target_dir, *, copy: bool = False) -> dict[str, Any]:
     copied: list[str] = []
     skipped: list[str] = []
 
-    for plugin in list_installed_plugins():
-        if not plugin.has_skills:
-            skipped.append(plugin.name)
-            continue
-        skills = skills_dir_for(plugin.name)
-        if skills is None:
-            skipped.append(plugin.name)
-            continue
-
+    def sync_one(name: str, skills) -> None:
         # Resolve the Traversable to a real filesystem path. importlib.resources
         # returns a MultiplexedPath / PosixPath / WindowsPath depending on the
         # install type. _resources.as_file() yields a real path.
         with _resources.as_file(skills) as src_path:
-            dest = target / plugin.name
+            dest = target / name
             if dest.is_symlink() or dest.exists():
                 try:
                     if dest.is_symlink():
@@ -442,22 +444,36 @@ def sync_skills_to(target_dir, *, copy: bool = False) -> dict[str, Any]:
                     else:
                         dest.unlink()
                 except OSError:
-                    skipped.append(plugin.name)
-                    continue
+                    skipped.append(name)
+                    return
 
             if copy:
                 import shutil
                 shutil.copytree(src_path, dest)
-                copied.append(plugin.name)
+                copied.append(name)
             else:
                 try:
                     dest.symlink_to(src_path, target_is_directory=True)
-                    linked.append(plugin.name)
+                    linked.append(name)
                 except (OSError, NotImplementedError):
                     # Windows / no privilege — fall back to copy.
                     import shutil
                     shutil.copytree(src_path, dest)
-                    copied.append(plugin.name)
+                    copied.append(name)
+
+    runtime_skills = runtime_skills_dir()
+    if runtime_skills is not None:
+        sync_one(_RUNTIME_SKILLS_NAME, runtime_skills)
+
+    for plugin in list_installed_plugins():
+        if not plugin.has_skills:
+            skipped.append(plugin.name)
+            continue
+        skills = skills_dir_for(plugin.name)
+        if skills is None:
+            skipped.append(plugin.name)
+            continue
+        sync_one(plugin.name, skills)
 
     return {
         "ok": True,

--- a/src/sim/server.py
+++ b/src/sim/server.py
@@ -339,7 +339,7 @@ def connect(req: ConnectRequest):
     tool_refs: dict[str, str] = {}
     if getattr(driver, "_gui", None) is not None:
         tools.append("gui")
-        tool_refs["gui"] = "sim-skills/sim-cli/gui/SKILL.md"
+        tool_refs["gui"] = "sim-cli/_skills/sim-cli/gui/SKILL.md"
 
     return {
         "ok": True,

--- a/tests/base/test_compat.py
+++ b/tests/base/test_compat.py
@@ -9,15 +9,14 @@ Three groups:
   TestSkillsBlockForProfile   — `skills_block_for_profile()` builds the
                                 dict that /connect returns to the agent
 
-All tests use synthetic temp trees so they do NOT depend on the sibling
-sim-skills repo being present.
+All tests use synthetic temp trees so they do NOT depend on external skill
+repositories being present.
 """
 from __future__ import annotations
 
 import os
 import shutil
 import tempfile
-import textwrap
 import unittest
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/base/test_describe.py
+++ b/tests/base/test_describe.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 
-import click
 import pytest
 from click.testing import CliRunner
 
@@ -44,6 +43,14 @@ def test_manifest_includes_nested_config_subcommands():
     names = {c["name"] for c in m["commands"]}
     for required in ("config show", "config path", "config init"):
         assert required in names
+
+
+def test_manifest_excludes_retired_plugin_mutation_commands():
+    m = _describe.build_manifest(main, version="0")
+    names = {c["name"] for c in m["commands"]}
+    assert "plugin install" not in names
+    assert "plugin uninstall" not in names
+    assert "plugin bundle" not in names
 
 
 def test_every_command_has_summary_and_help():

--- a/tests/base/test_init_setup.py
+++ b/tests/base/test_init_setup.py
@@ -184,7 +184,7 @@ def test_cli_setup_missing_sim_toml_errors_cleanly(runner: CliRunner, tmp_path: 
     assert data["error_code"] == "PLUGIN_NOT_FOUND"
 
 
-def test_cli_setup_dry_run_lists_what_would_install(runner: CliRunner, tmp_path: Path, monkeypatch):
+def test_cli_setup_lists_declared_plugin_package_specs(runner: CliRunner, tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "sim.toml").write_text("""
 [sim]
@@ -200,4 +200,5 @@ version = "==0.1.0"
     assert len(data["plugins"]) == 1
     assert data["plugins"][0]["name"] == "coolprop"
     assert data["plugins"][0]["source"] == "sim-plugin-coolprop==0.1.0"
-    assert data["plugins"][0]["action"] == "would-install"
+    assert data["plugins"][0]["action"] == "declared"
+    assert data["plugins"][0]["install"] == "uv add sim-cli-core sim-plugin-coolprop==0.1.0"

--- a/tests/base/test_plugin_install.py
+++ b/tests/base/test_plugin_install.py
@@ -1,248 +1,92 @@
-"""Tests for sim._plugin_install — source resolution and report shape.
-
-These cover the *classification* layer (no real pip calls). The actual
-install path is exercised against a fixture wheel in test_plugin_install_e2e
-— kept small and skipped when no fixture wheel exists yet.
-"""
+"""Tests for retired plugin installer command shims."""
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-import pytest
+from click.testing import CliRunner
 
-from sim._plugin_install import (
-    InstallReport,
-    bundle_plugins,
-    install_plugin,
-    resolve_source,
-)
+from sim import _plugin_install
+from sim._plugin_install import InstallReport, bundle_plugins, install_plugin, uninstall_plugin
+from sim.cli import main
 
 
-# ── Source resolution ──────────────────────────────────────────────────────
+def test_install_package_spec_returns_exact_uv_replacement():
+    report = install_plugin("sim-plugin-comsol")
+
+    assert report.ok is False
+    assert report.error_code == "PLUGIN_INSTALL_RETIRED"
+    assert "sim plugin install is retired." in report.message
+    assert "uv add sim-cli-core sim-plugin-comsol" in report.message
 
 
-def test_resolve_local_wheel(tmp_path: Path):
-    wheel = tmp_path / "sim_plugin_coolprop-0.1.0-py3-none-any.whl"
-    wheel.write_bytes(b"")  # contents irrelevant for resolution
-    rs = resolve_source(str(wheel))
-    assert rs.kind == "local-wheel"
-    assert rs.pip_target == str(wheel.resolve())
+def test_install_short_name_points_to_plugin_index():
+    report = install_plugin("comsol")
+
+    assert report.ok is False
+    assert report.error_code == "PLUGIN_INSTALL_RETIRED"
+    assert "Short solver names are not package specs" in report.message
+    assert "docs.svdailab.com/plugin-index" in report.message
+    assert "uv add sim-cli-core <plugin-package-spec>" in report.message
 
 
-def test_resolve_local_sdist(tmp_path: Path):
-    sdist = tmp_path / "sim-plugin-coolprop-0.1.0.tar.gz"
-    sdist.write_bytes(b"")
-    rs = resolve_source(str(sdist))
-    assert rs.kind == "local-sdist"
+def test_installer_module_has_no_pip_invoker():
+    assert not hasattr(_plugin_install, "_pip_install")
 
 
-def test_resolve_local_directory(tmp_path: Path):
-    pkg_dir = tmp_path / "sim-plugin-foo"
-    pkg_dir.mkdir()
-    rs = resolve_source(str(pkg_dir))
-    assert rs.kind == "local-dir"
+def test_uninstall_returns_uv_remove_guidance():
+    result = uninstall_plugin("comsol")
+
+    assert result["ok"] is False
+    assert result["error_code"] == "PLUGIN_INSTALL_RETIRED"
+    assert "sim plugin uninstall is retired." in result["message"]
+    assert "uv remove sim-plugin-comsol" in result["message"]
 
 
-def test_resolve_missing_local_path_errors(tmp_path: Path):
-    with pytest.raises(FileNotFoundError):
-        resolve_source(str(tmp_path / "no-such-thing/"))
+def test_bundle_plugins_is_retired(tmp_path: Path):
+    result = bundle_plugins(["comsol"], tmp_path / "bundle")
 
-
-def test_resolve_git_url():
-    url = "git+https://github.com/svd-ai-lab/sim-plugin-ltspice"
-    rs = resolve_source(url)
-    assert rs.kind == "git-url"
-    assert rs.pip_target == url
-
-
-def test_resolve_wheel_url():
-    url = "https://example.com/sim_plugin_ltspice-0.2.3-py3-none-any.whl"
-    rs = resolve_source(url)
-    assert rs.kind == "wheel-url"
-    assert rs.pip_target == url
-
-
-def test_resolve_sdist_url():
-    url = "https://example.com/sim-plugin-x-0.1.0.tar.gz"
-    rs = resolve_source(url)
-    assert rs.kind == "sdist-url"
-
-
-def test_resolve_exact_package_spec():
-    rs = resolve_source("sim-plugin-ltspice")
-    assert rs.kind == "package-spec"
-    assert rs.name == "sim-plugin-ltspice"
-    assert rs.pip_target == "sim-plugin-ltspice"
-
-
-def test_resolve_exact_version_package_spec():
-    rs = resolve_source("sim-plugin-ltspice==0.2.3")
-    assert rs.kind == "package-spec"
-    assert rs.name == "sim-plugin-ltspice"
-    assert rs.version == "0.2.3"
-    assert rs.pip_target == "sim-plugin-ltspice==0.2.3"
-
-
-def test_resolve_exact_range_package_spec():
-    rs = resolve_source("sim-plugin-ltspice>=0.2")
-    assert rs.kind == "package-spec"
-    assert rs.name == "sim-plugin-ltspice"
-    assert rs.version == "0.2"
-    assert rs.pip_target == "sim-plugin-ltspice>=0.2"
-
-
-@pytest.mark.parametrize("name", ["mechanical", "ltspice"])
-def test_resolve_bare_short_name_rejected(name: str):
-    with pytest.raises(ValueError) as exc:
-        resolve_source(name)
-    msg = str(exc.value)
-    assert "explicit plugin install source" in msg
-    assert "sim-plugin-index" in msg
-    assert f"sim-plugin-{name}" in msg
-
-
-def test_resolve_garbage_raises():
-    with pytest.raises(ValueError):
-        resolve_source("???not-a-source???")
-
-
-def test_bundle_plugins_is_disabled_without_index(tmp_path: Path):
-    output = tmp_path / "out"
-    result = bundle_plugins(["ltspice"], output)
     assert result["ok"] is False
     assert result["fetched"] == []
-    assert result["errors"][0]["name"] == "ltspice"
-    assert "sim-plugin-index" in result["errors"][0]["error"]
-
-
-def test_install_bare_short_name_returns_helpful_error(monkeypatch):
-    from sim import _plugin_install
-
-    def fail_if_called(*args, **kwargs):
-        raise AssertionError("pip install should not be called")
-
-    monkeypatch.setattr(_plugin_install, "_pip_install", fail_if_called)
-
-    report = install_plugin("mechanical")
-    assert report.ok is False
-    assert report.source_kind == "invalid"
-    assert report.error_code == "PLUGIN_NOT_FOUND"
-    assert "sim-plugin-mechanical" in report.message
-
-
-# ── InstallReport shape ─────────────────────────────────────────────────────
+    assert result["errors"][0]["error_code"] == "PLUGIN_INSTALL_RETIRED"
 
 
 def test_install_report_dict_includes_all_keys():
     r = InstallReport(
-        ok=True, name="x", source_kind="name", pip_target="...",
-        pip_returncode=0, pip_stdout="o", pip_stderr="e",
-        sync_skills={"ok": True, "linked": [], "copied": [], "skipped": []},
+        ok=False,
+        name="x",
+        source_kind="retired",
+        pip_target="...",
+        pip_returncode=-1,
+        pip_stdout="o",
+        pip_stderr="e",
+        sync_skills=None,
+        error_code="PLUGIN_INSTALL_RETIRED",
+        message="m",
     )
     d = r.to_dict()
-    for k in ("ok", "name", "source_kind", "pip_target",
-              "pip_returncode", "pip_stdout", "pip_stderr",
-              "sync_skills", "error_code", "message"):
+    for k in (
+        "ok", "name", "source_kind", "pip_target", "pip_returncode",
+        "pip_stdout", "pip_stderr", "sync_skills", "error_code", "message",
+    ):
         assert k in d
 
 
-# ── --python flag plumbing ─────────────────────────────────────────────────
+def test_cli_plugin_install_human_shows_migration_error():
+    runner = CliRunner()
+    result = runner.invoke(main, ["plugin", "install", "sim-plugin-comsol"])
+
+    assert result.exit_code == 4
+    assert "sim plugin install is retired." in result.output
+    assert "uv add sim-cli-core sim-plugin-comsol" in result.output
 
 
-class _FakeProc:
-    def __init__(self):
-        self.returncode = 0
-        self.stdout = ""
-        self.stderr = ""
+def test_cli_plugin_install_json_shows_retired_code():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--json", "plugin", "install", "comsol"])
 
-
-def test_pip_install_pins_python_via_uv(monkeypatch):
-    """When uv is on PATH, _pip_install must pass ``--python <exe>``."""
-    from sim import _plugin_install
-
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-        return _FakeProc()
-
-    monkeypatch.setattr(_plugin_install.shutil, "which",
-                        lambda exe: "/usr/bin/uv" if exe == "uv" else None)
-    monkeypatch.setattr(_plugin_install.subprocess, "run", fake_run)
-
-    _plugin_install._pip_install("sim-plugin-foo", python="/tmp/myvenv/bin/python")
-
-    cmd = captured["cmd"]
-    assert cmd[0] == "uv"
-    assert "--python" in cmd
-    assert "/tmp/myvenv/bin/python" in cmd
-    assert cmd[-1] == "sim-plugin-foo"
-
-
-def test_pip_install_pins_python_via_pip(monkeypatch):
-    """When uv is NOT on PATH, _pip_install must invoke ``<exe> -m pip``."""
-    from sim import _plugin_install
-
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-        return _FakeProc()
-
-    monkeypatch.setattr(_plugin_install.shutil, "which", lambda exe: None)
-    monkeypatch.setattr(_plugin_install.subprocess, "run", fake_run)
-
-    _plugin_install._pip_install("sim-plugin-foo", python="/tmp/myvenv/bin/python")
-
-    cmd = captured["cmd"]
-    assert cmd[0] == "/tmp/myvenv/bin/python"
-    assert cmd[1:4] == ["-m", "pip", "install"]
-
-
-def test_pip_install_defaults_to_sys_executable(monkeypatch):
-    """Without an explicit ``python``, fall back to ``sys.executable``."""
-    import sys
-    from sim import _plugin_install
-
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-        return _FakeProc()
-
-    monkeypatch.setattr(_plugin_install.shutil, "which",
-                        lambda exe: "/usr/bin/uv" if exe == "uv" else None)
-    monkeypatch.setattr(_plugin_install.subprocess, "run", fake_run)
-
-    _plugin_install._pip_install("sim-plugin-foo")
-
-    cmd = captured["cmd"]
-    assert "--python" in cmd
-    assert sys.executable in cmd
-
-
-def test_install_passes_extra_index_urls(monkeypatch):
-    from sim import _plugin_install
-
-    captured = {}
-
-    def fake_pip_install(target, **kwargs):
-        captured["target"] = target
-        captured["kwargs"] = kwargs
-        return _FakeProc()
-
-    monkeypatch.setattr(_plugin_install, "_pip_install", fake_pip_install)
-    monkeypatch.setattr(_plugin_install, "_default_skills_target", lambda: Path("/tmp/no-skills"))
-
-    report = install_plugin(
-        "sim-plugin-mechanical",
-        skip_sync=True,
-        extra_index_urls=["https://example.com/simple/"],
-    )
-
-    assert report.ok is True
-    assert captured["target"] == "sim-plugin-mechanical"
-    assert captured["kwargs"]["extra_args"] == [
-        "--extra-index-url",
-        "https://example.com/simple/",
-    ]
+    assert result.exit_code == 4
+    data = json.loads(result.output)
+    assert data["ok"] is False
+    assert data["error_code"] == "PLUGIN_INSTALL_RETIRED"
+    assert "docs.svdailab.com/plugin-index" in data["message"]

--- a/tests/base/test_plugins.py
+++ b/tests/base/test_plugins.py
@@ -3,9 +3,8 @@
 Post-Phase-3b ``_BUILTIN_REGISTRY`` is empty. The conftest synthetic
 ``coolprop`` driver (autouse fixture, ``tests/base/`` only) is what makes
 these tests find anything at all — when it's active, plugin/list/doctor
-see a single registered driver named "coolprop". Tests for actually
-installing external plugins (`sim plugin install <wheel>`) live in
-test_plugin_install.py.
+see a single registered driver named "coolprop". Retired installer shims
+are covered in test_plugin_install.py.
 """
 from __future__ import annotations
 
@@ -152,7 +151,9 @@ def test_sync_skills_creates_target_dir_and_returns_dict(tmp_path):
     out = _plugins.sync_skills_to(target, copy=True)
     assert out["ok"] is True
     assert target.exists()
-    # Built-ins don't ship sim.skills entry-points, so all are skipped.
+    assert (target / "sim-cli" / "SKILL.md").is_file()
+    assert "sim-cli" in out["copied"]
+    # Built-in drivers don't ship sim.skills entry-points, so they are skipped.
     assert isinstance(out["skipped"], list)
     assert isinstance(out["linked"], list)
     assert isinstance(out["copied"], list)

--- a/tests/gui/test_connect_tools_field.py
+++ b/tests/gui/test_connect_tools_field.py
@@ -74,7 +74,7 @@ def test_connect_advertises_gui_tool(client):
     assert r.status_code == 200, r.text
     data = r.json()["data"]
     assert data["tools"] == ["gui"]
-    assert data["tool_refs"] == {"gui": "sim-skills/sim-cli/gui/SKILL.md"}
+    assert data["tool_refs"] == {"gui": "sim-cli/_skills/sim-cli/gui/SKILL.md"}
 
 
 def test_connect_omits_tool_when_no_gui(client):

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ wheels = [
 
 [[package]]
 name = "sim-cli-core"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Refs svd-ai-lab/sim-proj#153.

This PR moves sim-cli to the uv-first plugin package model:

- hides `sim plugin install`, `sim plugin uninstall`, and `sim plugin bundle` behind migration shims
- changes `sim setup` to validate/report declared plugin package specs instead of installing packages
- removes retired installer examples from diagnostics, `sim describe`, and docs
- bundles the shared runtime skill under `src/sim/_skills/sim-cli` and syncs it with `sim plugin sync-skills`
- updates tests for retired command behavior and manifest visibility

## Validation

- `uv run pytest tests/base/test_plugin_install.py tests/base/test_init_setup.py tests/base/test_plugins.py tests/base/test_describe.py tests/gui/test_connect_tools_field.py -q --basetemp .pytest-tmp-retire` -> 63 passed
- `uv run ruff check src/sim tests/base/test_plugin_install.py tests/base/test_init_setup.py tests/base/test_plugins.py tests/base/test_compat.py tests/base/test_describe.py tests/gui/test_connect_tools_field.py` -> clean
- `git diff --check` -> clean, with Windows LF warnings only