### PR TITLE
Sync uv lock package version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ wheels = [
 
 [[package]]
 name = "sim-cli-core"
-version = "0.3.6"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

- Updates the editable `sim-cli-core` entry in `uv.lock` from `0.3.6` to `0.3.7`.

## Why

`pyproject.toml` and the release state already identify the package as `0.3.7`; the lockfile still had the previous editable package version.

## Validation

- Inspected the one-line diff in `uv.lock` against `pyproject.toml`.
- No runtime tests needed; this is lockfile metadata synchronization only.