### PR TITLE
docs: clarify sim-cli composability

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ engineering review.
   <img src="https://img.shields.io/badge/status-alpha-f97316" alt="Status: alpha">
 </p>
 
-[Quick Start](#quick-start-agent-setup) · [COMSOL + Codex](#example-comsol-and-codex-on-one-machine) · [Composability](#composable-not-a-universal-wrapper) · [Agent Loop](#the-agent-loop) · [Remote Solvers](#local-vs-remote-solvers) · [Plugins](#solver-plugins) · [Commands](#common-commands)
+[Quick Start](#quick-start-agent-setup) · [COMSOL + Codex](#example-comsol-and-codex-on-one-machine) · [Agent Loop](#the-agent-loop) · [Remote Solvers](#local-vs-remote-solvers) · [Plugins](#solver-plugins) · [Commands](#common-commands)
 
 </div>
 
@@ -56,14 +56,10 @@ Plugin authoring, runtime internals, and driver protocol details live in
 LLMs can often write solver scripts, but a one-shot script is a weak workflow:
 it hides intermediate state, fails late, and makes recovery difficult.
 
-`sim` gives an agent a small, repeatable control surface — detect the
+`sim` gives an agent a small, composable control surface: detect the
 environment, attach to a live session, inspect state, run one bounded step,
-verify, and checkpoint. See [The agent loop](#the-agent-loop) for the full
-sequence.
-
-That surface is intentionally small. Agents should use `sim` where it improves
-control and observability, and compose solver-native commands directly when
-those are the better execution primitive.
+verify, and checkpoint. Use solver-native batch commands directly when they are
+the right execution primitive.
 
 A bounded CAE step is one small modeling, meshing, solving, or postprocessing
 action that can be inspected and verified before continuing. Examples: create a
@@ -181,41 +177,17 @@ MCP surface adds context overhead and wrapper maintenance. For COMSOL, Abaqus,
 Ansys Workbench, OpenFOAM, LTspice, and similar solvers, sim-cli keeps the
 source of truth as a small, auditable command loop.
 
-## Composable, not a universal wrapper
-
-sim-cli does **not** try to wrap every solver operation, executable flag,
-vendor batch mode, or post-processing script. Agents should compose the best
-available tools for the job.
-
-Use `sim` when it adds a stable control plane: solver discovery and profile
-checks, live sessions, bounded `exec` / `inspect` loops, history and log
-capture, parsing, screenshots, or shared agent discipline. If the artifact is
-already a solver-native deck/script and the solver's own batch command is the
-right execution primitive, call that native command directly instead of forcing
-it through `sim run`. Preserve stdout/stderr, generated files, and acceptance
-evidence just as carefully.
-
-`sim run` remains useful when a plugin intentionally wraps a one-shot workflow
-and provides linting, profile-aware parsing, history, or safer invocation. The
-point is not that every action must pass through `sim`; the point is that
-agents have a small, auditable runtime where it helps and stay free to use
-solver-native tools where those are better.
-
 ## The agent loop
 
-For any solver, the agent should prefer a bounded
-inspect / execute / evaluate loop over one large generated script. When `sim`
-is the chosen control plane, the loop is:
+For any solver, the agent should prefer this loop over one large generated
+script:
 
 1. `uv run sim check <solver>` to detect installed solver versions and plugin
    compatibility.
-2. `uv run sim connect --solver <solver> ...` for live stateful work. For
-   one-shot work, use `uv run sim run` only when the plugin wrapper adds value
-   such as linting, history, parsing, profile-aware invocation, or safer
-   execution. Otherwise, run the solver-native batch command or project script
-   directly and keep the resulting logs/artifacts/evidence.
-3. In a persistent `sim` session, `uv run sim inspect session.versions` and
-   the solver-specific health or identity target before changing state.
+2. `uv run sim connect --solver <solver> ...` for live work, `uv run sim run`
+   when its wrapper adds value, or a solver-native batch command when better.
+3. `uv run sim inspect session.versions` and the solver-specific health or
+   identity target before changing state.
 4. `uv run sim exec --file step.py --label <step>` for one bounded modeling
    or analysis step.
 5. `uv run sim inspect last.result` and solver-specific state.
@@ -223,11 +195,6 @@ is the chosen control plane, the loop is:
 7. Save checkpoints and artifacts when the solver plugin or skill requires
    them.
 8. `uv run sim disconnect` when the session is done.
-
-For native one-shot work, keep the same discipline — explicit inputs, version
-or profile check, one bounded execution, preserved artifacts, and numerical
-acceptance evidence — but use the solver's own command surface as the execution
-primitive.
 
 Screenshots and plots help humans review the result, but engineering
 acceptance should prefer numeric evidence when the solver skill defines it:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ engineering review.
   <img src="https://img.shields.io/badge/status-alpha-f97316" alt="Status: alpha">
 </p>
 
-[Quick Start](#quick-start-agent-setup) · [COMSOL + Codex](#example-comsol-and-codex-on-one-machine) · [Agent Loop](#the-agent-loop) · [Remote Solvers](#local-vs-remote-solvers) · [Plugins](#solver-plugins) · [Commands](#common-commands)
+[Quick Start](#quick-start-agent-setup) · [COMSOL + Codex](#example-comsol-and-codex-on-one-machine) · [Composability](#composable-not-a-universal-wrapper) · [Agent Loop](#the-agent-loop) · [Remote Solvers](#local-vs-remote-solvers) · [Plugins](#solver-plugins) · [Commands](#common-commands)
 
 </div>
 
@@ -60,6 +60,10 @@ it hides intermediate state, fails late, and makes recovery difficult.
 environment, attach to a live session, inspect state, run one bounded step,
 verify, and checkpoint. See [The agent loop](#the-agent-loop) for the full
 sequence.
+
+That surface is intentionally small. Agents should use `sim` where it improves
+control and observability, and compose solver-native commands directly when
+those are the better execution primitive.
 
 A bounded CAE step is one small modeling, meshing, solving, or postprocessing
 action that can be inspected and verified before continuing. Examples: create a
@@ -177,17 +181,41 @@ MCP surface adds context overhead and wrapper maintenance. For COMSOL, Abaqus,
 Ansys Workbench, OpenFOAM, LTspice, and similar solvers, sim-cli keeps the
 source of truth as a small, auditable command loop.
 
+## Composable, not a universal wrapper
+
+sim-cli does **not** try to wrap every solver operation, executable flag,
+vendor batch mode, or post-processing script. Agents should compose the best
+available tools for the job.
+
+Use `sim` when it adds a stable control plane: solver discovery and profile
+checks, live sessions, bounded `exec` / `inspect` loops, history and log
+capture, parsing, screenshots, or shared agent discipline. If the artifact is
+already a solver-native deck/script and the solver's own batch command is the
+right execution primitive, call that native command directly instead of forcing
+it through `sim run`. Preserve stdout/stderr, generated files, and acceptance
+evidence just as carefully.
+
+`sim run` remains useful when a plugin intentionally wraps a one-shot workflow
+and provides linting, profile-aware parsing, history, or safer invocation. The
+point is not that every action must pass through `sim`; the point is that
+agents have a small, auditable runtime where it helps and stay free to use
+solver-native tools where those are better.
+
 ## The agent loop
 
-For any solver, the agent should prefer this loop over one large generated
-script:
+For any solver, the agent should prefer a bounded
+inspect / execute / evaluate loop over one large generated script. When `sim`
+is the chosen control plane, the loop is:
 
 1. `uv run sim check <solver>` to detect installed solver versions and plugin
    compatibility.
-2. `uv run sim connect --solver <solver> ...` for live stateful work, or
-   `uv run sim run` for a deterministic one-shot script.
-3. `uv run sim inspect session.versions` and the solver-specific health or
-   identity target before changing state.
+2. `uv run sim connect --solver <solver> ...` for live stateful work. For
+   one-shot work, use `uv run sim run` only when the plugin wrapper adds value
+   such as linting, history, parsing, profile-aware invocation, or safer
+   execution. Otherwise, run the solver-native batch command or project script
+   directly and keep the resulting logs/artifacts/evidence.
+3. In a persistent `sim` session, `uv run sim inspect session.versions` and
+   the solver-specific health or identity target before changing state.
 4. `uv run sim exec --file step.py --label <step>` for one bounded modeling
    or analysis step.
 5. `uv run sim inspect last.result` and solver-specific state.
@@ -195,6 +223,11 @@ script:
 7. Save checkpoints and artifacts when the solver plugin or skill requires
    them.
 8. `uv run sim disconnect` when the session is done.
+
+For native one-shot work, keep the same discipline — explicit inputs, version
+or profile check, one bounded execution, preserved artifacts, and numerical
+acceptance evidence — but use the solver's own command surface as the execution
+primitive.
 
 Screenshots and plots help humans review the result, but engineering
 acceptance should prefer numeric evidence when the solver skill defines it:

--- a/src/sim/_skills/sim-cli/SKILL.md
+++ b/src/sim/_skills/sim-cli/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: sim-cli
-description: Cross-solver operating discipline for sim-cli sessions — input classification, acceptance semantics, and escalation rules that apply to every solver. Use alongside the solver's own plugin skill, which is self-contained for solver-specific work; this skill carries only the shared rules.
+description: Cross-solver operating discipline for sim-cli workflows — tool choice, input classification, acceptance semantics, and escalation rules that apply across solvers. Use alongside the solver's own plugin skill, which is self-contained for solver-specific work; this skill carries only the shared rules.
 ---
 
 # sim-cli
 
-You are driving a solver through the **sim-cli** runtime. This skill carries
-the **cross-solver discipline** — the rules that hold for every sim-cli
-session, regardless of which solver you drive.
+You are working in a **sim-cli**-enabled solver workflow. Use the `sim`
+runtime where it adds control and observability, and compose solver-native
+tools directly where they are the right primitive. This skill carries the
+**cross-solver discipline** — the rules that hold across sim-cli workflows,
+regardless of which solver you drive.
 
 The solver's **plugin skill** is self-contained for solver-specific work:
 solver hard constraints, dependency chains, snippets, workflows, SDK/solver
@@ -19,39 +21,58 @@ solver, it belongs here, not in a plugin skill.
 
 ## Execution models
 
-The plugin skill tells you which model the solver uses:
+The plugin skill tells you which model the solver uses. Choose the narrowest
+correct execution primitive; sim-cli is composable, not a universal wrapper.
 
 | Model | Used by | Lifecycle |
 |---|---|---|
-| **Persistent session** | Drivers that hold a live process open | `connect → exec × N → inspect → disconnect` |
-| **One-shot batch** | Drivers that run one script/deck and exit | `run → parse_output → evaluate` |
+| **Persistent session** | Drivers that hold a live process open | `sim connect → sim exec × N → sim inspect → sim disconnect` |
+| **sim-wrapped one-shot batch** | Plugin wrappers that add linting, profile-aware invocation, parsing, history, or safer execution | `sim check → sim run → parse_output/logs → evaluate` |
+| **Native/tool one-shot batch** | Ready solver decks/scripts, vendor batch commands, project pipelines, or post-processing tools where native execution is the right primitive | version/profile probe → native command/script → parse artifacts/logs → evaluate |
 
-**The loop, either model:** classify inputs and get the missing Category A
-values from the user (including the acceptance criterion) → start the session
-(`sim connect`, or nothing for one-shot) → Step-0 version probe
-(`sim inspect session.versions`) → execute one bounded step at a time,
-inspecting `last.result` between steps → evaluate against the acceptance
-criterion → `sim disconnect`. On any failure, stop and report — do not
-silently retry.
+sim-cli does **not** try to wrap every solver operation, executable flag,
+vendor batch mode, or post-processing script. Use `sim` when it adds a stable
+control plane: solver discovery and profile checks, live sessions, bounded
+`exec` / `inspect` loops, history/log capture, parsing, screenshots, or shared
+agent discipline. If the artifact is already a solver-native deck/script and
+the solver's own batch command is the right execution primitive, call that
+native command directly instead of forcing it through `sim run`. Preserve
+stdout/stderr, generated files, and acceptance evidence just as carefully.
+
+Use `sim run` when the plugin skill says it is the canonical one-shot path or
+when the wrapper adds real value. Otherwise, keep the sim-cli discipline while
+composing the solver's native tools directly.
+
+**The loop, any model:** classify inputs and get the missing Category A values
+from the user (including the acceptance criterion) → choose the execution
+primitive → run a Step-0 version/profile probe (`sim inspect session.versions`
+for persistent sessions; `sim check <solver>`, plugin guidance, or native
+`--version` / license probe for one-shot work) → execute one bounded step at a
+time → inspect `last.result` or parse the native logs/artifacts between steps →
+evaluate against the acceptance criterion → `sim disconnect` if a persistent
+session was opened. On any failure, stop and report — do not silently retry.
 
 ---
 
-## Hard constraints (every sim-cli session)
+## Hard constraints (shared sim-cli discipline)
 
 1. **Never invent Category A defaults.** Physical decisions — geometry,
    materials, boundary conditions, the acceptance criterion — must come from
    the user. "Just use defaults" / "just run it" does not override this;
    treat it as a missing input and ask.
-2. **Step-0 version probe is mandatory.** After `sim connect` (persistent) or
-   before `sim run` (one-shot), call `sim inspect session.versions` and use
-   the returned `profile` / `active_sdk_layer` / `active_solver_layer` to pick
-   the right files in the plugin skill. If `profile` is empty, unknown, or
-   deprecated — **stop**.
-3. **Acceptance ≠ exit code.** A `sim run` / `sim exec` can return `ok=true`
-   and still be physically wrong. Always validate against an outcome-based,
-   bounded, measurable criterion — not "the solver ran".
+2. **Step-0 version/profile probe is mandatory.** After `sim connect`, call
+   `sim inspect session.versions` and use the returned `profile` /
+   `active_sdk_layer` / `active_solver_layer` to pick the right files in the
+   plugin skill. Before `sim run` or native one-shot execution, run the
+   relevant probe for that path (`sim check <solver>`, plugin guidance, or the
+   solver's native `--version` / license check). If a required profile is empty,
+   unknown, or deprecated — **stop**.
+3. **Acceptance ≠ exit code.** A `sim run` / `sim exec` / native solver command
+   can return success and still be physically wrong. Always validate against an
+   outcome-based, bounded, measurable criterion — not "the solver ran".
 4. **Never silently retry a failed step.** Report `stderr`, `stdout`, and
-   `run_count` / completion state; let the user decide the next move.
+   `run_count` / completion state / relevant artifact state; let the user
+   decide the next move.
 5. **Reference example values are not defaults.** Values in any `examples/`
    directory describe a specific published test case. Offer them explicitly
    if useful, but wait for the user's confirmation before adopting them.
@@ -67,7 +88,7 @@ default, which can I derive from the files in front of me?
 |---|---|---|
 | **A — physical decisions** | **Must ask if absent.** Non-negotiable. | Geometry, materials, boundary/initial conditions, physics-model choices, the acceptance criterion |
 | **B — operational** | **May default — must disclose.** Affects runtime/convenience, not what the simulation represents. | `--processors`, `--ui-mode`, `--workspace`, smoke-test iteration counts, log verbosity |
-| **C — file-derivable** | **Infer from the actual files** via a diagnostic `sim exec` — not from a similar example. Confirm if a downstream decision depends on it. | Mesh cell count, boundary names/types, fields present in a result file, material IDs |
+| **C — file-derivable** | **Infer from the actual files** via a diagnostic `sim exec`, solver-native inspection command, or artifact parser — not from a similar example. Confirm if a downstream decision depends on it. | Mesh cell count, boundary names/types, fields present in a result file, material IDs |
 
 Do not start until every Category A field has an explicit value from the user.
 


### PR DESCRIPTION
## Summary
- Keep the README concise while adding the composability message inline, with no net README line growth versus `main`.
- Clarify that agents should call solver-native batch commands directly when those are the right execution primitive, instead of forcing everything through `sim run`.
- Keep the fuller tool-choice guidance in the bundled `sim-cli` skill, including acceptance/version/artifact discipline for both sim-wrapped and native one-shot work.

## Test plan
- `git diff --check`
- Docs-only change; no test suite run.

## Merge status
Draft PR only. Do not merge yet.