### PR TITLE
docs: fix version-compat.md status label and stale section ref

### DIFF
--- a/docs/architecture/version-compat.md
+++ b/docs/architecture/version-compat.md
@@ -1,6 +1,6 @@
 # Version Compatibility & Plugin Discovery
 
-> **Status:** stub.
+> **Status:** current.
 > **Audience:** sim-cli maintainers, plugin authors.
 > **Last reviewed:** 2026-05-11.
 

--- a/src/sim/driver.py
+++ b/src/sim/driver.py
@@ -128,7 +128,7 @@ class DriverProtocol(Protocol):
         Must be safe to call when nothing is installed (returns []).
         Should be cheap (≤ a few hundred ms) — runs in interactive paths.
 
-        See docs/architecture/version-compat.md §7 for the contract.
+        See docs/architecture/version-compat.md §4 for the contract.
         Drivers that have not yet implemented this should return [] so the
         protocol stays runtime_checkable for partial migrations.
         """


### PR DESCRIPTION
## What

Two small doc-accuracy fixes:

1. **`docs/architecture/version-compat.md`** — header said `> **Status:** stub.`, but §2–§4 hold the live plugin-discovery + `compatibility.yaml` + detection contract, and `docs/DEVELOPMENT.md` links to it as "the compatibility and plugin discovery contract." Relabelled `stub` → `current`.
2. **`src/sim/driver.py`** — the `detect_installed()` docstring referenced `version-compat.md §7`, but the doc has only §1–§6. The section describing the `detect_installed()` contract is §4 ("Current detection and bootstrap"). Fixed `§7` → `§4`.

Docs-only; no behaviour change.

Note: `docs/architecture/skills-layering-plan.md` was also flagged as mislabelled ("proposal, awaiting review"), but that was already fixed in `05acb2f` — it now reads as "the current skill packaging model." No change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)