### PR TITLE
release: 0.3.7 — legacy plugin installer retired, docs cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sim-cli-core"
-version = "0.3.6"
+version = "0.3.7"
 description = "Make every engineering tool agent-native — a CLI runtime that lets LLM agents launch, drive, and observe CAD/CAE software"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bumps `sim-cli-core` **0.3.6 → 0.3.7**. First release after the refactor-window version-bump hold was lifted.

### Changes since v0.3.6
- Retire legacy plugin installer (#108)
- README: task-shaped agent prompts, duplication trim (#109, #112)
- version-compat doc fixes (#111)
- `_skills/sim-cli`: trim to cross-solver discipline (#110)

## Test plan
- [x] `uv build` → `sim_cli_core-0.3.7-{whl,tar.gz}`
- [x] `twine check` PASSED on both artifacts
- [x] Clean-venv smoke test: `sim --version`, `import sim`, `importlib.metadata.version` all report `0.3.7`

After merge: tag `v0.3.7` from `main`, push, OIDC publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)